### PR TITLE
JCL-203: cleanup tests

### DIFF
--- a/integration/src/test/java/com/inrupt/client/integration/CoreModulesResourceTest.java
+++ b/integration/src/test/java/com/inrupt/client/integration/CoreModulesResourceTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.Test;
 
 class CoreModulesResourceTest {
 
+    private static final MockSolidServer mockHttpServer = new MockSolidServer();
     private static final Config config = ConfigProvider.getConfig();
     private static final SolidSyncClient client = SolidSyncClient.getClient().session(Session.anonymous());
 
@@ -66,7 +67,10 @@ class CoreModulesResourceTest {
     @BeforeAll
     static void setup() {
         if (testEnv.contains("MockSolidServer")) {
-            Utils.initMockServer();
+            mockHttpServer.start();
+            Utils.POD_URL = mockHttpServer.getMockServerUrl();
+            Utils.AS_URI = Utils.POD_URL + "/uma";
+            Utils.WEBID = URI.create(Utils.POD_URL + "/" + Utils.USERNAME);
         }
 
         final Request requestRdf = Request.newBuilder(Utils.WEBID).GET().build();
@@ -85,7 +89,7 @@ class CoreModulesResourceTest {
     @AfterAll
     static void teardown() {
         if (testEnv.equals("MockSolidServer")) {
-            Utils.stopMockServer();
+            mockHttpServer.stop();
         }
     }
 

--- a/integration/src/test/java/com/inrupt/client/integration/DomainModulesResourceTest.java
+++ b/integration/src/test/java/com/inrupt/client/integration/DomainModulesResourceTest.java
@@ -56,6 +56,7 @@ import org.junit.jupiter.api.Test;
 
 class DomainModulesResourceTest {
 
+    private static final MockSolidServer mockHttpServer = new MockSolidServer();
     private static final Config config = ConfigProvider.getConfig();
     private static final RDF rdf = RDFFactory.getInstance();
     private static final SolidSyncClient client = SolidSyncClient.getClient().session(Session.anonymous());
@@ -66,7 +67,10 @@ class DomainModulesResourceTest {
     @BeforeAll
     static void setup() {
         if (testEnv.contains("MockSolidServer")) {
-            Utils.initMockServer();
+            mockHttpServer.start();
+            Utils.POD_URL = mockHttpServer.getMockServerUrl();
+            Utils.AS_URI = Utils.POD_URL + "/uma";
+            Utils.WEBID = URI.create(Utils.POD_URL + "/" + Utils.USERNAME);
         }
 
         final var req = Request.newBuilder(Utils.WEBID).GET().header("Accept", "text/turtle").build();
@@ -84,7 +88,7 @@ class DomainModulesResourceTest {
     @AfterAll
     static void teardown() {
         if (testEnv.equals("MockSolidServer")) {
-            Utils.stopMockServer();
+            mockHttpServer.stop();
         }
     }
 

--- a/integration/src/test/java/com/inrupt/client/integration/MockServerTest.java
+++ b/integration/src/test/java/com/inrupt/client/integration/MockServerTest.java
@@ -44,15 +44,19 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class MockServerTest {
+    private static final MockSolidServer mockHttpServer = new MockSolidServer();
 
     @BeforeAll
     static void setup() {
-        Utils.initMockServer();
+        mockHttpServer.start();
+        Utils.POD_URL = mockHttpServer.getMockServerUrl();
+        Utils.AS_URI = Utils.POD_URL + "/uma";
+        Utils.WEBID = URI.create(Utils.POD_URL + "/" + Utils.USERNAME);
     }
 
     @AfterAll
     static void teardown() {
-        Utils.stopMockServer();
+        mockHttpServer.stop();
     }
 
     @Test

--- a/integration/src/test/java/com/inrupt/client/integration/MockSolidServer.java
+++ b/integration/src/test/java/com/inrupt/client/integration/MockSolidServer.java
@@ -25,7 +25,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -49,11 +48,9 @@ class MockSolidServer {
         wireMockServer.stubFor(delete(anyUrl()));
     }
 
-    public Map<String, String> start() {
+    public void start() {
         wireMockServer.start();
-
         setupMocks();
-        return Collections.singletonMap("solid_server", wireMockServer.baseUrl());
     }
 
     public String getMockServerUrl() {

--- a/integration/src/test/java/com/inrupt/client/integration/OpenIdTokenAndClientCredentialAuthTest.java
+++ b/integration/src/test/java/com/inrupt/client/integration/OpenIdTokenAndClientCredentialAuthTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public class OpenIdTokenAndClientCredentialAuthTest {
 
+    private static final MockSolidServer mockHttpServer = new MockSolidServer();
     private static final Config config = ConfigProvider.getConfig();
 
     private static final String testEnv = config.getValue("inrupt.test.environment", String.class);
@@ -65,7 +66,10 @@ public class OpenIdTokenAndClientCredentialAuthTest {
     static void setup() {
 
         if (testEnv.contains("MockSolidServer")) {
-            Utils.initMockServer();
+            mockHttpServer.start();
+            Utils.POD_URL = mockHttpServer.getMockServerUrl();
+            Utils.AS_URI = Utils.POD_URL + "/uma";
+            Utils.WEBID = URI.create(Utils.POD_URL + "/" + Utils.USERNAME);
         }
 
         final SolidSyncClient session =
@@ -86,7 +90,7 @@ public class OpenIdTokenAndClientCredentialAuthTest {
     @AfterAll
     static void teardown() {
         if (testEnv.equals("MockSolidServer")) {
-            Utils.stopMockServer();
+            mockHttpServer.stop();
         }
     }
 

--- a/integration/src/test/java/com/inrupt/client/integration/Utils.java
+++ b/integration/src/test/java/com/inrupt/client/integration/Utils.java
@@ -75,7 +75,6 @@ final class Utils {
     static final int PRECONDITION_FAILED = 412;
     static final int ERROR = 500;
 
-    private static final MockSolidServer mockHttpServer = new MockSolidServer();
     private static final Config config = ConfigProvider.getConfig();
 
     static final String PRIVATE_RESOURCE_PATH = config
@@ -88,9 +87,9 @@ final class Utils {
     static final String ISS = config.getValue("inrupt.test.idp", String.class);
     private static final String AZP = config.getValue("inrupt.test.azp", String.class);
 
-    static String UMA_DISCOVERY_ENDPOINT = "/.well-known/uma2-configuration";
-    static String TOKEN_ENDPOINT = "/token";
-    static String JWKS_ENDPOINT = "/jwks";
+    static final String UMA_DISCOVERY_ENDPOINT = "/.well-known/uma2-configuration";
+    static final String TOKEN_ENDPOINT = "token";
+    static final String JWKS_ENDPOINT = "jwks";
 
     static String setupIdToken() {
         final Map<String, Object> claims = new HashMap<>();
@@ -129,21 +128,6 @@ final class Utils {
         }
     }
 
-    static void initMockServer() {
-        mockHttpServer.start();
-        POD_URL = mockHttpServer.getMockServerUrl();
-        AS_URI = POD_URL + "/uma";
-        WEBID = URI.create(POD_URL + "/" + USERNAME);
-    }
-
-    static void stopMockServer() {
-        mockHttpServer.stop();
-    }
-
-    static String getMockServerUrl() {
-        return mockHttpServer.getMockServerUrl();
-    }
-
     static boolean isSuccessful(final int status) {
         return Arrays.asList(SUCCESS, NO_CONTENT, CREATED).contains(status);
     }
@@ -175,7 +159,11 @@ final class Utils {
     }
 
     static String getResource(final String path, final String baseUrl, final String issuer) {
-        return getResource(path).replace("{{baseUrl}}", baseUrl).replace("{{issuerUrl}}", issuer);
+        return getResource(path)
+                .replace("{{baseUrl}}", baseUrl)
+                .replace("{{issuerUrl}}", issuer)
+                .replace("{{tokenEndpoint}}", TOKEN_ENDPOINT)
+                .replace("{{jwksEndpoint}}", JWKS_ENDPOINT);
     }
 
     static String getResource(final String path) {

--- a/integration/src/test/resources/uma2-configuration.json
+++ b/integration/src/test/resources/uma2-configuration.json
@@ -3,8 +3,8 @@
         "urn:ietf:params:oauth:grant-type:uma-ticket"
     ],
     "issuer": "{{issuerUrl}}",
-    "jwks_uri": "{{baseUrl}}/uma/jwks",
-    "token_endpoint": "{{baseUrl}}/uma/token",
+    "jwks_uri": "{{baseUrl}}/uma/{{jwksEndpoint}}",
+    "token_endpoint": "{{baseUrl}}/uma/{{tokenEndpoint}}",
     "uma_profiles_supported": [
         "http://openid.net/specs/openid-connect-core-1_0.html#IDToken"
     ]


### PR DESCRIPTION
This PR cleans up integration tests.
I had to change how wiremock gets started. It turns out it did not like when started through another class, reason why the connection was not started. This was only the case only when running locally 'mvn verify'.