### PR TITLE
JCL-236: Fix Jackson javadoc link

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
               <link>https://jena.apache.org/documentation/javadoc/arq/</link>
               <link>https://www.antlr.org/api/Java/</link>
               <link>https://rdf4j.org/javadoc/latest/</link>
-              <link>https://fasterxml.github.io/jackson-databind/javadoc/2.13/</link>
+              <link>http://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/</link>
             </links>
             <header>
               <![CDATA[


### PR DESCRIPTION
See https://fasterxml.github.io/jackson-databind/ for more details.