### PR TITLE
JCL-219: Improve error handling for the high-level client

### DIFF
--- a/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+import com.inrupt.client.InruptClientException;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class SolidClientException extends InruptClientException {
+
+    private static final long serialVersionUID = 2868432164225689934L;
+
+    private final URI uri;
+    private final int statusCode;
+    private final Headers headers;
+    private final String body;
+
+    /**
+     * Create a SolidClient exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param statusCode the HTTP status code
+     * @param headers the response headers
+     * @param body the body
+     */
+    public SolidClientException(final String message, final URI uri, final int statusCode,
+            final Headers headers, final String body) {
+        super(message);
+        this.uri = uri;
+        this.statusCode = statusCode;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    /**
+     * Retrieve the URI associated with this exception.
+     *
+     * @return the uri
+     */
+    public URI getUri() {
+        return uri;
+    }
+
+    /**
+     * Retrieve the status code associated with this exception.
+     *
+     * @return the status code
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    /**
+     * Retrieve the headers associated with this exception.
+     *
+     * @return the headers
+     */
+    public Headers getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Retrieve the body associated with this exception.
+     *
+     * @return the body
+     */
+    public String getBody() {
+        return body;
+    }
+}
+

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -139,4 +139,46 @@ class SolidClientTest {
         })
         .toCompletableFuture().join();
     }
+
+    @Test
+    void testUnauthorizedResource() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/unauthorized");
+
+        final CompletionException err = assertThrows(CompletionException.class, () ->
+                client.read(uri, Recipe.class).toCompletableFuture().join());
+        assertTrue(err.getCause() instanceof SolidClientException);
+        final SolidClientException ex = (SolidClientException) err.getCause();
+        assertEquals(401, ex.getStatusCode());
+        assertEquals(uri, ex.getUri());
+        assertEquals(Optional.of("application/json"), ex.getHeaders().firstValue("Content-Type"));
+        assertNotNull(ex.getBody());
+    }
+
+    @Test
+    void testForbiddenResource() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/forbidden");
+
+        final CompletionException err = assertThrows(CompletionException.class, () ->
+                client.read(uri, Recipe.class).toCompletableFuture().join());
+        assertTrue(err.getCause() instanceof SolidClientException);
+        final SolidClientException ex = (SolidClientException) err.getCause();
+        assertEquals(403, ex.getStatusCode());
+        assertEquals(uri, ex.getUri());
+        assertEquals(Optional.of("application/json"), ex.getHeaders().firstValue("Content-Type"));
+        assertNotNull(ex.getBody());
+    }
+
+    @Test
+    void testMissingResource() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/missing");
+
+        final CompletionException err = assertThrows(CompletionException.class, () ->
+                client.read(uri, Recipe.class).toCompletableFuture().join());
+        assertTrue(err.getCause() instanceof SolidClientException);
+        final SolidClientException ex = (SolidClientException) err.getCause();
+        assertEquals(404, ex.getStatusCode());
+        assertEquals(uri, ex.getUri());
+        assertEquals(Optional.of("application/json"), ex.getHeaders().firstValue("Content-Type"));
+        assertNotNull(ex.getBody());
+    }
 }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
@@ -125,6 +125,24 @@ public class SolidMockHttpService {
                     .withBody("This isn't valid turtle.")
             )
         );
+
+        wireMockServer.stubFor(get(urlEqualTo("/missing"))
+                .willReturn(aResponse()
+                    .withStatus(404)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"error\": \"missing resource\"}")));
+
+        wireMockServer.stubFor(get(urlEqualTo("/unauthorized"))
+                .willReturn(aResponse()
+                    .withStatus(401)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"error\": \"unauthorized\"}")));
+
+        wireMockServer.stubFor(get(urlEqualTo("/forbidden"))
+                .willReturn(aResponse()
+                    .withStatus(403)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"error\": \"forbidden\"}")));
     }
 
     public Map<String, String> start() {

--- a/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
@@ -136,4 +136,37 @@ class SolidSyncClientTest {
             assertEquals(7, recipe.getSteps().size());
         }
     }
+
+    @Test
+    void testUnauthorizedResource() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/unauthorized");
+
+        final SolidClientException err = assertThrows(SolidClientException.class, () -> client.read(uri, Recipe.class));
+        assertEquals(401, err.getStatusCode());
+        assertEquals(uri, err.getUri());
+        assertEquals(Optional.of("application/json"), err.getHeaders().firstValue("Content-Type"));
+        assertNotNull(err.getBody());
+    }
+
+    @Test
+    void testForbiddenResource() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/forbidden");
+
+        final SolidClientException err = assertThrows(SolidClientException.class, () -> client.read(uri, Recipe.class));
+        assertEquals(403, err.getStatusCode());
+        assertEquals(uri, err.getUri());
+        assertEquals(Optional.of("application/json"), err.getHeaders().firstValue("Content-Type"));
+        assertNotNull(err.getBody());
+    }
+
+    @Test
+    void testMissingResource() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/missing");
+
+        final SolidClientException err = assertThrows(SolidClientException.class, () -> client.read(uri, Recipe.class));
+        assertEquals(404, err.getStatusCode());
+        assertEquals(uri, err.getUri());
+        assertEquals(Optional.of("application/json"), err.getHeaders().firstValue("Content-Type"));
+        assertNotNull(err.getBody());
+    }
 }

--- a/webid/src/main/java/com/inrupt/client/webid/WebIdBodyHandlers.java
+++ b/webid/src/main/java/com/inrupt/client/webid/WebIdBodyHandlers.java
@@ -27,7 +27,6 @@ import com.inrupt.client.spi.ServiceProvider;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.RDFSyntax;
@@ -42,14 +41,13 @@ public final class WebIdBodyHandlers {
     /**
      * Transform an HTTP response into a WebID Profile object.
      *
-     * @param webid the WebID URI
      * @return an HTTP body handler
      */
-    public static Response.BodyHandler<WebIdProfile> ofWebIdProfile(final URI webid) {
+    public static Response.BodyHandler<WebIdProfile> ofWebIdProfile() {
         return responseInfo -> {
             try (final InputStream input = new ByteArrayInputStream(responseInfo.body().array())) {
                 final Dataset dataset = service.toDataset(RDFSyntax.TURTLE, input, responseInfo.uri().toString());
-                return new WebIdProfile(webid, dataset);
+                return new WebIdProfile(responseInfo.uri(), dataset);
             } catch (final IOException ex) {
                 throw new WebIdException("Error processing WebId profile resource", ex);
             }

--- a/webid/src/test/java/com/inrupt/client/webid/WebIdBodyHandlersTest.java
+++ b/webid/src/test/java/com/inrupt/client/webid/WebIdBodyHandlersTest.java
@@ -63,7 +63,7 @@ class WebIdBodyHandlersTest {
             .build();
 
         final Response<WebIdProfile> response = client.send(request,
-                WebIdBodyHandlers.ofWebIdProfile(webid))
+                WebIdBodyHandlers.ofWebIdProfile())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());


### PR DESCRIPTION
This adds a `SolidClientException` class for handling cases where the high level client encounters a 4xx/5xx level error.