### PR TITLE
JCL-67: Skip client credentials if not configured

### DIFF
--- a/integration/src/test/resources/META-INF/microprofile-config.properties
+++ b/integration/src/test/resources/META-INF/microprofile-config.properties
@@ -6,8 +6,4 @@ inrupt.test.username=javasdk
 inrupt.test.azp=https://app.example
 inrupt.test.asUri="uma"
 
-inrupt.test.clientId=605181c0-4b23-4ebf-8911-185c63f76cc4
-inrupt.test.clientSecret=410f2a73-fc58-49df-b3ba-599f59166069
-inrupt.test.authMethod=client_secret_basic
-
 inrupt.test.privateResourcePath=private


### PR DESCRIPTION
We currently have some "dummy credentials" for client_credentials flows. But it would be better to just skip this flow if that isn't configured. This changes these values to be `Optional<String>` so that they are not strictly required.