### PR TITLE
JCL-149: Move http header parsers to core package

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -36,6 +36,15 @@
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.inrupt</groupId>
+      <artifactId>inrupt-client-parser</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
 
     <!-- tests -->
     <dependency>

--- a/core/src/main/java/com/inrupt/client/core/HeaderParser.java
+++ b/core/src/main/java/com/inrupt/client/core/HeaderParser.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.core;
+
+import java.util.List;
+
+/**
+ * A class for parsing HTTP headers with ANTLR.
+ */
+public interface HeaderParser {
+
+    /**
+     * Parse the supplied link headers.
+     *
+     * @param headers the link headers to parse
+     * @return a list of parsed link headers
+     */
+    List<Link> parseLinkHeaders(String... headers);
+}
+

--- a/core/src/main/java/com/inrupt/client/core/HttpHeaders.java
+++ b/core/src/main/java/com/inrupt/client/core/HttpHeaders.java
@@ -18,25 +18,25 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client.http;
+package com.inrupt.client.core;
 
 import java.util.List;
 
-public final class Headers {
+public final class HttpHeaders {
 
-    /** 
+    /**
      * Create a list of links based on a given header.
-     * 
+     *
      * @param headers the values of the headers to be parsed
      * @return arrayList of links from header
      */
     public static List<Link> link(final String... headers) {
-        return link(new HeaderParser(), headers);
+        return link(new DefaultHeaderParser(), headers);
     }
 
-    /** 
+    /**
      * Create a list of links based on a given header.
-     * 
+     *
      * @param parser
      * @param headers the values of the headers to be parsed
      * @return arrayList of links from header
@@ -45,7 +45,7 @@ public final class Headers {
         return parser.parseLinkHeaders(headers);
     }
 
-    private Headers() {
+    private HttpHeaders() {
         // Prevent instantiation
     }
 }

--- a/core/src/main/java/com/inrupt/client/core/Link.java
+++ b/core/src/main/java/com/inrupt/client/core/Link.java
@@ -18,7 +18,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client.http;
+package com.inrupt.client.core;
 
 import java.net.URI;
 import java.util.Collections;
@@ -85,7 +85,7 @@ public final class Link {
             return false;
         }
 
-        final var c = (Link) obj;
+        final Link c = (Link) obj;
 
         if (!this.getUri().equals(c.getUri())) {
             return false;

--- a/core/src/test/java/com/inrupt/client/core/HttpHeadersTest.java
+++ b/core/src/test/java/com/inrupt/client/core/HttpHeadersTest.java
@@ -18,7 +18,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client.http;
+package com.inrupt.client.core;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,14 +33,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class HeadersTest {
+class HttpHeadersTest {
 
     @Test
     void parseSingleLink() {
-        final var header = "<https://example.com/%E8%8B%97%E6%9D%A1>; rel=\"preconnect\"";
-        final var linkValues = Headers.link(header);
+        final String header = "<https://example.com/%E8%8B%97%E6%9D%A1>; rel=\"preconnect\"";
+        final List<Link> linkValues = HttpHeaders.link(header);
 
-        final var expected = List.of(
+        final List<Link> expected = List.of(
                     Link.of(URI.create("https://example.com/%E8%8B%97%E6%9D%A1"),
                     Map.of("rel", "preconnect")));
 
@@ -50,7 +50,7 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void parseListedParams(final String header, final List<Link> expected) {
-        final var linkValues = Headers.link(header);
+        final List<Link> linkValues = HttpHeaders.link(header);
         assertEquals(expected, linkValues);
     }
 
@@ -81,7 +81,7 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void parseListedLinks(final String header, final List<Link> expected) {
-        final var linkValues = Headers.link(header);
+        final List<Link> linkValues = HttpHeaders.link(header);
         assertEquals(expected, linkValues);
     }
 
@@ -113,7 +113,7 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void parseRelativeReferenceLink(final String header, final List<Link> expected) {
-        final var linkValues = Headers.link(header);
+        final List<Link> linkValues = HttpHeaders.link(header);
         assertEquals(expected, linkValues);
     }
 
@@ -133,7 +133,7 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void parseLinkInOrder(final String header, final List<Link> expected) {
-        final var linkValues = Headers.link(header);
+        final List<Link> linkValues = HttpHeaders.link(header);
         assertEquals(expected, linkValues);
     }
 
@@ -159,7 +159,7 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void parseIRIs(final String header, final List<Link> expected) {
-        final var linkValues = Headers.link(header);
+        final List<Link> linkValues = HttpHeaders.link(header);
         assertEquals(expected, linkValues, "Unexpected handling of IRI values");
     }
 
@@ -173,7 +173,7 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void parseNonHttpUris(final String header, final List<Link> expected) {
-        final var linkValues = Headers.link(header);
+        final List<Link> linkValues = HttpHeaders.link(header);
         assertEquals(expected, linkValues, "Unexpected handling of invalid link header");
     }
 
@@ -193,7 +193,7 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void ignoreInvalidParams(final String header, final List<Link> expected) {
-        final var linkValues = Headers.link(header);
+        final List<Link> linkValues = HttpHeaders.link(header);
         assertEquals(expected, linkValues);
     }
 
@@ -216,8 +216,8 @@ class HeadersTest {
     @ParameterizedTest
     @MethodSource
     void parseInvalidLinkHeader(final String header) {
-        final var linkValues = Headers.link(header);
-        final var empty = Collections.emptyList();
+        final List<Link> linkValues = HttpHeaders.link(header);
+        final List<Link> empty = Collections.emptyList();
         assertEquals(empty, linkValues, "Unexpected handling of invalid link header");
     }
 


### PR DESCRIPTION
This moves the header parsers from the `http` module into the `core` module, paving the way for eliminating the `http` module altogether.

In addition, this changes the `HeaderParser` to an interface and makes the existing impl into a `DefaultHeaderParser` class, making it easier to override, if that is something devs want to do.

And as this is going into `core`, it gets the Java11 -> Java8 treatment