### PR TITLE
SDKJAVA-103: Rename common module to core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,10 +7,10 @@
     <version>0.1.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>inrupt-client-common</artifactId>
-  <name>Inrupt Solid Client - Common Utilities</name>
+  <artifactId>inrupt-client-core</artifactId>
+  <name>Inrupt Solid Client - Core</name>
   <description>
-      Common Utilities for the Inrupt Client Libraries.
+      Core Classes and Utilities for the Inrupt Client Libraries.
   </description>
 
   <dependencies>

--- a/core/src/main/java/com/inrupt/client/core/IOUtils.java
+++ b/core/src/main/java/com/inrupt/client/core/IOUtils.java
@@ -18,7 +18,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client.common;
+package com.inrupt.client.core;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/src/main/java/com/inrupt/client/core/URIBuilder.java
+++ b/core/src/main/java/com/inrupt/client/core/URIBuilder.java
@@ -18,7 +18,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client.common;
+package com.inrupt.client.core;
 
 import static java.net.URLEncoder.encode;
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/core/src/main/java/com/inrupt/client/core/package-info.java
+++ b/core/src/main/java/com/inrupt/client/core/package-info.java
@@ -19,6 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 /**
- * Common utilities for the Inrupt client libraries.
+ * Core classes and utilities for the Inrupt client libraries.
  */
-package com.inrupt.client.common;
+package com.inrupt.client.core;

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>com.inrupt</groupId>
-      <artifactId>inrupt-client-common</artifactId>
+      <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/jena/src/main/java/com/inrupt/client/jena/JenaBodyPublishers.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaBodyPublishers.java
@@ -20,7 +20,7 @@
  */
 package com.inrupt.client.jena;
 
-import com.inrupt.client.common.IOUtils;
+import com.inrupt.client.core.IOUtils;
 
 import java.net.http.HttpRequest;
 

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>com.inrupt</groupId>
-      <artifactId>inrupt-client-common</artifactId>
+      <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
@@ -23,7 +23,7 @@ package com.inrupt.client.openid;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.inrupt.client.authentication.DPoP;
-import com.inrupt.client.common.URIBuilder;
+import com.inrupt.client.core.URIBuilder;
 import com.inrupt.client.spi.JsonProcessor;
 import com.inrupt.client.spi.ServiceProvider;
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <modules>
     <module>authentication</module>
     <module>build-tools</module>
-    <module>common</module>
+    <module>core</module>
     <module>http</module>
     <module>jackson</module>
     <module>jena</module>

--- a/vc/pom.xml
+++ b/vc/pom.xml
@@ -16,7 +16,7 @@
   <dependencies>
     <dependency>
       <groupId>com.inrupt</groupId>
-      <artifactId>inrupt-client-common</artifactId>
+      <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/vc/src/main/java/com/inrupt/client/vc/Holder.java
+++ b/vc/src/main/java/com/inrupt/client/vc/Holder.java
@@ -20,8 +20,8 @@
  */
 package com.inrupt.client.vc;
 
-import com.inrupt.client.common.IOUtils;
-import com.inrupt.client.common.URIBuilder;
+import com.inrupt.client.core.IOUtils;
+import com.inrupt.client.core.URIBuilder;
 import com.inrupt.client.spi.JsonProcessor;
 import com.inrupt.client.spi.ServiceProvider;
 

--- a/vc/src/main/java/com/inrupt/client/vc/Issuer.java
+++ b/vc/src/main/java/com/inrupt/client/vc/Issuer.java
@@ -20,8 +20,8 @@
  */
 package com.inrupt.client.vc;
 
-import com.inrupt.client.common.IOUtils;
-import com.inrupt.client.common.URIBuilder;
+import com.inrupt.client.core.IOUtils;
+import com.inrupt.client.core.URIBuilder;
 import com.inrupt.client.spi.JsonProcessor;
 import com.inrupt.client.spi.ServiceProvider;
 

--- a/vc/src/main/java/com/inrupt/client/vc/VerifiableCredentialBodyPublishers.java
+++ b/vc/src/main/java/com/inrupt/client/vc/VerifiableCredentialBodyPublishers.java
@@ -20,7 +20,7 @@
  */
 package com.inrupt.client.vc;
 
-import com.inrupt.client.common.IOUtils;
+import com.inrupt.client.core.IOUtils;
 import com.inrupt.client.spi.JsonProcessor;
 import com.inrupt.client.spi.ServiceProvider;
 

--- a/vc/src/main/java/com/inrupt/client/vc/Verifier.java
+++ b/vc/src/main/java/com/inrupt/client/vc/Verifier.java
@@ -20,7 +20,7 @@
  */
 package com.inrupt.client.vc;
 
-import com.inrupt.client.common.URIBuilder;
+import com.inrupt.client.core.URIBuilder;
 import com.inrupt.client.spi.JsonProcessor;
 import com.inrupt.client.spi.ServiceProvider;
 


### PR DESCRIPTION
This is a simple renaming `common` => `core`, as "core" is a better name for this.