### PR TITLE
JCL-130: OWASP false positive

### DIFF
--- a/build-tools/src/main/resources/inrupt-owasp/suppressions.xml
+++ b/build-tools/src/main/resources/inrupt-owasp/suppressions.xml
@@ -14,4 +14,11 @@
     <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
     <cve>CVE-2022-42003</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+        The client libraries are not vulnerable to this deserialization bug in Jackson
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+    <cve>CVE-2022-42004</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
This addresses an OWASP false positive described at https://nvd.nist.gov/vuln/detail/CVE-2022-42003. (These libraries do not use the `UNWRAP_SINGLE_VALUE_ARRAYS` feature)