### PR TITLE
SDKJAVA-106: Add CODEOWNERS definition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file controls which users are required reviewers for given segments of the repository
+
+* @acoburn @timea-solid
+


### PR DESCRIPTION
This adds a CODEOWNERS file to define the required reviewers for this branch of the repository.