### PR TITLE
SDKJAVA-118: Upgrade Wiremock dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <!-- testing -->
     <junit.version>5.9.0</junit.version>
     <yasson.version>1.0.3</yasson.version>
-    <wiremock.version>2.27.2</wiremock.version>
+    <wiremock.version>2.33.2</wiremock.version>
   </properties>
 
   <modules>
@@ -111,7 +111,7 @@
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock</artifactId>
+        <artifactId>wiremock-jre8</artifactId>
         <version>${wiremock.version}</version>
       </dependency>
     </dependencies>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -86,7 +86,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
@@ -218,6 +218,7 @@ class RDF4JBodyHandlersTest {
                 .uri(URI.create(config.get("httpMock_uri") + "/postOneTriple"))
                 .header("Content-Type", "text/turtle")
                 .POST(RDF4JBodyPublishers.ofModel(model))
+                .version(HttpClient.Version.HTTP_1_1)
                 .build();
 
         final var response = client.send(request, HttpResponse.BodyHandlers.discarding());
@@ -249,6 +250,7 @@ class RDF4JBodyHandlersTest {
                 .uri(URI.create(config.get("httpMock_uri") + "/postOneTriple"))
                 .header("Content-Type", "text/turtle")
                 .POST(RDF4JBodyPublishers.ofRepository(repository))
+                .version(HttpClient.Version.HTTP_1_1)
                 .build();
 
         final var response = client.send(request, HttpResponse.BodyHandlers.discarding());

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -46,7 +46,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This upgrades our use of Wiremock. The more recent versions (newer than 2 years ago) use a different `artifactId`, which is why dependabot doesn't pick up the change. Note also the use of `HTTP/1.1` in some of the tests. For now, as we are using plain HTTP connections in the test interactions, the HTTPS support isn't set up (which is where the HTTP/2 connections are relevant).

That change would be a separate improvement, but this allows us to move the dependency forward.

Please also note that, when Wiremock starts to support Jersey 11 (it currently uses the EOL version 9), there will be a major version bump and the `artifactId` will go back to just `wiremock`.