### PR TITLE
JCL-147: Processor to Service naming change

### DIFF
--- a/api/src/main/java/com/inrupt/client/spi/HttpService.java
+++ b/api/src/main/java/com/inrupt/client/spi/HttpService.java
@@ -20,46 +20,35 @@
  */
 package com.inrupt.client.spi;
 
+import com.inrupt.client.Request;
+import com.inrupt.client.Response;
+
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Type;
+import java.util.concurrent.CompletionStage;
 
 /**
- * A JSON handling abstraction.
+ * An HTTP handling abstraction.
  */
-public interface JsonProcessor {
+public interface HttpService {
 
     /**
-     * Write object data into JSON.
+     * Perform a synchonous HTTP request.
      *
-     * @param <T> the object type
-     * @param object the object to serialize
-     * @param output the output stream
-     * @throws IOException when there is a serialization error
+     * @param request the request
+     * @param responseBodyHandler the response body handler
+     * @param <T> the response type
+     * @return the response
+     * @throws IOException when there is an I/O error
      */
-    <T> void toJson(T object, OutputStream output) throws IOException;
+    <T> Response<T> send(Request request, Response.BodyHandler<T> responseBodyHandler) throws IOException;
 
     /**
-     * Read JSON into a java object.
+     * Perform an asynchonous HTTP request.
      *
-     * @param <T> the object type
-     * @param input the input stream
-     * @param clazz the object class
-     * @return the newly created object
-     * @throws IOException when there is a parsing error
+     * @param request the request
+     * @param responseBodyHandler the response body handler
+     * @param <T> the response type
+     * @return the next stage of completion, containing the response
      */
-    <T> T fromJson(InputStream input, Class<T> clazz) throws IOException;
-
-    /**
-     * Read JSON into a java object.
-     *
-     * @param <T> the object type
-     * @param input the input stream
-     * @param type the runtime type of the object
-     * @return the newly created object
-     * @throws IOException when there is a parsing error
-     */
-    <T> T fromJson(InputStream input, Type type) throws IOException;
-
+    <T> CompletionStage<Response<T>> sendAsync(Request request, Response.BodyHandler<T> responseBodyHandler);
 }

--- a/api/src/main/java/com/inrupt/client/spi/JsonService.java
+++ b/api/src/main/java/com/inrupt/client/spi/JsonService.java
@@ -20,35 +20,46 @@
  */
 package com.inrupt.client.spi;
 
-import com.inrupt.client.Request;
-import com.inrupt.client.Response;
-
 import java.io.IOException;
-import java.util.concurrent.CompletionStage;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
 
 /**
- * An HTTP handling abstraction.
+ * A JSON handling abstraction.
  */
-public interface HttpProcessor {
+public interface JsonService {
 
     /**
-     * Perform a synchonous HTTP request.
+     * Write object data into JSON.
      *
-     * @param request the request
-     * @param responseBodyHandler the response body handler
-     * @param <T> the response type
-     * @return the response
-     * @throws IOException when there is an I/O error
+     * @param <T> the object type
+     * @param object the object to serialize
+     * @param output the output stream
+     * @throws IOException when there is a serialization error
      */
-    <T> Response<T> send(Request request, Response.BodyHandler<T> responseBodyHandler) throws IOException;
+    <T> void toJson(T object, OutputStream output) throws IOException;
 
     /**
-     * Perform an asynchonous HTTP request.
+     * Read JSON into a java object.
      *
-     * @param request the request
-     * @param responseBodyHandler the response body handler
-     * @param <T> the response type
-     * @return the next stage of completion, containing the response
+     * @param <T> the object type
+     * @param input the input stream
+     * @param clazz the object class
+     * @return the newly created object
+     * @throws IOException when there is a parsing error
      */
-    <T> CompletionStage<Response<T>> sendAsync(Request request, Response.BodyHandler<T> responseBodyHandler);
+    <T> T fromJson(InputStream input, Class<T> clazz) throws IOException;
+
+    /**
+     * Read JSON into a java object.
+     *
+     * @param <T> the object type
+     * @param input the input stream
+     * @param type the runtime type of the object
+     * @return the newly created object
+     * @throws IOException when there is a parsing error
+     */
+    <T> T fromJson(InputStream input, Type type) throws IOException;
+
 }

--- a/api/src/main/java/com/inrupt/client/spi/RdfService.java
+++ b/api/src/main/java/com/inrupt/client/spi/RdfService.java
@@ -31,7 +31,7 @@ import java.io.OutputStream;
 /**
  * A generic abstraction for interacting with different underlying RDF libraries.
  */
-public interface RdfProcessor {
+public interface RdfService {
 
     /**
      * Serialize a dataset to an output stream.

--- a/api/src/main/java/com/inrupt/client/spi/ServiceProvider.java
+++ b/api/src/main/java/com/inrupt/client/spi/ServiceProvider.java
@@ -28,62 +28,62 @@ import java.util.ServiceLoader;
  */
 public final class ServiceProvider {
 
-    private static volatile JsonProcessor jsonProcessor = null;
-    private static volatile RdfProcessor rdfProcessor = null;
-    private static volatile HttpProcessor httpProcessor = null;
+    private static volatile JsonService jsonService = null;
+    private static volatile RdfService rdfService = null;
+    private static volatile HttpService httpService = null;
 
     /**
-     * Get the {@link JsonProcessor} for this application.
+     * Get the {@link JsonService} for this application.
      *
      * @return an object for processing JSON
      */
-    public static JsonProcessor getJsonProcessor() {
-        if (jsonProcessor == null) {
+    public static JsonService getJsonService() {
+        if (jsonService == null) {
             synchronized (ServiceProvider.class) {
-                if (jsonProcessor != null) {
-                    return jsonProcessor;
+                if (jsonService != null) {
+                    return jsonService;
                 }
-                jsonProcessor = loadSpi(JsonProcessor.class, ServiceProvider.class.getClassLoader());
+                jsonService = loadSpi(JsonService.class, ServiceProvider.class.getClassLoader());
             }
 
         }
-        return jsonProcessor;
+        return jsonService;
     }
 
     /**
-     * Get the {@link RdfProcessor} for this application.
+     * Get the {@link RdfService} for this application.
      *
      * @return an object for processing RDF
      */
-    public static RdfProcessor getRdfProcessor() {
-        if (rdfProcessor == null) {
+    public static RdfService getRdfService() {
+        if (rdfService == null) {
             synchronized (ServiceProvider.class) {
-                if (rdfProcessor != null) {
-                    return rdfProcessor;
+                if (rdfService != null) {
+                    return rdfService;
                 }
-                rdfProcessor = loadSpi(RdfProcessor.class, ServiceProvider.class.getClassLoader());
+                rdfService = loadSpi(RdfService.class, ServiceProvider.class.getClassLoader());
             }
 
         }
-        return rdfProcessor;
+        return rdfService;
     }
 
     /**
-     * Get the {@link HttpProcessor} for this application.
+     * Get the {@link HttpService} for this application.
      *
      * @return an object for processing HTTP
      */
-    public static HttpProcessor getHttpProcessor() {
-        if (httpProcessor == null) {
+    public static HttpService getHttpService() {
+        if (httpService == null) {
             synchronized (ServiceProvider.class) {
-                if (httpProcessor != null) {
-                    return httpProcessor;
+                if (httpService != null) {
+                    return httpService;
                 }
-                httpProcessor = loadSpi(HttpProcessor.class, ServiceProvider.class.getClassLoader());
+                httpService = loadSpi(HttpService.class, ServiceProvider.class.getClassLoader());
             }
 
         }
-        return httpProcessor;
+        return httpService;
     }
 
     static <T> T loadSpi(final Class<T> clazz, final ClassLoader cl) {

--- a/api/src/main/java/com/inrupt/client/spi/package-info.java
+++ b/api/src/main/java/com/inrupt/client/spi/package-info.java
@@ -22,13 +22,13 @@
  * <h2>Service interfaces for the Inrupt client libraries.</h2>
  *
  * <p>This module provides a pluggable service provider interface, which allows
- * the HTTP server, JSON processing and RDF processing to be replaced with concrete implementations.
+ * the HTTP, JSON, and RDF services to be used with any concrete implementation.
  *
  * <p>One can make use of available implementation such as:
  * <ul>
- * <li> for HTTP server: {@code OkHttpProcessor} or the {@code HttpProcessor};</li>
- * <li> for JSON processing: {@code JsonbProcessor} or the {@code JacksonProcessor};</li>
- * <li> for RDF processing: {@code JenaRdfProcessor} or the {@code RDF4JRdfProcessor}.</li>
+ * <li> for HTTP processing: {@code OkHttpService} or the {@code HttpClientService};</li>
+ * <li> for JSON processing: {@code JsonbService} or the {@code JacksonService};</li>
+ * <li> for RDF processing: {@code JenaService} or the {@code RDF4JService}.</li>
  * </ul>
  *
  * <p>To make use of a concrete implementation make sure, first, to
@@ -45,31 +45,31 @@
  * <h3>Example of using the JSON processor fromJson() method to read a {@code VerifiableCredential}:</h3>
  *
  * <pre>{@code
-       JsonProcessor processor = ServiceProvider.getJsonProcessor();
+       JsonService service = ServiceProvider.getJsonService();
        VerifiableCredential vc;
        try (InputStream is =
               Test.class.getResourceAsStream("verifiableCredential.json")) {
-              vc = processor.fromJson(is, VerifiableCredential.class);
+              vc = service.fromJson(is, VerifiableCredential.class);
        }
        System.out.println("The Verifiable Credential Id is: " + vc.id);
  * }</pre>
- * 
- * <h3>Example of using the RDF processor toDataset() method to read triples
+ *
+ * <h3>Example of using the RDF service toDataset() method to read triples
  * from a trig file into a {@code Dataset}:</h3>
  *
  * <pre>{@code
-       RdfProcessor processor = ServiceProvider.getRdfProcessor();
+       RdfService processor = ServiceProvider.getRdfService();
        Dataset dataset;
        try (InputStream input = Test.class.getResourceAsStream("/oneTriple.trig")) {
               dataset = processor.toDataset(Syntax.TRIG, input);
        }
        System.out.println("Number of triples in file: " + dataset.stream().count());
  * }</pre>
- * 
- * <h3>Example of using the HTTP server send() method to request the Solid logo:</h3>
+ *
+ * <h3>Example of using the HTTP service send() method to request the Solid logo:</h3>
  *
  * <pre>{@code
-       HttpProcessor processor = ServiceProvider.getHttpProcessor();
+       HttpService processor = ServiceProvider.getHttpService();
        Request request = Request.newBuilder()
               .uri("https://example.example/solid.png")
               .GET()

--- a/http/src/main/java/com/inrupt/client/http/SolidClient.java
+++ b/http/src/main/java/com/inrupt/client/http/SolidClient.java
@@ -27,7 +27,7 @@ import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.authentication.AccessToken;
 import com.inrupt.client.authentication.SolidAuthenticator;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -53,7 +53,7 @@ public class SolidClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(SolidClient.class);
 
     private final SolidAuthenticator solidAuthenticator;
-    private final HttpProcessor client;
+    private final HttpService client;
     private final Cache<URI, AccessToken> tokenCache;
 
     /**
@@ -62,7 +62,7 @@ public class SolidClient {
      * @param authenticator the Solid authenticator
      */
     public SolidClient(final SolidAuthenticator authenticator) {
-        this.client = ServiceProvider.getHttpProcessor();
+        this.client = ServiceProvider.getHttpService();
         this.solidAuthenticator = Objects.requireNonNull(authenticator);
         this.tokenCache = Caffeine.newBuilder()
             .expireAfter(new AccessTokenExpiry())

--- a/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientService.java
+++ b/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientService.java
@@ -25,7 +25,7 @@ package com.inrupt.client.httpclient;
 
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 
 import java.io.IOException;
 import java.net.http.HttpClient;
@@ -36,15 +36,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
-public class HttpClientProcessor implements HttpProcessor {
+public class HttpClientService implements HttpService {
 
     private final HttpClient client;
 
-    public HttpClientProcessor() {
+    public HttpClientService() {
         this(HttpClient.newBuilder().followRedirects(HttpClient.Redirect.ALWAYS).build());
     }
 
-    private HttpClientProcessor(final HttpClient client) {
+    private HttpClientService(final HttpClient client) {
         // TODO log that this was initialized at DEBUG level
         this.client = client;
     }
@@ -78,7 +78,7 @@ public class HttpClientProcessor implements HttpProcessor {
             });
     }
 
-    public static HttpClientProcessor ofHttpClient(final HttpClient client) {
-        return new HttpClientProcessor(client);
+    public static HttpClientService ofHttpClient(final HttpClient client) {
+        return new HttpClientService(client);
     }
 }

--- a/httpclient/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpProcessor
+++ b/httpclient/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpProcessor
@@ -1,1 +1,0 @@
-com.inrupt.client.httpclient.HttpClientProcessor

--- a/httpclient/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpService
+++ b/httpclient/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpService
@@ -1,0 +1,1 @@
+com.inrupt.client.httpclient.HttpClientService

--- a/httpclient/src/test/java/com/inrupt/client/httpclient/HttpClientServiceTest.java
+++ b/httpclient/src/test/java/com/inrupt/client/httpclient/HttpClientServiceTest.java
@@ -18,7 +18,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client.okhttp;
+package com.inrupt.client.httpclient;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,11 +36,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class OkHttpProcessorTest {
+class HttpClientServiceTest {
 
     private static final MockHttpServer mockHttpServer = new MockHttpServer();
     private static final Map<String, String> config = new HashMap<>();
-    private static final OkHttpProcessor client = new OkHttpProcessor();
+    private static final HttpClientService client = new HttpClientService();
 
     @BeforeAll
     static void setup() {
@@ -103,10 +103,10 @@ class OkHttpProcessorTest {
 
         assertEquals(200, response.statusCode());
         assertEquals(uri, response.uri());
-        assertEquals(Optional.of("image/png"), response.headers().firstValue("content-type"));
         assertEquals(Optional.of("image/png"), response.headers().firstValue("Content-Type"));
-        assertEquals(Arrays.asList("image/png"), response.headers().asMap().get("content-type"));
+        assertEquals(Optional.of("image/png"), response.headers().firstValue("content-type"));
         assertEquals(Arrays.asList("image/png"), response.headers().asMap().get("Content-Type"));
+        assertEquals(Arrays.asList("image/png"), response.headers().asMap().get("content-type"));
     }
 
     @Test

--- a/jackson/src/main/java/com/inrupt/client/jackson/JacksonService.java
+++ b/jackson/src/main/java/com/inrupt/client/jackson/JacksonService.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,16 +34,16 @@ import java.io.OutputStream;
 import java.lang.reflect.Type;
 
 /**
- * A {@link JsonProcessor} using the Jackson JSON library.
+ * A {@link JsonService} using the Jackson JSON library.
  */
-public class JacksonProcessor implements JsonProcessor {
+public class JacksonService implements JsonService {
 
     private final ObjectMapper mapper;
 
     /**
-     * Create a Jackson processor.
+     * Create a Jackson service.
      */
-    public JacksonProcessor() {
+    public JacksonService() {
         mapper = new ObjectMapper();
         mapper.findAndRegisterModules();
         mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);

--- a/jackson/src/main/java/com/inrupt/client/jackson/package-info.java
+++ b/jackson/src/main/java/com/inrupt/client/jackson/package-info.java
@@ -36,13 +36,13 @@
  *     &lt;/dependency&gt;
  * </pre>
  *
- * <h3>Example of using the JSON processor fromJson() method to read a {@code VerifiableCredential}:</h3>
+ * <h3>Example of using the JSON service fromJson() method to read a {@code VerifiableCredential}:</h3>
  *
  * <pre>{@code
-    JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    JsonService service = ServiceProvider.getJsonService();
     VerifiableCredential vc;
     try (InputStream is = Test.class.getResourceAsStream("verifiableCredential.json")) {
-        vc = processor.fromJson(is, VerifiableCredential.class);
+        vc = service.fromJson(is, VerifiableCredential.class);
     }
     System.out.println("The Verifiable Credential Id is: " + vc.id);
  * }</pre>

--- a/jackson/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonProcessor
+++ b/jackson/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonProcessor
@@ -1,1 +1,0 @@
-com.inrupt.client.jackson.JacksonProcessor

--- a/jackson/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonService
+++ b/jackson/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonService
@@ -1,0 +1,1 @@
+com.inrupt.client.jackson.JacksonService

--- a/jackson/src/test/java/com/inrupt/client/jackson/JacksonServiceTest.java
+++ b/jackson/src/test/java/com/inrupt/client/jackson/JacksonServiceTest.java
@@ -22,7 +22,7 @@ package com.inrupt.client.jackson;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
@@ -36,18 +36,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class JacksonProcessorTest {
+class JacksonServiceTest {
 
-    private final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private final JsonService processor = ServiceProvider.getJsonService();
 
     @Test
     void testInstance() {
-        assertTrue(processor instanceof JacksonProcessor);
+        assertTrue(processor instanceof JacksonService);
     }
 
     @Test
     void parseJsonInput() throws IOException {
-        try (final var input = JacksonProcessorTest.class.getResourceAsStream("/myobject.json")) {
+        try (final var input = JacksonServiceTest.class.getResourceAsStream("/myobject.json")) {
             final var obj = processor.fromJson(input, MyObject.class);
             assertEquals("Quinn", obj.name);
             assertEquals(25, obj.age);
@@ -89,7 +89,7 @@ class JacksonProcessorTest {
     @ParameterizedTest
     @ValueSource(strings = {"/invalid.json", "/malformed.json"})
     void parseInvalidJson(final String resource) throws IOException {
-        try (final var input = JacksonProcessorTest.class.getResourceAsStream(resource)) {
+        try (final var input = JacksonServiceTest.class.getResourceAsStream(resource)) {
             assertThrows(IOException.class, () -> processor.fromJson(input, MyObject.class));
         }
     }

--- a/jackson/src/test/java/com/inrupt/client/jackson/JacksonVCTest.java
+++ b/jackson/src/test/java/com/inrupt/client/jackson/JacksonVCTest.java
@@ -23,7 +23,7 @@ package com.inrupt.client.jackson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.inrupt.client.VerifiableCredential;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.File;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 public class JacksonVCTest {
 
-    private static final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private static final JsonService processor = ServiceProvider.getJsonService();
     private static VerifiableCredential vc;
     private static VerifiableCredential vcCopy;
 

--- a/jackson/src/test/java/com/inrupt/client/jackson/JacksonVPTest.java
+++ b/jackson/src/test/java/com/inrupt/client/jackson/JacksonVPTest.java
@@ -23,7 +23,7 @@ package com.inrupt.client.jackson;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.File;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 
 public class JacksonVPTest {
 
-    private static final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private static final JsonService processor = ServiceProvider.getJsonService();
     private static VerifiablePresentation vp;
     private static VerifiablePresentation vpCopy;
 

--- a/jena/src/main/java/com/inrupt/client/jena/JenaService.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaService.java
@@ -23,7 +23,7 @@ package com.inrupt.client.jena;
 import com.inrupt.client.Dataset;
 import com.inrupt.client.Graph;
 import com.inrupt.client.Syntax;
-import com.inrupt.client.spi.RdfProcessor;
+import com.inrupt.client.spi.RdfService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,9 +39,9 @@ import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RiotException;
 
 /**
- * An {@link RdfProcessor} that uses the Jena library.
+ * An {@link RdfService} that uses the Jena library.
  */
-public class JenaRdfProcessor implements RdfProcessor {
+public class JenaService implements RdfService {
 
     private static Map<Syntax, Lang> SYNTAX_TO_LANG = Map.of(
             Syntax.TURTLE, Lang.TURTLE,

--- a/jena/src/main/java/com/inrupt/client/jena/package-info.java
+++ b/jena/src/main/java/com/inrupt/client/jena/package-info.java
@@ -21,22 +21,22 @@
 /**
  * <h2>Jena RDF support for the Inrupt client libraries.</h2>
  *
- * <p>The Jena module gives two possibilities to read RDF data: through the Processor {@link JenaRdfProcessor}
+ * <p>The Jena module gives two possibilities to read RDF data: through the Service {@link JenaService}
  * and through the BodyHandler {@link JenaBodyHandlers}.
  *
- * <h3>Example of using the Jena Processor toDataset() method to read triples
+ * <h3>Example of using the Jena Service toDataset() method to read triples
  * from a trig file into a {@code Dataset}:</h3>
  *
  * <pre>{@code
-    RdfProcessor processor = ServiceProvider.getRdfProcessor();
+    RdfService service = ServiceProvider.getRdfService();
     Dataset dataset;
     try (InputStream input = Test.class.getResourceAsStream("/tripleExamples.trig")) {
-        dataset = processor.toDataset(Syntax.TRIG, input);
+        dataset = service.toDataset(Syntax.TRIG, input);
     }
     System.out.println("Number of triples in file: " + dataset.stream().count());
  * }</pre>
  *
- * <p>A user of the {@code JenaRdfProcessor} should ensure that this implementation is
+ * <p>A user of the {@code JenaService} should ensure that this implementation is
  * available on the classpath by adding the following dependency:
  *
  * <pre>

--- a/jena/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfProcessor
+++ b/jena/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfProcessor
@@ -1,1 +1,0 @@
-com.inrupt.client.jena.JenaRdfProcessor

--- a/jena/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfService
+++ b/jena/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfService
@@ -1,0 +1,1 @@
+com.inrupt.client.jena.JenaService

--- a/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -43,7 +43,7 @@ class JenaBodyHandlersTest {
 
     private static final MockHttpService mockHttpServer = new MockHttpService();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
 
     @BeforeAll
     static void setup() {

--- a/jena/src/test/java/com/inrupt/client/jena/JenaBodyPublishersTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaBodyPublishersTest.java
@@ -23,7 +23,7 @@ package com.inrupt.client.jena;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.*;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -49,7 +49,7 @@ class JenaBodyPublishersTest {
 
     private static final MockHttpService mockHttpClient = new MockHttpService();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
 
     private static Dataset ds;
     private static Graph graph;

--- a/jena/src/test/java/com/inrupt/client/jena/JenaServiceTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaServiceTest.java
@@ -1,16 +1,16 @@
 /*
  * Copyright 2022 Inrupt Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to use,
  * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
  * Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
  * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
@@ -23,7 +23,7 @@ package com.inrupt.client.jena;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.Syntax;
-import com.inrupt.client.spi.RdfProcessor;
+import com.inrupt.client.spi.RdfService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
@@ -44,9 +44,9 @@ import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class JenaRdfProcessorTest {
+class JenaServiceTest {
 
-    private final RdfProcessor processor = ServiceProvider.getRdfProcessor();
+    private final RdfService service = ServiceProvider.getRdfService();
     private static JenaDataset jenaDataset;
     private static JenaGraph jenaGraph;
 
@@ -84,13 +84,13 @@ class JenaRdfProcessorTest {
 
     @Test
     void checkInstance() {
-        assertTrue(processor instanceof JenaRdfProcessor);
+        assertTrue(service instanceof JenaService);
     }
 
     @Test
     void parseToDatasetTurtle() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/profileExample.ttl")) {
-            final var dataset = processor.toDataset(Syntax.TURTLE, input);
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/profileExample.ttl")) {
+            final var dataset = service.toDataset(Syntax.TURTLE, input);
             assertFalse(dataset.stream().findFirst().get().getGraphName().isPresent());
             assertEquals(10, dataset.stream().count());
         }
@@ -98,8 +98,8 @@ class JenaRdfProcessorTest {
 
     @Test
     void parseToDatasetTrig() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/oneTriple.trig")) {
-            final var dataset = processor.toDataset(Syntax.TRIG, input);
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/oneTriple.trig")) {
+            final var dataset = service.toDataset(Syntax.TRIG, input);
             assertTrue(dataset.stream().findFirst().get().getGraphName().isPresent());
             assertEquals(
                 "http://example.test/graph",
@@ -111,8 +111,8 @@ class JenaRdfProcessorTest {
 
     @Test
     void parseToDataserRelativeURIs() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/relativeURIs.ttl")) {
-            final var dataset = processor.toDataset(Syntax.TURTLE, input, "http://example.test/");
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
+            final var dataset = service.toDataset(Syntax.TURTLE, input, "http://example.test/");
             assertEquals(2, dataset.stream().count());
             assertTrue(dataset.stream().findFirst().get().getSubject().getURI().toString()
                 .contains("http://example.test/")
@@ -122,8 +122,8 @@ class JenaRdfProcessorTest {
 
     @Test
     void parseToDatasetRelativeURIsButNoBaseURI() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/relativeURIs.ttl")) {
-            final var dataset = processor.toDataset(Syntax.TURTLE, input);
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
+            final var dataset = service.toDataset(Syntax.TURTLE, input);
             assertEquals(2, dataset.stream().count());
             assertTrue(dataset.stream().findFirst().get().getSubject().getURI().toString()
                 .contains("file://") //treats relative URIs like local files
@@ -133,23 +133,23 @@ class JenaRdfProcessorTest {
 
     @Test
     void parsetoDatasetException() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/oneTriple.trig")) {
-            assertThrows(IOException.class, () -> processor.toDataset(Syntax.TURTLE, input));
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/oneTriple.trig")) {
+            assertThrows(IOException.class, () -> service.toDataset(Syntax.TURTLE, input));
         }
     }
 
     @Test
     void parseToGraph() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/profileExample.ttl")) {
-            final var graph = processor.toGraph(Syntax.TURTLE, input);
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/profileExample.ttl")) {
+            final var graph = service.toGraph(Syntax.TURTLE, input);
             assertEquals(10, graph.stream().count());
         }
     }
 
     @Test
     void parseToGraphRelativeURIs() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/relativeURIs.ttl")) {
-            final var graph = processor.toGraph(Syntax.TURTLE, input, "http://example.test/");
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
+            final var graph = service.toGraph(Syntax.TURTLE, input, "http://example.test/");
             assertEquals(2, graph.stream().count());
             assertTrue(graph.stream().findFirst().get().getSubject().getURI().toString()
                 .contains("http://example.test/")
@@ -159,17 +159,17 @@ class JenaRdfProcessorTest {
 
     @Test
     void parseToGraphException() throws IOException {
-        try (final var input = JenaRdfProcessorTest.class.getResourceAsStream("/invalid.ttl")) {
-            assertThrows(IOException.class, () -> processor.toGraph(Syntax.TURTLE, input));
+        try (final var input = JenaServiceTest.class.getResourceAsStream("/invalid.ttl")) {
+            assertThrows(IOException.class, () -> service.toGraph(Syntax.TURTLE, input));
         }
     }
 
     @Test
     void serializeFromDatasetTRIGRoundtrip() throws IOException {
         try (final var output = new ByteArrayOutputStream()) {
-            processor.fromDataset(jenaDataset, Syntax.TRIG, output);
+            service.fromDataset(jenaDataset, Syntax.TRIG, output);
             final var input = new ByteArrayInputStream(output.toByteArray());
-            final var roundtrip = processor.toDataset(Syntax.TRIG, input);
+            final var roundtrip = service.toDataset(Syntax.TRIG, input);
             assertEquals(2, roundtrip.stream().count());
             assertEquals(jenaDataset.stream().count(), roundtrip.stream().count());
             final var st = jenaDataset.stream(
@@ -191,9 +191,9 @@ class JenaRdfProcessorTest {
     @Test
     void serializeFromDatasetTURTLERoundtrip() throws IOException {
         try (final var output = new ByteArrayOutputStream()) {
-            processor.fromDataset(jenaDataset, Syntax.TURTLE, output);
+            service.fromDataset(jenaDataset, Syntax.TURTLE, output);
             final var input = new ByteArrayInputStream(output.toByteArray());
-            final var roundtrip = processor.toDataset(Syntax.TURTLE, input);
+            final var roundtrip = service.toDataset(Syntax.TURTLE, input);
 
             assertEquals(2, roundtrip.stream().count());
             assertEquals(jenaDataset.stream().count(), roundtrip.stream().count());
@@ -216,9 +216,9 @@ class JenaRdfProcessorTest {
     @Test
     void serializeFromGraphRoundtrip() throws IOException {
         try (final var output = new ByteArrayOutputStream()) {
-            processor.fromGraph(jenaGraph, Syntax.TURTLE, output);
+            service.fromGraph(jenaGraph, Syntax.TURTLE, output);
             final var input = new ByteArrayInputStream(output.toByteArray());
-            final var roundtrip = processor.toGraph(Syntax.TURTLE, input);
+            final var roundtrip = service.toGraph(Syntax.TURTLE, input);
             assertEquals(2, roundtrip.stream().count());
             assertEquals(jenaGraph.stream().count(), roundtrip.stream().count());
             final var st = jenaGraph.stream(
@@ -240,7 +240,7 @@ class JenaRdfProcessorTest {
         final var tmp = Files.createTempFile(null, null).toFile();
         try (final var output = new FileOutputStream(tmp)) {
             output.close();
-            assertThrows(RuntimeIOException.class, () -> processor.fromDataset(jenaDataset, Syntax.TRIG, output));
+            assertThrows(RuntimeIOException.class, () -> service.fromDataset(jenaDataset, Syntax.TRIG, output));
         }
     }
 
@@ -249,7 +249,7 @@ class JenaRdfProcessorTest {
         final var tmp = Files.createTempFile(null, null).toFile();
         try (final var output = new FileOutputStream(tmp)) {
             output.close();
-            assertThrows(RuntimeIOException.class, () -> processor.fromGraph(jenaGraph, Syntax.TURTLE, output));
+            assertThrows(RuntimeIOException.class, () -> service.fromGraph(jenaGraph, Syntax.TURTLE, output));
         }
     }
 

--- a/jsonb/src/main/java/com/inrupt/client/jsonb/JsonbService.java
+++ b/jsonb/src/main/java/com/inrupt/client/jsonb/JsonbService.java
@@ -20,7 +20,7 @@
  */
 package com.inrupt.client.jsonb;
 
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,16 +35,16 @@ import javax.json.bind.JsonbException;
 import javax.json.bind.config.PropertyNamingStrategy;
 
 /**
- * A {@link JsonProcessor} using the JakartaEE JSON Bind API.
+ * A {@link JsonService} using the JakartaEE JSON Bind API.
  */
-public class JsonbProcessor implements JsonProcessor {
+public class JsonbService implements JsonService {
 
     private final Jsonb jsonb;
 
     /**
-     * Create a JSON-B processor.
+     * Create a JSON-B service.
      */
-    public JsonbProcessor() {
+    public JsonbService() {
         final JsonbConfig config = new JsonbConfig();
         config.withAdapters(new VCAdapter());
         config.withAdapters(new VPAdapter());

--- a/jsonb/src/main/java/com/inrupt/client/jsonb/package-info.java
+++ b/jsonb/src/main/java/com/inrupt/client/jsonb/package-info.java
@@ -38,13 +38,13 @@
  *     &lt;/dependency&gt;
  * </pre>
  *
- * <h3>Example of using the JSON processor fromJson() method to read a {@code VerifiableCredential}:</h3>
+ * <h3>Example of using the JSON service fromJson() method to read a {@code VerifiableCredential}:</h3>
  *
  * <pre>{@code
-    JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    JsonService service = ServiceProvider.getJsonService();
     VerifiableCredential vc;
     try (InputStream is = Test.class.getResourceAsStream("verifiableCredential.json")) {
-        vc = processor.fromJson(is, VerifiableCredential.class);
+        vc = service.fromJson(is, VerifiableCredential.class);
     }
     System.out.println("The Verifiable Credential Id is: " + vc.id);
  * }</pre>

--- a/jsonb/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonProcessor
+++ b/jsonb/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonProcessor
@@ -1,1 +1,0 @@
-com.inrupt.client.jsonb.JsonbProcessor

--- a/jsonb/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonService
+++ b/jsonb/src/main/resources/META-INF/services/com.inrupt.client.spi.JsonService
@@ -1,0 +1,1 @@
+com.inrupt.client.jsonb.JsonbService

--- a/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbServiceTest.java
+++ b/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbServiceTest.java
@@ -22,7 +22,7 @@ package com.inrupt.client.jsonb;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
@@ -36,19 +36,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class JsonbProcessorTest {
+class JsonbServiceTest {
 
-    private final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private final JsonService service = ServiceProvider.getJsonService();
 
     @Test
     void checkInstance() {
-        assertTrue(processor instanceof JsonbProcessor);
+        assertTrue(service instanceof JsonbService);
     }
 
     @Test
     void parseJsonInput() throws IOException {
-        try (final var input = JsonbProcessorTest.class.getResourceAsStream("/myobject.json")) {
-            final var obj = processor.fromJson(input, MyObject.class);
+        try (final var input = JsonbServiceTest.class.getResourceAsStream("/myobject.json")) {
+            final var obj = service.fromJson(input, MyObject.class);
             assertEquals("Quinn", obj.name);
             assertEquals(25, obj.age);
             assertEquals(List.of("Dog", "Goldfish"), obj.pets);
@@ -63,9 +63,9 @@ class JsonbProcessorTest {
         obj.pets = List.of("Dog", "Goldfish");
 
         try (final var output = new ByteArrayOutputStream()) {
-            processor.toJson(obj, output);
+            service.toJson(obj, output);
             final var input = new ByteArrayInputStream(output.toByteArray());
-            final var roundtrip = processor.fromJson(input, MyObject.class);
+            final var roundtrip = service.fromJson(input, MyObject.class);
             assertEquals(obj.name, roundtrip.name);
             assertEquals(obj.age, roundtrip.age);
             assertEquals(obj.pets, roundtrip.pets);
@@ -82,15 +82,15 @@ class JsonbProcessorTest {
         final var tmp = Files.createTempFile(null, null).toFile();
         try (final var output = new FileOutputStream(tmp)) {
             output.close();
-            assertThrows(IOException.class, () -> processor.toJson(obj, output));
+            assertThrows(IOException.class, () -> service.toJson(obj, output));
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"/invalid.json", "/malformed.json"})
     void parseInvalidJson(final String resource) throws IOException {
-        try (final var input = JsonbProcessorTest.class.getResourceAsStream(resource)) {
-            assertThrows(IOException.class, () -> processor.fromJson(input, MyObject.class));
+        try (final var input = JsonbServiceTest.class.getResourceAsStream(resource)) {
+            assertThrows(IOException.class, () -> service.fromJson(input, MyObject.class));
         }
     }
 

--- a/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbVCAdapterTest.java
+++ b/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbVCAdapterTest.java
@@ -23,7 +23,7 @@ package com.inrupt.client.jsonb;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.inrupt.client.VerifiableCredential;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.File;
@@ -37,14 +37,14 @@ import org.junit.jupiter.api.Test;
 
 public class JsonbVCAdapterTest {
 
-    private static final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private static final JsonService service = ServiceProvider.getJsonService();
     private static VerifiableCredential vc;
     private static VerifiableCredential vcCopy;
 
     @Test
     void roundtripVC() throws IOException {
         try (final var res = JsonbVCAdapterTest.class.getResourceAsStream("/verifiableCredential.json")) {
-            vc = processor.fromJson(res, VerifiableCredential.class);
+            vc = service.fromJson(res, VerifiableCredential.class);
         }
 
         final var targetPath = new File("target").toPath();
@@ -53,11 +53,11 @@ public class JsonbVCAdapterTest {
         final var testFile = Files.createTempFile(testFolderPath, UUID.randomUUID().toString(), ".json");
 
         try (final var out = new FileOutputStream(testFile.toString())) {
-            processor.toJson(vc, out);
+            service.toJson(vc, out);
         }
 
         try (final var in = new FileInputStream(testFile.toString())) {
-            vcCopy = processor.fromJson(in, VerifiableCredential.class);
+            vcCopy = service.fromJson(in, VerifiableCredential.class);
         }
 
         assertEquals(vc.context, vcCopy.context);

--- a/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbVPAdapterTest.java
+++ b/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbVPAdapterTest.java
@@ -23,7 +23,7 @@ package com.inrupt.client.jsonb;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.File;
@@ -37,14 +37,14 @@ import org.junit.jupiter.api.Test;
 
 public class JsonbVPAdapterTest {
 
-    private static final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private static final JsonService service = ServiceProvider.getJsonService();
     private static VerifiablePresentation vp;
     private static VerifiablePresentation vpCopy;
 
     @Test
     void roundtripVP() throws IOException {
         try (final var res = JsonbVPAdapterTest.class.getResourceAsStream("/verifiablePresentation.json")) {
-            vp = processor.fromJson(res, VerifiablePresentation.class);
+            vp = service.fromJson(res, VerifiablePresentation.class);
         }
 
         final var targetPath = new File("target").toPath();
@@ -53,11 +53,11 @@ public class JsonbVPAdapterTest {
         final var testFile = Files.createTempFile(testFolderPath, UUID.randomUUID().toString(), ".json");
 
         try (final var out = new FileOutputStream(testFile.toString())) {
-            processor.toJson(vp, out);
+            service.toJson(vp, out);
         }
 
         try (final var in = new FileInputStream(testFile.toString())) {
-            vpCopy = processor.fromJson(in, VerifiablePresentation.class);
+            vpCopy = service.fromJson(in, VerifiablePresentation.class);
         }
 
         assertEquals(vp.context, vpCopy.context);

--- a/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpService.java
+++ b/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpService.java
@@ -25,7 +25,7 @@ package com.inrupt.client.okhttp;
 
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -43,16 +43,16 @@ import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.RequestBody;
 
-public class OkHttpProcessor implements HttpProcessor {
+public class OkHttpService implements HttpService {
 
     private static final Set<String> NO_BODY_METHODS = new HashSet<>(Arrays.asList("GET", "HEAD", "DELETE"));
     private final OkHttpClient client;
 
-    public OkHttpProcessor() {
+    public OkHttpService() {
         this(new OkHttpClient());
     }
 
-    public OkHttpProcessor(final OkHttpClient client) {
+    public OkHttpService(final OkHttpClient client) {
         // TODO -- Log that this was initialized at DEBUG level
         this.client = client;
     }

--- a/okhttp/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpProcessor
+++ b/okhttp/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpProcessor
@@ -1,1 +1,0 @@
-com.inrupt.client.okhttp.OkHttpProcessor

--- a/okhttp/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpService
+++ b/okhttp/src/main/resources/META-INF/services/com.inrupt.client.spi.HttpService
@@ -1,0 +1,1 @@
+com.inrupt.client.okhttp.OkHttpService

--- a/okhttp/src/test/java/com/inrupt/client/okhttp/OkHttpServiceTest.java
+++ b/okhttp/src/test/java/com/inrupt/client/okhttp/OkHttpServiceTest.java
@@ -18,7 +18,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client.httpclient;
+package com.inrupt.client.okhttp;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -36,11 +36,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class HttpClientProcessorTest {
+class OkHttpServiceTest {
 
     private static final MockHttpServer mockHttpServer = new MockHttpServer();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpClientProcessor client = new HttpClientProcessor();
+    private static final OkHttpService client = new OkHttpService();
 
     @BeforeAll
     static void setup() {
@@ -103,10 +103,10 @@ class HttpClientProcessorTest {
 
         assertEquals(200, response.statusCode());
         assertEquals(uri, response.uri());
-        assertEquals(Optional.of("image/png"), response.headers().firstValue("Content-Type"));
         assertEquals(Optional.of("image/png"), response.headers().firstValue("content-type"));
-        assertEquals(Arrays.asList("image/png"), response.headers().asMap().get("Content-Type"));
+        assertEquals(Optional.of("image/png"), response.headers().firstValue("Content-Type"));
         assertEquals(Arrays.asList("image/png"), response.headers().asMap().get("content-type"));
+        assertEquals(Arrays.asList("image/png"), response.headers().asMap().get("Content-Type"));
     }
 
     @Test

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
@@ -24,8 +24,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.inrupt.client.*;
 import com.inrupt.client.authentication.DPoP;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -54,8 +54,8 @@ public class OpenIdProvider {
 
     private final URI issuer;
     private final DPoP dpop;
-    private final HttpProcessor httpClient;
-    private final JsonProcessor processor;
+    private final HttpService httpClient;
+    private final JsonService jsonService;
 
     /**
      * Create an OpenID Provider client.
@@ -73,7 +73,7 @@ public class OpenIdProvider {
      * @param dpop a DPoP proof generator
      */
     public OpenIdProvider(final URI issuer, final DPoP dpop) {
-        this(issuer, dpop, ServiceProvider.getHttpProcessor());
+        this(issuer, dpop, ServiceProvider.getHttpService());
     }
 
     /**
@@ -83,11 +83,11 @@ public class OpenIdProvider {
      * @param dpop a DPoP proof generator
      * @param httpClient an HTTP client
      */
-    public OpenIdProvider(final URI issuer, final DPoP dpop, final HttpProcessor httpClient) {
+    public OpenIdProvider(final URI issuer, final DPoP dpop, final HttpService httpClient) {
         this.issuer = Objects.requireNonNull(issuer);
         this.dpop = Objects.requireNonNull(dpop);
         this.httpClient = Objects.requireNonNull(httpClient);
-        this.processor = ServiceProvider.getJsonProcessor();
+        this.jsonService = ServiceProvider.getJsonService();
     }
 
     /**
@@ -116,7 +116,7 @@ public class OpenIdProvider {
                 try {
                     final int httpStatus = res.statusCode();
                     if (httpStatus >= 200 && httpStatus < 300) {
-                        return processor.fromJson(res.body(), Metadata.class);
+                        return jsonService.fromJson(res.body(), Metadata.class);
                     }
                     throw new OpenIdException(
                         "Unexpected error while fetching the OpenID metadata resource.",
@@ -196,7 +196,7 @@ public class OpenIdProvider {
                 try {
                     final int httpStatus = res.statusCode();
                     if (httpStatus >= 200 && httpStatus < 300) {
-                        return processor.fromJson(res.body(), TokenResponse.class);
+                        return jsonService.fromJson(res.body(), TokenResponse.class);
                     }
                     throw new OpenIdException(
                         "Unexpected error while interacting with the OpenID Provider's token endpoint.",

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdProviderTest.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdProviderTest.java
@@ -23,7 +23,7 @@ package com.inrupt.client.openid;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.authentication.DPoP;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.net.URI;
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test;
 
 class OpenIdProviderTest {
 
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
     private static OpenIdProvider openIdProvider;
     private static DPoP dpop;
     private static final OpenIdMockHttpService mockHttpService = new OpenIdMockHttpService();

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JService.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JService.java
@@ -23,7 +23,7 @@ package com.inrupt.client.rdf4j;
 import com.inrupt.client.Dataset;
 import com.inrupt.client.Graph;
 import com.inrupt.client.Syntax;
-import com.inrupt.client.spi.RdfProcessor;
+import com.inrupt.client.spi.RdfService;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -46,9 +46,9 @@ import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 
 /**
- * An {@link RdfProcessor} that uses the RDF4J library.
+ * An {@link RdfService} that uses the RDF4J library.
  */
-public class RDF4JRdfProcessor implements RdfProcessor {
+public class RDF4JService implements RdfService {
 
     private static final Map<Syntax, RDFFormat> SYNTAX_TO_FORMAT = Map.of(
             Syntax.TURTLE, RDFFormat.TURTLE,

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
@@ -21,22 +21,22 @@
 /**
  * <h2>RDF4J RDF support for the Inrupt client libraries.</h2>
  *
- * <p>The RDF4J module gives two possibilities to read RDF data: through the Processor {@link RDF4JRdfProcessor}
+ * <p>The RDF4J module gives two possibilities to read RDF data: through the Service {@link RDF4JService}
  * and through the BodyHandler {@link RDF4JBodyHandlers}.
  *
- * <h3>Example of using the RDF4J Processor toDataset() method to read triples
+ * <h3>Example of using the RDF4J Service toDataset() method to read triples
  * from a trig file into a {@code Dataset}:</h3>
  *
  * <pre>{@code
-    RdfProcessor processor = ServiceProvider.getRdfProcessor();
+    RdfService service = ServiceProvider.getRdfService();
     Dataset dataset;
     try (InputStream input = Test.class.getResourceAsStream("/tripleExamples.trig")) {
-        dataset = processor.toDataset(Syntax.TRIG, input);
+        dataset = service.toDataset(Syntax.TRIG, input);
     }
     System.out.println("Number of triples in file: " + dataset.stream().count());
  * }</pre>
  *
- * <p>A user of {@code RDF4JRdfProcessor} should ensure that this implementation is
+ * <p>A user of {@code RDF4JService} should ensure that this implementation is
  * available on the classpath by adding the following dependency:
  *
  * <pre>

--- a/rdf4j/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfProcessor
+++ b/rdf4j/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfProcessor
@@ -1,1 +1,0 @@
-com.inrupt.client.rdf4j.RDF4JRdfProcessor

--- a/rdf4j/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfService
+++ b/rdf4j/src/main/resources/META-INF/services/com.inrupt.client.spi.RdfService
@@ -1,0 +1,1 @@
+com.inrupt.client.rdf4j.RDF4JService

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ class RDF4JBodyHandlersTest {
 
     private static final RDF4JMockHttpService mockHttpService = new RDF4JMockHttpService();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
 
     @BeforeAll
     static void setup() {

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyPublishersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyPublishersTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -53,7 +53,7 @@ class RDF4JBodyPublishersTest {
 
     private static final RDF4JMockHttpService mockHttpService = new RDF4JMockHttpService();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
 
     @BeforeAll
     static void setup() {

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JServiceTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JServiceTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.inrupt.client.Dataset;
 import com.inrupt.client.Graph;
 import com.inrupt.client.Syntax;
-import com.inrupt.client.spi.RdfProcessor;
+import com.inrupt.client.spi.RdfService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
@@ -48,9 +48,9 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class RDF4JRdfProcessorTest {
+class RDF4JServiceTest {
 
-    private final RdfProcessor processor = ServiceProvider.getRdfProcessor();
+    private final RdfService service = ServiceProvider.getRdfService();
     private static RDF4JDataset rdf4jDataset;
     private static RDF4JGraph rdf4jGraph;
 
@@ -87,13 +87,13 @@ class RDF4JRdfProcessorTest {
 
     @Test
     void checkInstance() {
-        assertTrue(processor instanceof RDF4JRdfProcessor);
+        assertTrue(service instanceof RDF4JService);
     }
 
     @Test
     void parseToDatasetTurtle() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/profileExample.ttl")) {
-            final Dataset dataset = processor.toDataset(Syntax.TURTLE, input);
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/profileExample.ttl")) {
+            final Dataset dataset = service.toDataset(Syntax.TURTLE, input);
             assertFalse(dataset.stream().findFirst().get().getGraphName().isPresent());
             assertEquals(10, dataset.stream().count());
         }
@@ -101,8 +101,8 @@ class RDF4JRdfProcessorTest {
 
     @Test
     void parseToDatasetTrig() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/oneTriple.trig")) {
-            final Dataset dataset = processor.toDataset(Syntax.TRIG, input);
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/oneTriple.trig")) {
+            final Dataset dataset = service.toDataset(Syntax.TRIG, input);
             assertTrue(dataset.stream().findFirst().get().getGraphName().isPresent());
             assertEquals(
                 "http://example.test/graph",
@@ -114,8 +114,8 @@ class RDF4JRdfProcessorTest {
 
     @Test
     void parseToDataserRelativeURIs() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/relativeURIs.ttl")) {
-            final Dataset dataset = processor.toDataset(Syntax.TURTLE, input, "http://example.test/");
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
+            final Dataset dataset = service.toDataset(Syntax.TURTLE, input, "http://example.test/");
             assertEquals(2, dataset.stream().count());
             assertTrue(dataset.stream().findFirst().get().getSubject().getURI().toString()
                 .contains("http://example.test/")
@@ -125,30 +125,30 @@ class RDF4JRdfProcessorTest {
 
     @Test
     void parseToDatasetRelativeURIsButNoBaseURI() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/relativeURIs.ttl")) {
-            assertThrows(IOException.class, () -> processor.toDataset(Syntax.TURTLE, input));
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
+            assertThrows(IOException.class, () -> service.toDataset(Syntax.TURTLE, input));
         }
     }
 
     @Test
     void parseToDatasetException() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/oneTriple.trig")) {
-            assertThrows(IOException.class, () -> processor.toDataset(Syntax.TURTLE, input));
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/oneTriple.trig")) {
+            assertThrows(IOException.class, () -> service.toDataset(Syntax.TURTLE, input));
         }
     }
 
     @Test
     void parseToGraph() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/profileExample.ttl")) {
-            final Graph graph = processor.toGraph(Syntax.TURTLE, input);
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/profileExample.ttl")) {
+            final Graph graph = service.toGraph(Syntax.TURTLE, input);
             assertEquals(10, graph.stream().count());
         }
     }
 
     @Test
     void parseToGraphRelativeURIs() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/relativeURIs.ttl")) {
-            final Graph graph = processor.toGraph(Syntax.TURTLE, input, "http://example.test/");
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
+            final Graph graph = service.toGraph(Syntax.TURTLE, input, "http://example.test/");
             assertEquals(2, graph.stream().count());
             assertTrue(graph.stream().findFirst().get().getSubject().getURI().toString()
                 .contains("http://example.test/")
@@ -158,24 +158,24 @@ class RDF4JRdfProcessorTest {
 
     @Test
     void parseToGraphRelativeURIsButNoBaseURI() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/relativeURIs.ttl")) {
-            assertThrows(IOException.class, () -> processor.toGraph(Syntax.TURTLE, input));
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
+            assertThrows(IOException.class, () -> service.toGraph(Syntax.TURTLE, input));
         }
     }
 
     @Test
     void parseToGraphException() throws IOException {
-        try (final InputStream input = RDF4JRdfProcessorTest.class.getResourceAsStream("/invalid.ttl")) {
-            assertThrows(IOException.class, () -> processor.toGraph(Syntax.TURTLE, input));
+        try (final InputStream input = RDF4JServiceTest.class.getResourceAsStream("/invalid.ttl")) {
+            assertThrows(IOException.class, () -> service.toGraph(Syntax.TURTLE, input));
         }
     }
 
     @Test
     void serializeFromDatasetTRIGRoundtrip() throws IOException {
         try (final ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            processor.fromDataset(rdf4jDataset, Syntax.TRIG, output);
+            service.fromDataset(rdf4jDataset, Syntax.TRIG, output);
             final InputStream input = new ByteArrayInputStream(output.toByteArray());
-            final Dataset roundtrip = processor.toDataset(Syntax.TRIG, input);
+            final Dataset roundtrip = service.toDataset(Syntax.TRIG, input);
             assertEquals(2, roundtrip.stream().count());
             assertEquals(rdf4jDataset.stream().count(), roundtrip.stream().count());
             final String st = rdf4jDataset.stream(
@@ -197,9 +197,9 @@ class RDF4JRdfProcessorTest {
     @Test
     void serializeFromDatasetTURTLERoundtrip() throws IOException {
         try (final ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            processor.fromDataset(rdf4jDataset, Syntax.TURTLE, output);
+            service.fromDataset(rdf4jDataset, Syntax.TURTLE, output);
             final InputStream input = new ByteArrayInputStream(output.toByteArray());
-            final Dataset roundtrip = processor.toDataset(Syntax.TURTLE, input);
+            final Dataset roundtrip = service.toDataset(Syntax.TURTLE, input);
 
             assertEquals(2, roundtrip.stream().count());
             assertEquals(rdf4jDataset.stream().count(), roundtrip.stream().count());
@@ -222,9 +222,9 @@ class RDF4JRdfProcessorTest {
     @Test
     void serializeFromGraphRoundtrip() throws IOException {
         try (final ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            processor.fromGraph(rdf4jGraph, Syntax.TURTLE, output);
+            service.fromGraph(rdf4jGraph, Syntax.TURTLE, output);
             final InputStream input = new ByteArrayInputStream(output.toByteArray());
-            final Graph roundtrip = processor.toGraph(Syntax.TURTLE, input);
+            final Graph roundtrip = service.toGraph(Syntax.TURTLE, input);
             assertEquals(2, roundtrip.stream().count());
             assertEquals(rdf4jGraph.stream().count(), roundtrip.stream().count());
             final String st = rdf4jGraph.stream(
@@ -246,7 +246,7 @@ class RDF4JRdfProcessorTest {
         final File tmp = Files.createTempFile(null, null).toFile();
         try (final OutputStream output = new FileOutputStream(tmp)) {
             output.close();
-            assertThrows(IOException.class, () -> processor.fromDataset(rdf4jDataset, Syntax.TRIG, output));
+            assertThrows(IOException.class, () -> service.fromDataset(rdf4jDataset, Syntax.TRIG, output));
         }
     }
 
@@ -255,7 +255,7 @@ class RDF4JRdfProcessorTest {
         final File tmp = Files.createTempFile(null, null).toFile();
         try (final OutputStream output = new FileOutputStream(tmp)) {
             output.close();
-            assertThrows(IOException.class, () -> processor.fromGraph(rdf4jGraph, Syntax.TURTLE, output));
+            assertThrows(IOException.class, () -> service.fromGraph(rdf4jGraph, Syntax.TURTLE, output));
         }
     }
 }

--- a/uma/src/main/java/com/inrupt/client/uma/UmaClient.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaClient.java
@@ -23,8 +23,8 @@ package com.inrupt.client.uma;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.inrupt.client.*;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -71,8 +71,8 @@ public class UmaClient {
     private static final String REQUEST_DENIED = "request_denied";
 
     // TODO add metadata cache
-    private final HttpProcessor httpClient;
-    private final JsonProcessor processor;
+    private final HttpService httpClient;
+    private final JsonService jsonService;
     private final int maxIterations;
 
     /**
@@ -83,7 +83,7 @@ public class UmaClient {
     }
 
     public UmaClient(final int maxIterations) {
-        this(ServiceProvider.getHttpProcessor(), maxIterations);
+        this(ServiceProvider.getHttpService(), maxIterations);
     }
 
     /**
@@ -92,10 +92,10 @@ public class UmaClient {
      * @param httpClient the externally configured HTTP client
      * @param maxIterations the maximum number of claims gathering stages
      */
-    public UmaClient(final HttpProcessor httpClient, final int maxIterations) {
+    public UmaClient(final HttpService httpClient, final int maxIterations) {
         this.httpClient = httpClient;
         this.maxIterations = maxIterations;
-        this.processor = ServiceProvider.getJsonProcessor();
+        this.jsonService = ServiceProvider.getJsonService();
     }
 
     /**
@@ -179,12 +179,12 @@ public class UmaClient {
                 try {
                     // Successful terminal state
                     if (SUCCESS == res.statusCode()) {
-                        return CompletableFuture.completedFuture(processor.fromJson(res.body(), TokenResponse.class));
+                        return CompletableFuture.completedFuture(jsonService.fromJson(res.body(), TokenResponse.class));
                     }
 
                     // Everything else is a 4xx response
                     // Attempt to read the error response as JSON
-                    final ErrorResponse err = processor.fromJson(res.body(), ErrorResponse.class);
+                    final ErrorResponse err = jsonService.fromJson(res.body(), ErrorResponse.class);
 
                     if (err.error != null) {
                         switch (err.error) {
@@ -263,7 +263,7 @@ public class UmaClient {
     private Metadata processMetadataResponse(final Response<InputStream> response) {
         if (response.statusCode() == SUCCESS) {
             try {
-                return processor.fromJson(response.body(), Metadata.class);
+                return jsonService.fromJson(response.body(), Metadata.class);
             } catch (final IOException ex) {
                 throw new UmaException("Error while processing UMA metadata response", ex);
             }

--- a/vc/src/main/java/com/inrupt/client/vc/Holder.java
+++ b/vc/src/main/java/com/inrupt/client/vc/Holder.java
@@ -26,8 +26,8 @@ import com.inrupt.client.URIBuilder;
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
 import com.inrupt.client.core.IOUtils;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
@@ -57,8 +57,8 @@ public class Holder {
     private static final String EXCHANGES = "exchanges";
 
     private final URI baseUri;
-    private final HttpProcessor httpClient;
-    private final JsonProcessor processor;
+    private final HttpService httpClient;
+    private final JsonService jsonService;
 
     /**
      * Create a new Holder object for interacting with a VC-API.
@@ -66,7 +66,7 @@ public class Holder {
      * @param baseUri the base URI for the VC-API
      */
     public Holder(final URI baseUri) {
-        this(baseUri, ServiceProvider.getHttpProcessor());
+        this(baseUri, ServiceProvider.getHttpService());
     }
 
     /**
@@ -75,10 +75,10 @@ public class Holder {
      * @param baseUri the base URI for the VC-API
      * @param httpClient an HTTP client
      */
-    public Holder(final URI baseUri, final HttpProcessor httpClient) {
+    public Holder(final URI baseUri, final HttpService httpClient) {
         this.baseUri = baseUri;
         this.httpClient = httpClient;
-        this.processor = ServiceProvider.getJsonProcessor();
+        this.jsonService = ServiceProvider.getJsonService();
     }
 
     /**
@@ -122,7 +122,7 @@ public class Holder {
                 try {
                     final int httpStatus = res.statusCode();
                     if (httpStatus >= 200 && httpStatus < 300) {
-                        return processor.fromJson(res.body(),
+                        return jsonService.fromJson(res.body(),
                             new ArrayList<VerifiableCredential>(){}.getClass().getGenericSuperclass());
                     }
                     throw new VerifiableCredentialException(
@@ -257,7 +257,7 @@ public class Holder {
                 try {
                     final int httpStatus = res.statusCode();
                     if (httpStatus >= 200 && httpStatus < 300) {
-                        return processor.fromJson(res.body(),
+                        return jsonService.fromJson(res.body(),
                             new ArrayList<VerifiablePresentation>(){}.getClass().getGenericSuperclass());
                     }
                     throw new VerifiableCredentialException(
@@ -512,7 +512,7 @@ public class Holder {
             final int httpStatus = responseInfo.statusCode();
             if (httpStatus >= 200 && httpStatus < 300) {
                 try (final InputStream input = new ByteArrayInputStream(responseInfo.body().array())) {
-                    return processor.fromJson(input, VerifiablePresentationRequest.class);
+                    return jsonService.fromJson(input, VerifiablePresentationRequest.class);
                 } catch (final IOException ex) {
                     throw new VerifiableCredentialException("Error parsing presentation request", ex);
                 }
@@ -526,7 +526,7 @@ public class Holder {
     private <T> Request.BodyPublisher serialize(final T request) {
         return IOUtils.buffer(out -> {
             try {
-                processor.toJson(request, out);
+                jsonService.toJson(request, out);
             } catch (final IOException ex) {
                 throw new VerifiableCredentialException("Error serializing JSON", ex);
             }

--- a/vc/src/main/java/com/inrupt/client/vc/Issuer.java
+++ b/vc/src/main/java/com/inrupt/client/vc/Issuer.java
@@ -25,8 +25,8 @@ import com.inrupt.client.Response;
 import com.inrupt.client.URIBuilder;
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.core.IOUtils;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -47,8 +47,8 @@ public class Issuer {
     private static final String APPLICATION_JSON = "application/json";
 
     private final URI baseUri;
-    private final HttpProcessor httpClient;
-    private final JsonProcessor processor;
+    private final HttpService httpClient;
+    private final JsonService jsonService;
 
     /**
      * Create a new Issuer object.
@@ -56,7 +56,7 @@ public class Issuer {
      * @param baseUri the base URL for the VC-API
      */
     public Issuer(final URI baseUri) {
-        this(baseUri, ServiceProvider.getHttpProcessor());
+        this(baseUri, ServiceProvider.getHttpService());
     }
 
     /**
@@ -65,10 +65,10 @@ public class Issuer {
      * @param baseUri the base URI for the VC-API
      * @param httpClient an HTTP client
      */
-    public Issuer(final URI baseUri, final HttpProcessor httpClient) {
+    public Issuer(final URI baseUri, final HttpService httpClient) {
         this.baseUri = baseUri;
         this.httpClient = httpClient;
-        this.processor = ServiceProvider.getJsonProcessor();
+        this.jsonService = ServiceProvider.getJsonService();
     }
 
     /**
@@ -238,7 +238,7 @@ public class Issuer {
     private Request.BodyPublisher ofStatusRequest(final StatusRequest request) {
         return IOUtils.buffer(out -> {
             try {
-                processor.toJson(request, out);
+                jsonService.toJson(request, out);
             } catch (final IOException ex) {
                 throw new VerifiableCredentialException("Error serializing status request", ex);
             }

--- a/vc/src/main/java/com/inrupt/client/vc/VerifiableCredentialBodyHandlers.java
+++ b/vc/src/main/java/com/inrupt/client/vc/VerifiableCredentialBodyHandlers.java
@@ -23,7 +23,7 @@ package com.inrupt.client.vc;
 import com.inrupt.client.Response;
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
@@ -35,7 +35,7 @@ import java.io.InputStream;
  */
 public final class VerifiableCredentialBodyHandlers {
 
-    private static final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private static final JsonService jsonService = ServiceProvider.getJsonService();
 
     /**
      * Create a {@link VerifiableCredential} from an HTTP response.
@@ -47,7 +47,7 @@ public final class VerifiableCredentialBodyHandlers {
             final int httpStatus = responseInfo.statusCode();
             if (httpStatus >= 200 && httpStatus < 300) {
                 try (final InputStream input = new ByteArrayInputStream(responseInfo.body().array())) {
-                    return processor.fromJson(input, VerifiableCredential.class);
+                    return jsonService.fromJson(input, VerifiableCredential.class);
                 } catch (final IOException ex) {
                     throw new VerifiableCredentialException("Error parsing credential", ex);
                 }
@@ -68,7 +68,7 @@ public final class VerifiableCredentialBodyHandlers {
             final int httpStatus = responseInfo.statusCode();
             if (httpStatus >= 200 && httpStatus < 300) {
                 try (final InputStream input = new ByteArrayInputStream(responseInfo.body().array())) {
-                    return processor.fromJson(input, VerifiablePresentation.class);
+                    return jsonService.fromJson(input, VerifiablePresentation.class);
                 } catch (final IOException ex) {
                     throw new VerifiableCredentialException("Error parsing presentation", ex);
                 }

--- a/vc/src/main/java/com/inrupt/client/vc/VerifiableCredentialBodyPublishers.java
+++ b/vc/src/main/java/com/inrupt/client/vc/VerifiableCredentialBodyPublishers.java
@@ -24,7 +24,7 @@ import com.inrupt.client.Request;
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
 import com.inrupt.client.core.IOUtils;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ import java.io.IOException;
  */
 public final class VerifiableCredentialBodyPublishers {
 
-    private static final JsonProcessor processor = ServiceProvider.getJsonProcessor();
+    private static final JsonService jsonService = ServiceProvider.getJsonService();
 
     /**
      * Serialize a {@link VerifiableCredential} as an HTTP request body.
@@ -45,7 +45,7 @@ public final class VerifiableCredentialBodyPublishers {
     public static Request.BodyPublisher ofVerifiableCredential(final VerifiableCredential vc) {
         return IOUtils.buffer(out -> {
             try {
-                processor.toJson(vc, out);
+                jsonService.toJson(vc, out);
             } catch (final IOException ex) {
                 throw new VerifiableCredentialException("Error serializing credential", ex);
             }
@@ -61,7 +61,7 @@ public final class VerifiableCredentialBodyPublishers {
     public static Request.BodyPublisher ofVerifiablePresentation(final VerifiablePresentation vp) {
         return IOUtils.buffer(out -> {
             try {
-                processor.toJson(vp, out);
+                jsonService.toJson(vp, out);
             } catch (final IOException ex) {
                 throw new VerifiableCredentialException("Error serializing presentation", ex);
             }

--- a/vc/src/main/java/com/inrupt/client/vc/Verifier.java
+++ b/vc/src/main/java/com/inrupt/client/vc/Verifier.java
@@ -25,8 +25,8 @@ import com.inrupt.client.Response;
 import com.inrupt.client.URIBuilder;
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
@@ -47,8 +47,8 @@ public class Verifier {
     private static final String APPLICATION_JSON = "application/json";
 
     private final URI baseUri;
-    private final HttpProcessor httpClient;
-    private final JsonProcessor processor;
+    private final HttpService httpClient;
+    private final JsonService jsonService;
 
     /**
      * Create a new Verifier object for interacting with a VC-API.
@@ -56,7 +56,7 @@ public class Verifier {
      * @param baseUri the base URI for the VC-API
      */
     public Verifier(final URI baseUri) {
-        this(baseUri, ServiceProvider.getHttpProcessor());
+        this(baseUri, ServiceProvider.getHttpService());
     }
 
     /**
@@ -65,10 +65,10 @@ public class Verifier {
      * @param baseUri the base URI for the VC-API
      * @param httpClient an HTTP client
      */
-    public Verifier(final URI baseUri, final HttpProcessor httpClient) {
+    public Verifier(final URI baseUri, final HttpService httpClient) {
         this.baseUri = baseUri;
         this.httpClient = httpClient;
-        this.processor = ServiceProvider.getJsonProcessor();
+        this.jsonService = ServiceProvider.getJsonService();
     }
 
     /**
@@ -150,7 +150,7 @@ public class Verifier {
             final int httpStatus = responseInfo.statusCode();
             if (httpStatus >= 200 && httpStatus < 300) {
                 try (final InputStream input = new ByteArrayInputStream(responseInfo.body().array())) {
-                    return processor.fromJson(input, VerificationResponse.class);
+                    return jsonService.fromJson(input, VerificationResponse.class);
                 } catch (final IOException ex) {
                     throw new VerifiableCredentialException(
                             "Error parsing verification request", ex);

--- a/vc/src/test/java/com/inrupt/client/vc/HolderTest.java
+++ b/vc/src/test/java/com/inrupt/client/vc/HolderTest.java
@@ -24,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -44,10 +44,10 @@ import org.junit.jupiter.api.Test;
 class HolderTest {
 
     private static final VerifiableCredentialMockService vcMockService = new VerifiableCredentialMockService();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
     private static final Map<String, String> config = new HashMap<>();
     private static Holder holder;
-    private static JsonProcessor processor;
+    private static JsonService jsonService;
     private static VerifiableCredential expectedVC;
     private static VerifiablePresentation expectedVP;
 
@@ -55,13 +55,13 @@ class HolderTest {
     static void setup() throws IOException {
         config.putAll(vcMockService.start());
         holder = new Holder(URI.create(config.get("vc_uri")), client);
-        processor = ServiceProvider.getJsonProcessor();
+        jsonService = ServiceProvider.getJsonService();
         try (final var res =
                 HolderTest.class.getResourceAsStream("/__files/verifiableCredential.json")) {
-            expectedVC = processor.fromJson(res, VerifiableCredential.class);
+            expectedVC = jsonService.fromJson(res, VerifiableCredential.class);
         }
         try (final var res = HolderTest.class.getResourceAsStream("/__files/verifiablePresentation.json")) {
-            expectedVP = processor.fromJson(res, VerifiablePresentation.class);
+            expectedVP = jsonService.fromJson(res, VerifiablePresentation.class);
         }
     }
 

--- a/vc/src/test/java/com/inrupt/client/vc/IssuerTest.java
+++ b/vc/src/test/java/com/inrupt/client/vc/IssuerTest.java
@@ -23,8 +23,8 @@ package com.inrupt.client.vc;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.VerifiableCredential;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 import com.inrupt.client.vc.Issuer.StatusRequest;
 
@@ -42,19 +42,19 @@ import org.junit.jupiter.api.Test;
 class IssuerTest {
 
     private static final VerifiableCredentialMockService vcMockService = new VerifiableCredentialMockService();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
     private static final Map<String, String> config = new HashMap<>();
     private static Issuer issuer;
-    private static JsonProcessor processor;
+    private static JsonService jsonService;
     private static VerifiableCredential expectedVC;
 
     @BeforeAll
     static void setup() throws IOException {
         config.putAll(vcMockService.start());
         issuer = new Issuer(URI.create(config.get("vc_uri")), client);
-        processor = ServiceProvider.getJsonProcessor();
+        jsonService = ServiceProvider.getJsonService();
         try (final var res = IssuerTest.class.getResourceAsStream("/__files/verifiableCredential.json")) {
-            expectedVC = processor.fromJson(res, VerifiableCredential.class);
+            expectedVC = jsonService.fromJson(res, VerifiableCredential.class);
         }
     }
 

--- a/vc/src/test/java/com/inrupt/client/vc/VerifiableCredentialBodyHandlersTest.java
+++ b/vc/src/test/java/com/inrupt/client/vc/VerifiableCredentialBodyHandlersTest.java
@@ -23,7 +23,7 @@ package com.inrupt.client.vc;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.inrupt.client.Request;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -39,7 +39,7 @@ class VerifiableCredentialBodyHandlersTest {
 
     private static final VerifiableCredentialMockService vcMockService = new VerifiableCredentialMockService();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
 
     @BeforeAll
     static void setup() {

--- a/vc/src/test/java/com/inrupt/client/vc/VerifiableCredentialBodyPublishersTest.java
+++ b/vc/src/test/java/com/inrupt/client/vc/VerifiableCredentialBodyPublishersTest.java
@@ -26,8 +26,8 @@ import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -43,22 +43,22 @@ class VerifiableCredentialBodyPublishersTest {
 
     private static final VerifiableCredentialMockService vcMockService = new VerifiableCredentialMockService();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
-    private static JsonProcessor processor;
+    private static final HttpService client = ServiceProvider.getHttpService();
+    private static JsonService jsonService;
     private static VerifiableCredential expectedVC;
     private static VerifiablePresentation expectedVP;
 
     @BeforeAll
     static void setup() throws IOException {
         config.putAll(vcMockService.start());
-        processor = ServiceProvider.getJsonProcessor();
+        jsonService = ServiceProvider.getJsonService();
         try (final var res = VerifiableCredentialBodyPublishersTest.class
                 .getResourceAsStream("/__files/verifiableCredential.json")) {
-            expectedVC = processor.fromJson(res, VerifiableCredential.class);
+            expectedVC = jsonService.fromJson(res, VerifiableCredential.class);
         }
         try (final var res = VerifiableCredentialBodyPublishersTest.class
             .getResourceAsStream("/__files/verifiablePresentation.json")) {
-            expectedVP = processor.fromJson(res, VerifiablePresentation.class);
+            expectedVP = jsonService.fromJson(res, VerifiablePresentation.class);
         }
     }
 

--- a/vc/src/test/java/com/inrupt/client/vc/VerifierTest.java
+++ b/vc/src/test/java/com/inrupt/client/vc/VerifierTest.java
@@ -24,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.VerifiableCredential;
 import com.inrupt.client.VerifiablePresentation;
-import com.inrupt.client.spi.HttpProcessor;
-import com.inrupt.client.spi.JsonProcessor;
+import com.inrupt.client.spi.HttpService;
+import com.inrupt.client.spi.JsonService;
 import com.inrupt.client.spi.ServiceProvider;
 import com.inrupt.client.vc.Verifier.VerificationResponse;
 
@@ -44,9 +44,9 @@ class VerifierTest {
 
     private static final VerifiableCredentialMockService vcMockService = new VerifiableCredentialMockService();
     private static final Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
     private static Verifier verifier;
-    private static JsonProcessor processor;
+    private static JsonService service;
     private static VerificationResponse expectedVerificationResponse;
     private static VerifiableCredential expectedVC;
     private static VerifiablePresentation expectedVP;
@@ -55,16 +55,16 @@ class VerifierTest {
     static void setup() throws IOException {
         config.putAll(vcMockService.start());
         verifier = new Verifier(URI.create(config.get("vc_uri")), client);
-        processor = ServiceProvider.getJsonProcessor();
+        service = ServiceProvider.getJsonService();
         try (final var res = VerifierTest.class.getResourceAsStream("/__files/verificationResponse.json")) {
-            expectedVerificationResponse = processor.fromJson(res, VerificationResponse.class);
+            expectedVerificationResponse = service.fromJson(res, VerificationResponse.class);
         }
         try (final var res =
                 VerifierTest.class.getResourceAsStream("/__files/verifiableCredential.json")) {
-            expectedVC = processor.fromJson(res, VerifiableCredential.class);
+            expectedVC = service.fromJson(res, VerifiableCredential.class);
         }
         try (final var res = VerifierTest.class.getResourceAsStream("/__files/verifiablePresentation.json")) {
-            expectedVP = processor.fromJson(res, VerifiablePresentation.class);
+            expectedVP = service.fromJson(res, VerifiablePresentation.class);
         }
     }
 

--- a/webid/src/main/java/com/inrupt/client/webid/WebIdBodyHandlers.java
+++ b/webid/src/main/java/com/inrupt/client/webid/WebIdBodyHandlers.java
@@ -21,7 +21,7 @@
 package com.inrupt.client.webid;
 
 import com.inrupt.client.*;
-import com.inrupt.client.spi.RdfProcessor;
+import com.inrupt.client.spi.RdfService;
 import com.inrupt.client.spi.ServiceProvider;
 import com.inrupt.client.vocabulary.PIM;
 import com.inrupt.client.vocabulary.RDF;
@@ -37,7 +37,7 @@ import java.net.URI;
  */
 public final class WebIdBodyHandlers {
 
-    private static final RdfProcessor processor = ServiceProvider.getRdfProcessor();
+    private static final RdfService service = ServiceProvider.getRdfService();
 
     /**
      * Transform an HTTP response into a WebID Profile object.
@@ -49,7 +49,7 @@ public final class WebIdBodyHandlers {
         return responseInfo -> {
             final var builder = WebIdProfile.newBuilder();
             try (final var input = new ByteArrayInputStream(responseInfo.body().array())) {
-                final var graph = processor.toGraph(Syntax.TURTLE, input);
+                final var graph = service.toGraph(Syntax.TURTLE, input);
 
                 graph.stream(RDFNode.namedNode(webid), RDFNode.namedNode(Solid.oidcIssuer), null)
                     .map(Triple::getObject)

--- a/webid/src/test/java/com/inrupt/client/webid/WebIdBodyHandlersTest.java
+++ b/webid/src/test/java/com/inrupt/client/webid/WebIdBodyHandlersTest.java
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
-import com.inrupt.client.spi.HttpProcessor;
+import com.inrupt.client.spi.HttpService;
 import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.IOException;
@@ -40,7 +40,7 @@ class WebIdBodyHandlersTest {
 
     private static final WebIdMockHttpService mockHttpServer = new WebIdMockHttpService();
     private static Map<String, String> config = new HashMap<>();
-    private static final HttpProcessor client = ServiceProvider.getHttpProcessor();
+    private static final HttpService client = ServiceProvider.getHttpService();
 
     @BeforeAll
     static void setup() {


### PR DESCRIPTION
This will conflict with #110 , but I can deal with the fallout of that fairly easily.

Overall, this changes the naming of some interfaces from `*Processor` to `*Service`, since that's what they are.