### PR TITLE
JCL-169: Set an explicit site output target

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Build the code with Maven
         run: ./mvnw -B -ntp clean install site site:stage
 
-      - name: Copy Resources
-        run: sh scripts/move-site-modules.sh
-
       - name: Publish to GitHub pages
         uses: peaceiris/actions-gh-pages@v3
         if: github.actor != 'dependabot[bot]'

--- a/pom.xml
+++ b/pom.xml
@@ -515,6 +515,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
           <version>${site.plugin.version}</version>
+          <configuration>
+            <outputDirectory>${project.build.directory}/site</outputDirectory>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.sonarsource.scanner.maven</groupId>

--- a/scripts/move-site-modules.sh
+++ b/scripts/move-site-modules.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-for MODULE in api bom core httpclient jackson jena jsonb okhttp openid parser rdf4j uma vc vocabulary webid
-do
-    mv target/$MODULE target/site/
-done


### PR DESCRIPTION
Supersedes #147 

This sets an explicit location for the site output files, which, in fact, makes the generation much cleaner, avoiding the need for the shell script altogether.