### PR TITLE
JCL-126: Use Java8 for the UMA module

### DIFF
--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -13,6 +13,11 @@
       UMA abstractions for the Inrupt Client Libraries.
   </description>
 
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.inrupt</groupId>

--- a/uma/src/main/java/com/inrupt/client/uma/NeedInfo.java
+++ b/uma/src/main/java/com/inrupt/client/uma/NeedInfo.java
@@ -23,6 +23,7 @@ package com.inrupt.client.uma;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -78,9 +79,9 @@ public final class NeedInfo {
      */
     public static Optional<NeedInfo> ofErrorResponse(final ErrorResponse error) {
         if (NEED_INFO.equals(error.error) && error.ticket != null) {
-            final var requiredClaims = new ArrayList<RequiredClaims>();
+            final List<RequiredClaims> requiredClaims = new ArrayList<>();
             if (error.requiredClaims != null) {
-                for (var item : error.requiredClaims) {
+                for (final Map<String, Object> item : error.requiredClaims) {
                     requiredClaims.add(new RequiredClaims(item));
                 }
             }

--- a/uma/src/main/java/com/inrupt/client/uma/RequiredClaims.java
+++ b/uma/src/main/java/com/inrupt/client/uma/RequiredClaims.java
@@ -108,7 +108,7 @@ public class RequiredClaims {
     }
 
     private String getValue(final String key) {
-        final var value = data.get(key);
+        final Object value = data.get(key);
         if (value instanceof String) {
             return (String) value;
         }
@@ -116,11 +116,11 @@ public class RequiredClaims {
     }
 
     private Set<String> getValues(final String key) {
-        final var values = data.get(key);
+        final Object values = data.get(key);
 
-        final var results = new HashSet<String>();
+        final Set<String> results = new HashSet<>();
         if (values instanceof Collection) {
-            for (final var item : (Collection) values) {
+            for (final Object item : (Collection) values) {
                 if (item instanceof String) {
                     results.add((String) item);
                 }

--- a/uma/src/main/java/com/inrupt/client/uma/UmaClient.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaClient.java
@@ -122,7 +122,7 @@ public class UmaClient {
      * @return the next stage of completion, containing the authorization server discovery metadata
      */
     public CompletionStage<Metadata> metadataAsync(final URI authorizationServer) {
-        final var req = Request.newBuilder(getMetadataUrl(authorizationServer)).header(ACCEPT, JSON).build();
+        final Request req = Request.newBuilder(getMetadataUrl(authorizationServer)).header(ACCEPT, JSON).build();
         return httpClient.sendAsync(req, Response.BodyHandlers.ofInputStream())
             .thenApply(this::processMetadataResponse);
     }
@@ -137,7 +137,7 @@ public class UmaClient {
      */
     public TokenResponse token(final URI tokenEndpoint, final TokenRequest tokenRequest,
             final Function<NeedInfo, ClaimToken> claimMapper) {
-        final var mapper = Objects.requireNonNull(claimMapper);
+        final Function<NeedInfo, ClaimToken> mapper = Objects.requireNonNull(claimMapper);
         try {
             return negotiateToken(Objects.requireNonNull(tokenEndpoint),
                     Objects.requireNonNull(tokenRequest),
@@ -173,7 +173,7 @@ public class UmaClient {
             throw new UmaException("Claim gathering stages exceeded configured maximum of " + maxIterations);
         }
 
-        final var req = buildTokenRequest(tokenEndpoint, tokenRequest);
+        final Request req = buildTokenRequest(tokenEndpoint, tokenRequest);
         return httpClient.sendAsync(req, Response.BodyHandlers.ofInputStream())
             .thenCompose(res -> {
                 try {
@@ -184,7 +184,7 @@ public class UmaClient {
 
                     // Everything else is a 4xx response
                     // Attempt to read the error response as JSON
-                    final var err = processor.fromJson(res.body(), ErrorResponse.class);
+                    final ErrorResponse err = processor.fromJson(res.body(), ErrorResponse.class);
 
                     if (err.error != null) {
                         switch (err.error) {
@@ -229,7 +229,7 @@ public class UmaClient {
     }
 
     private Request buildTokenRequest(final URI tokenEndpoint, final TokenRequest request) {
-        final var data = new HashMap<String, String>();
+        final Map<String, String> data = new HashMap<>();
         data.put(GRANT_TYPE, UMA_TICKET);
         data.put(TICKET, request.getTicket());
         request.getPersistedClaimToken().ifPresent(pct -> data.put(PCT, pct));
@@ -250,9 +250,9 @@ public class UmaClient {
     }
 
     private static Request.BodyPublisher ofFormData(final Map<String, String> data) {
-        final var form = data.entrySet().stream().map(entry -> {
-            final var name = URLEncoder.encode(entry.getKey(), UTF_8);
-            final var value = URLEncoder.encode(entry.getValue(), UTF_8);
+        final String form = data.entrySet().stream().map(entry -> {
+            final String name = URLEncoder.encode(entry.getKey(), UTF_8);
+            final String value = URLEncoder.encode(entry.getValue(), UTF_8);
             return String.join(EQUALS, name, value);
         }).collect(Collectors.joining(ETC));
 

--- a/uma/src/test/java/com/inrupt/client/uma/UmaClientTest.java
+++ b/uma/src/test/java/com/inrupt/client/uma/UmaClientTest.java
@@ -54,33 +54,33 @@ class UmaClientTest {
 
     @Test
     void testMetadata() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
         checkMetadata(metadata);
     }
 
     @Test
     void testMetadataNotFound() {
-        final var asUri = URI.create(config.get("as_uri") + "/not-found");
-        final var client = new UmaClient();
+        final URI asUri = URI.create(config.get("as_uri") + "/not-found");
+        final UmaClient client = new UmaClient();
         assertThrows(UmaException.class, () -> client.metadata(asUri));
     }
 
     @Test
     void testMetadataMalformed() {
-        final var asUri = URI.create(config.get("as_uri") + "/malformed");
-        final var client = new UmaClient();
+        final URI asUri = URI.create(config.get("as_uri") + "/malformed");
+        final UmaClient client = new UmaClient();
         assertThrows(UmaException.class, () -> client.metadata(asUri));
     }
 
     @Test
     void testSimpleTokenNegotiationInvalidTicket() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-invalid-grant";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-invalid-grant";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(InvalidGrantException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiation a token");
@@ -89,11 +89,11 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenNegotiationRequestDenied() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-request-denied";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-request-denied";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(RequestDeniedException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiation a token");
@@ -102,11 +102,11 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenUnknownError() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-unknown-error";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-unknown-error";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(UmaException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiation a token");
@@ -115,11 +115,11 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenMalformedResponse() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-malformed-response";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-malformed-response";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(UmaException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiation a token");
@@ -128,11 +128,11 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenInvalidJsonResponse() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-invalid-response";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-invalid-response";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(UmaException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiation a token");
@@ -141,11 +141,11 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenInvalidScope() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-invalid-scope";
-        final var req = new TokenRequest(ticket, null, null, null, List.of("invalid-scope"));
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-invalid-scope";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, List.of("invalid-scope"));
 
         assertThrows(InvalidScopeException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiation a token");
@@ -154,13 +154,13 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenNegotiation() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-12345";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-12345";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var res = client.token(metadata.tokenEndpoint, req, needInfo -> {
+        final TokenResponse res = client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiate a simple token");
         });
 
@@ -170,11 +170,11 @@ class UmaClientTest {
 
     @Test
     void testTokenNegotiationMissingResponseTicket() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-need-info-no-response-ticket";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-need-info-no-response-ticket";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(RequestDeniedException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> {
             throw new UmaException("Unable to negotiate a simple token");
@@ -183,26 +183,26 @@ class UmaClientTest {
 
     @Test
     void testTokenNegotiationNullResponse() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var ticket = "ticket-need-info-with-ticket";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String ticket = "ticket-need-info-with-ticket";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(RequestDeniedException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo -> null));
     }
 
     @Test
     void testTokenNegotiationOidcMapper() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadata(asUri);
-        final var idToken = "oidc-id-token";
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadata(asUri);
+        final String idToken = "oidc-id-token";
 
-        final var ticket = "ticket-need-info-oidc-requirement";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final String ticket = "ticket-need-info-oidc-requirement";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var token = client.token(metadata.tokenEndpoint, req, needInfo ->
+        final TokenResponse token = client.token(metadata.tokenEndpoint, req, needInfo ->
                 ClaimToken.of(idToken, ID_TOKEN_CLAIM_TOKEN_FORMAT));
 
         assertEquals("token-from-id-token", token.accessToken);
@@ -211,13 +211,13 @@ class UmaClientTest {
 
     @Test
     void testTokenNegotiationRecursionLimit() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient(0);
-        final var metadata = client.metadata(asUri);
-        final var idToken = "oidc-id-token";
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient(0);
+        final Metadata metadata = client.metadata(asUri);
+        final String idToken = "oidc-id-token";
 
-        final var ticket = "ticket-need-info-oidc-requirement";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final String ticket = "ticket-need-info-oidc-requirement";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         assertThrows(UmaException.class, () -> client.token(metadata.tokenEndpoint, req, needInfo ->
                 ClaimToken.of(idToken, ID_TOKEN_CLAIM_TOKEN_FORMAT)));
@@ -229,38 +229,38 @@ class UmaClientTest {
     // ---------------
     @Test
     void testMetadataAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var metadata = client.metadataAsync(asUri).toCompletableFuture().join();
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final Metadata metadata = client.metadataAsync(asUri).toCompletableFuture().join();
         checkMetadata(metadata);
     }
 
     @Test
     void testMetadataNotFoundAsync() {
-        final var asUri = URI.create(config.get("as_uri") + "/not-found");
-        final var client = new UmaClient();
-        final var err = assertThrows(CompletionException.class,
+        final URI asUri = URI.create(config.get("as_uri") + "/not-found");
+        final UmaClient client = new UmaClient();
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri).toCompletableFuture()::join);
         assertTrue(err.getCause() instanceof UmaException);
     }
 
     @Test
     void testMetadataMalformedAsync() {
-        final var asUri = URI.create(config.get("as_uri") + "/malformed");
-        final var client = new UmaClient();
-        final var err = assertThrows(CompletionException.class,
+        final URI asUri = URI.create(config.get("as_uri") + "/malformed");
+        final UmaClient client = new UmaClient();
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri).toCompletableFuture()::join);
         assertTrue(err.getCause() instanceof UmaException);
     }
 
     @Test
     void testSimpleTokenNegotiationInvalidTicketAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-invalid-grant";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-invalid-grant";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
@@ -273,12 +273,12 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenNegotiationRequestDeniedAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-request-denied";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-request-denied";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
@@ -291,12 +291,12 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenUnknownErrorAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-unknown-error";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-unknown-error";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
@@ -309,12 +309,12 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenMalformedResponseAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-malformed-response";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-malformed-response";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
@@ -327,12 +327,12 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenInvalidJsonResponseAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-invalid-response";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-invalid-response";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
@@ -345,12 +345,12 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenInvalidScopeAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-invalid-scope";
-        final var req = new TokenRequest(ticket, null, null, null, List.of("invalid-scope"));
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-invalid-scope";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, List.of("invalid-scope"));
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
@@ -363,12 +363,12 @@ class UmaClientTest {
 
     @Test
     void testSimpleTokenNegotiationAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-12345";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-12345";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var res = client.metadataAsync(asUri).thenCompose(metadata ->
+        final TokenResponse res = client.metadataAsync(asUri).thenCompose(metadata ->
                 client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
                     throw new UmaException("Unable to negotiate a simple token");
                 })).toCompletableFuture().join();
@@ -379,12 +379,12 @@ class UmaClientTest {
 
     @Test
     void testTokenNegotiationMissingResponseTicketAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-need-info-no-response-ticket";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-need-info-no-response-ticket";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo -> {
@@ -397,12 +397,12 @@ class UmaClientTest {
 
     @Test
     void testTokenNegotiationNullResponseAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var ticket = "ticket-need-info-with-ticket";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String ticket = "ticket-need-info-with-ticket";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo ->
@@ -414,13 +414,13 @@ class UmaClientTest {
 
     @Test
     void testTokenNegotiationOidcMapperAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient();
-        final var idToken = "oidc-id-token";
-        final var ticket = "ticket-need-info-oidc-requirement";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient();
+        final String idToken = "oidc-id-token";
+        final String ticket = "ticket-need-info-oidc-requirement";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var token = client.metadataAsync(asUri)
+        final TokenResponse token = client.metadataAsync(asUri)
                 .thenCompose(metadata ->
                     client.tokenAsync(metadata.tokenEndpoint, req, needInfo ->
                         CompletableFuture.completedFuture(ClaimToken.of(idToken, ID_TOKEN_CLAIM_TOKEN_FORMAT))))
@@ -432,13 +432,13 @@ class UmaClientTest {
 
     @Test
     void testTokenNegotiationRecursionLimitAsync() {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var client = new UmaClient(0);
-        final var idToken = "oidc-id-token";
-        final var ticket = "ticket-need-info-oidc-requirement";
-        final var req = new TokenRequest(ticket, null, null, null, null);
+        final URI asUri = URI.create(config.get("as_uri"));
+        final UmaClient client = new UmaClient(0);
+        final String idToken = "oidc-id-token";
+        final String ticket = "ticket-need-info-oidc-requirement";
+        final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
-        final var err = assertThrows(CompletionException.class,
+        final CompletionException err = assertThrows(CompletionException.class,
                 client.metadataAsync(asUri)
                     .thenCompose(metadata ->
                         client.tokenAsync(metadata.tokenEndpoint, req, needInfo ->
@@ -449,9 +449,9 @@ class UmaClientTest {
     }
 
     static void checkMetadata(final Metadata metadata) {
-        final var asUri = URI.create(config.get("as_uri"));
-        final var jwksEndpoint = URIBuilder.newBuilder(asUri).path("jwks").build();
-        final var tokenEndpoint = URIBuilder.newBuilder(asUri).path("token").build();
+        final URI asUri = URI.create(config.get("as_uri"));
+        final URI jwksEndpoint = URIBuilder.newBuilder(asUri).path("jwks").build();
+        final URI tokenEndpoint = URIBuilder.newBuilder(asUri).path("token").build();
 
         assertEquals(List.of("ES256", "RS256"), metadata.dpopSigningAlgValuesSupported);
         assertEquals(List.of("urn:ietf:params:oauth:grant-type:uma-ticket"),


### PR DESCRIPTION
This converts the UMA module to Java8. The only thing going on here of any consequence is the replacement of `var` for the explicit type.