### PR TITLE
JCL-169: Using staging direcotry

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -34,7 +34,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.actor != 'dependabot[bot]'
         with:
-          publish_dir: ./target/site/
+          publish_dir: ./target/staging/
           personal_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Artifacts


### PR DESCRIPTION
This uses the correct (staging) directory to copy resources to the GH-Pages branch.