### PR TITLE
SDKJAVA-121: Minor Javadoc updates

### DIFF
--- a/core/src/main/java/com/inrupt/client/core/InputStreamBodySubscribers.java
+++ b/core/src/main/java/com/inrupt/client/core/InputStreamBodySubscribers.java
@@ -38,14 +38,16 @@ import java.util.function.Function;
  * <pre>{@code
  *     public static HttpResponse.BodySubscriber<VerifiablePresentation> ofVerifiablePresentation() {
  *         return InputStreamBodySubscribers.mapping(input -> {
- *             try (final var stream = input) {
+ *             try (var stream = input) {
  *                 return processor.fromJson(stream, VerifiablePresentation.class);
- *             } catch (final IOException ex) {
- *                  throw new UncheckedIOException("Error parsing presentation", ex);
+ *             } catch (IOException ex) {
+ *                 throw new UncheckedIOException("Error parsing presentation", ex);
  *             }
  *         });
  *     }
  * }</pre>
+ *
+ * <p>After consuming an {@link InputStream}, please be sure to close the resource.
  *
  * @param <T> the type into which the {@link InputStream} is mapped.
  */


### PR DESCRIPTION
The impetus here was that the spacing did not align in the example, but I took the opportunity to remove some `final` clauses (these are nice to have in our code, but we want to keep the example as simple as possible) and add a note that the InputStream needs to be closed