### PR TITLE
SDKJAVA-78: Follow-on commit to simplify method signatures

### DIFF
--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -21,7 +21,6 @@
 package com.inrupt.client.rdf4j;
 
 import java.net.http.HttpResponse;
-import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.repository.Repository;
@@ -39,7 +38,7 @@ public final class RDF4JBodyHandlers {
      *
      * @return an HTTP body handler
      */
-    public static HttpResponse.BodyHandler<Supplier<Model>> ofModel() {
+    public static HttpResponse.BodyHandler<Model> ofModel() {
         return responseInfo -> {
             final var format = responseInfo.headers().firstValue("Content-Type").orElseThrow(
                     () -> new RDFHandlerException("Missing content-type header from response"));
@@ -52,7 +51,7 @@ public final class RDF4JBodyHandlers {
      *
      * @return an HTTP body handler
      */
-    public static HttpResponse.BodyHandler<Supplier<Repository>> ofRepository() {
+    public static HttpResponse.BodyHandler<Repository> ofRepository() {
         return responseInfo -> {
             final var format = responseInfo.headers().firstValue("Content-Type").orElseThrow(
                     () -> new RDFHandlerException("Missing content-type header from response"));

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodySubscribers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodySubscribers.java
@@ -44,7 +44,7 @@ public final class RDF4JBodySubscribers {
      *
      * @return the body subscriber
      */
-    public static HttpResponse.BodySubscriber<Supplier<Model>> ofModel() {
+    public static HttpResponse.BodySubscriber<Model> ofModel() {
         return ofModel(RDFFormat.TURTLE);
     }
 
@@ -54,7 +54,7 @@ public final class RDF4JBodySubscribers {
      * @param format the RDF serialization of the HTTP response
      * @return the body subscriber
      */
-    public static HttpResponse.BodySubscriber<Supplier<Model>> ofModel(final RDFFormat format) {
+    public static HttpResponse.BodySubscriber<Model> ofModel(final RDFFormat format) {
         final var upstream = HttpResponse.BodySubscribers.ofInputStream();
         final HttpResponse.BodySubscriber<Supplier<Model>> downstream = HttpResponse.BodySubscribers.mapping(
             upstream,
@@ -69,7 +69,7 @@ public final class RDF4JBodySubscribers {
                 }
             }
         );
-        return downstream;
+        return HttpResponse.BodySubscribers.mapping(downstream, Supplier::get);
     }
 
     /**
@@ -79,7 +79,7 @@ public final class RDF4JBodySubscribers {
      *
      * @return the body subscriber
      */
-    public static HttpResponse.BodySubscriber<Supplier<Repository>> ofRepository() {
+    public static HttpResponse.BodySubscriber<Repository> ofRepository() {
         return ofRepository(RDFFormat.TRIG);
     }
 
@@ -89,7 +89,7 @@ public final class RDF4JBodySubscribers {
      * @param format the RDF serialization of the HTTP response
      * @return the body subscriber
      */
-    public static HttpResponse.BodySubscriber<Supplier<Repository>> ofRepository(final RDFFormat format) {
+    public static HttpResponse.BodySubscriber<Repository> ofRepository(final RDFFormat format) {
         final var upstream = HttpResponse.BodySubscribers.ofInputStream();
         final HttpResponse.BodySubscriber<Supplier<Repository>> downstream = HttpResponse.BodySubscribers.mapping(
             upstream,
@@ -108,7 +108,7 @@ public final class RDF4JBodySubscribers {
                 }
             }
         );
-        return downstream;
+        return HttpResponse.BodySubscribers.mapping(downstream, Supplier::get);
     }
 
     private RDF4JBodySubscribers() {

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
@@ -74,7 +74,7 @@ class RDF4JBodyHandlersTest {
         final var asyncResponse = client.sendAsync(request, RDF4JBodyHandlers.ofModel());
 
         final var statusCode = asyncResponse.thenApply(HttpResponse::statusCode).join();
-        final var responseBody = asyncResponse.thenApply(HttpResponse::body).join().get();
+        final var responseBody = asyncResponse.thenApply(HttpResponse::body).join();
 
         assertEquals(200, statusCode);
         assertEquals(1, responseBody.size());
@@ -97,7 +97,7 @@ class RDF4JBodyHandlersTest {
         final var response = client.send(request, RDF4JBodyHandlers.ofModel());
 
         assertEquals(200, response.statusCode());
-        final var responseBody = response.body().get();
+        final var responseBody = response.body();
         assertEquals(1, responseBody.size());
         assertTrue(responseBody.contains(
             (Resource)SimpleValueFactory.getInstance().createIRI("http://example.com/s"),
@@ -117,7 +117,7 @@ class RDF4JBodyHandlersTest {
         final var response = client.send(request, RDF4JBodyHandlers.ofModel());
 
         assertEquals(200, response.statusCode());
-        final var responseBody = response.body().get();
+        final var responseBody = response.body();
         assertEquals(7, responseBody.size());
         assertTrue(responseBody.contains(
                 null,
@@ -141,7 +141,7 @@ class RDF4JBodyHandlersTest {
         final var statusCode = asyncResponse.thenApply(HttpResponse::statusCode).join();
         assertEquals(200, statusCode);
 
-        final var responseBody = asyncResponse.thenApply(HttpResponse::body).join().get();
+        final var responseBody = asyncResponse.thenApply(HttpResponse::body).join();
         assertTrue(responseBody instanceof Repository);
         try (final var conn = responseBody.getConnection()) {
             assertTrue(conn.hasStatement(
@@ -166,7 +166,7 @@ class RDF4JBodyHandlersTest {
         final var response = client.send(request, RDF4JBodyHandlers.ofRepository());
         assertEquals(200, response.statusCode());
 
-        final var responseBody = response.body().get();
+        final var responseBody = response.body();
         assertTrue(responseBody instanceof Repository);
         try (final var conn = responseBody.getConnection()) {
             assertTrue(conn.hasStatement(
@@ -190,7 +190,7 @@ class RDF4JBodyHandlersTest {
         final var response = client.send(request, RDF4JBodyHandlers.ofRepository());
         assertEquals(200, response.statusCode());
 
-        final var responseBody = response.body().get();
+        final var responseBody = response.body();
         assertTrue(responseBody instanceof Repository);
         try (final var conn = responseBody.getConnection()) {
             assertTrue(conn.hasStatement(


### PR DESCRIPTION
This builds on @timea-solid's excellent work and just simplifies the signatures of the body handlers a bit.

Let me know if you like this change. I find it aesthetically / ergonomically nicer. 