### PR TITLE
JCL-199: Set logging rules for wiremock classes

### DIFF
--- a/core/src/test/resources/simplelogger.properties
+++ b/core/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/httpclient/src/test/resources/simplelogger.properties
+++ b/httpclient/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/jena/src/test/resources/simplelogger.properties
+++ b/jena/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/okhttp/src/test/resources/simplelogger.properties
+++ b/okhttp/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/openid/src/test/resources/simplelogger.properties
+++ b/openid/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/rdf4j/src/test/resources/simplelogger.properties
+++ b/rdf4j/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/solid/src/test/resources/simplelogger.properties
+++ b/solid/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/uma/src/test/resources/simplelogger.properties
+++ b/uma/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/webid/src/test/resources/simplelogger.properties
+++ b/webid/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn


### PR DESCRIPTION
This sets the jetty-related logs (from wiremock) to `WARN` so that ordinary log output is kept to a minimum