### PR TITLE
JCL-67: Avoid implicitly closed resources

### DIFF
--- a/api/src/main/java/com/inrupt/client/spi/package-info.java
+++ b/api/src/main/java/com/inrupt/client/spi/package-info.java
@@ -77,7 +77,7 @@
        try (InputStream input = Test.class.getResourceAsStream("/oneTriple.trig")) {
               dataset = processor.toDataset(RDFSyntax.TRIG, input);
        }
-       System.out.println("Number of triples in file: " + dataset.stream().count());
+       System.out.println("Number of triples in file: " + dataset.size());
  * }</pre>
  */
 package com.inrupt.client.spi;

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -19,7 +19,7 @@
         <smallrye.config.version>3.1.1</smallrye.config.version>
         <jackson.annotations.version>2.14.1</jackson.annotations.version>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>com.inrupt</groupId>
@@ -100,6 +100,11 @@
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/integration/base/src/test/resources/simplelogger.properties
+++ b/integration/base/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -14,10 +14,6 @@
   </description>
 
   <dependencies>
-    <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-    </dependency>
     <!-- test dependencies -->
     <dependency>
         <groupId>com.inrupt</groupId>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -12,6 +12,7 @@
   <description>
       OpenID Connect integration tests for the Inrupt Client Libraries.
   </description>
+  <packaging>pom</packaging>
 
   <dependencies>
     <!-- test dependencies -->

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -12,6 +12,7 @@
   <description>
       UMA integration tests for the Inrupt Client Libraries.
   </description>
+  <packaging>pom</packaging>
 
   <dependencies>
     <dependency>

--- a/jena/src/main/java/com/inrupt/client/jena/package-info.java
+++ b/jena/src/main/java/com/inrupt/client/jena/package-info.java
@@ -33,7 +33,7 @@
     try (InputStream input = Test.class.getResourceAsStream("/tripleExamples.trig")) {
         dataset = service.toDataset(RDFSyntax.TRIG, input);
     }
-    System.out.println("Number of triples in file: " + dataset.stream().count());
+    System.out.println("Number of triples in file: " + dataset.size());
  * }</pre>
  *
  * <h3>Example of using the Jena BodyHandler ofModel() method to read the triples

--- a/jena/src/test/java/com/inrupt/client/jena/JenaServiceTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaServiceTest.java
@@ -90,7 +90,7 @@ class JenaServiceTest extends RdfServices {
     void parseToDatasetRelativeURIsButNoBaseURI() throws IOException {
         try (final var input = JenaServiceTest.class.getResourceAsStream("/relativeURIs.ttl")) {
             final var dataset = service.toDataset(RDFSyntax.TURTLE, input, null);
-            assertEquals(2, dataset.stream().count());
+            assertEquals(2, dataset.size());
             assertTrue(dataset.stream()
                     .map(Quad::getSubject)
                     .filter(IRI.class::isInstance).map(IRI.class::cast)
@@ -104,8 +104,8 @@ class JenaServiceTest extends RdfServices {
             service.fromDataset(jenaDataset, RDFSyntax.TRIG, output);
             final var input = new ByteArrayInputStream(output.toByteArray());
             final var roundtrip = service.toDataset(RDFSyntax.TRIG, input, null);
-            assertEquals(2, roundtrip.stream().count());
-            assertEquals(jenaDataset.stream().count(), roundtrip.stream().count());
+            assertEquals(2, roundtrip.size());
+            assertEquals(jenaDataset.size(), roundtrip.size());
             final var st = jenaDataset.stream(Optional.of(RdfTestModel.G_RDFNode), null, null, null)
                 .map(Quad::getSubject).filter(IRI.class::isInstance).map(IRI.class::cast)
                 .map(IRI::getIRIString).findFirst();
@@ -124,8 +124,8 @@ class JenaServiceTest extends RdfServices {
             final var input = new ByteArrayInputStream(output.toByteArray());
             final var roundtrip = service.toDataset(RDFSyntax.TURTLE, input, null);
 
-            assertEquals(2, roundtrip.stream().count());
-            assertEquals(jenaDataset.stream().count(), roundtrip.stream().count());
+            assertEquals(2, roundtrip.size());
+            assertEquals(jenaDataset.size(), roundtrip.size());
             final var st = jenaDataset.stream(Optional.of(RdfTestModel.G_RDFNode), null, null, null)
                 .map(Quad::getSubject).filter(IRI.class::isInstance).map(IRI.class::cast)
                 .map(IRI::getIRIString).findFirst();
@@ -143,8 +143,8 @@ class JenaServiceTest extends RdfServices {
             service.fromGraph(jenaGraph, RDFSyntax.TURTLE, output);
             final var input = new ByteArrayInputStream(output.toByteArray());
             final var roundtrip = service.toGraph(RDFSyntax.TURTLE, input, null);
-            assertEquals(2, roundtrip.stream().count());
-            assertEquals(jenaGraph.stream().count(), roundtrip.stream().count());
+            assertEquals(2, roundtrip.size());
+            assertEquals(jenaGraph.size(), roundtrip.size());
             final var st = jenaGraph.stream(RdfTestModel.S_RDFNode, null, null)
                 .map(Triple::getSubject).filter(IRI.class::isInstance).map(IRI.class::cast)
                 .map(IRI::getIRIString).findFirst();

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
@@ -33,7 +33,7 @@
     try (InputStream input = Test.class.getResourceAsStream("/tripleExamples.trig")) {
         dataset = service.toDataset(Syntax.TRIG, input);
     }
-    System.out.println("Number of triples in file: " + dataset.stream().count());
+    System.out.println("Number of triples in file: " + dataset.size());
  * }</pre>
  *
  * <p>A user of {@code RDF4JService} should ensure that this implementation is

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>inrupt-client-report</artifactId>
   <name>Inrupt Client Libraries - Report</name>
+  <packaging>pom</packaging>
 
   <dependencies>
     <dependency>

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -88,7 +88,7 @@ class SolidClientTest {
         client.read(uri, SolidResource.class).thenAccept(resource -> {
             try (final SolidResource r = resource) {
                 assertEquals(uri, r.getIdentifier());
-                assertEquals(4, r.stream().count());
+                assertEquals(4, r.size());
                 assertEquals(2, r.stream(Optional.empty(), rdf.createIRI(uri.toString()),
                             rdf.createIRI("https://example.com/song"), null).count());
 
@@ -108,7 +108,7 @@ class SolidClientTest {
             try (final SolidContainer c = container) {
                 assertEquals(uri, c.getIdentifier());
                 assertEquals(0, c.getContainedResources().count());
-                assertEquals(4, c.stream().count());
+                assertEquals(4, c.size());
                 assertEquals(2, c.stream(Optional.empty(), rdf.createIRI(uri.toString()),
                             rdf.createIRI("https://example.com/song"), null).count());
 

--- a/solid/src/test/java/com/inrupt/client/solid/SolidResourceTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidResourceTest.java
@@ -73,25 +73,26 @@ class SolidResourceTest {
 
         assertEquals(200, response.statusCode());
 
-        final SolidResource resource = response.body();
-        assertEquals(uri, resource.getIdentifier());
-        assertTrue(resource.getMetadata().getType().contains(LDP.BasicContainer));
-        assertEquals(Optional.of(URI.create("http://storage.example/")),
-                resource.getMetadata().getStorage());
-        assertTrue(resource.getMetadata().getWacAllow().get("user")
-                .containsAll(Arrays.asList("read", "write")));
-        assertEquals(Collections.singleton("read"), resource.getMetadata().getWacAllow().get("public"));
-        assertEquals(13, resource.size());
-        assertEquals(3, resource.getMetadata().getAllowedMethods().size());
-        assertTrue(resource.getMetadata().getAllowedMethods()
-                .containsAll(Arrays.asList("PUT", "POST", "PATCH")));
-        assertTrue(resource.getMetadata().getAllowedPatchSyntaxes()
-                .containsAll(Arrays.asList("application/sparql-update", "text/n3")));
-        assertTrue(resource.getMetadata().getAllowedPostSyntaxes()
-                .containsAll(Arrays.asList("application/ld+json", "text/turtle")));
-        assertTrue(resource.getMetadata().getAllowedPutSyntaxes()
-                .containsAll(Arrays.asList("application/ld+json", "text/turtle")));
-        assertEquals("text/turtle", resource.getMetadata().getContentType());
+        try (final SolidResource resource = response.body()) {
+            assertEquals(uri, resource.getIdentifier());
+            assertTrue(resource.getMetadata().getType().contains(LDP.BasicContainer));
+            assertEquals(Optional.of(URI.create("http://storage.example/")),
+                    resource.getMetadata().getStorage());
+            assertTrue(resource.getMetadata().getWacAllow().get("user")
+                    .containsAll(Arrays.asList("read", "write")));
+            assertEquals(Collections.singleton("read"), resource.getMetadata().getWacAllow().get("public"));
+            assertEquals(13, resource.size());
+            assertEquals(3, resource.getMetadata().getAllowedMethods().size());
+            assertTrue(resource.getMetadata().getAllowedMethods()
+                    .containsAll(Arrays.asList("PUT", "POST", "PATCH")));
+            assertTrue(resource.getMetadata().getAllowedPatchSyntaxes()
+                    .containsAll(Arrays.asList("application/sparql-update", "text/n3")));
+            assertTrue(resource.getMetadata().getAllowedPostSyntaxes()
+                    .containsAll(Arrays.asList("application/ld+json", "text/turtle")));
+            assertTrue(resource.getMetadata().getAllowedPutSyntaxes()
+                    .containsAll(Arrays.asList("application/ld+json", "text/turtle")));
+            assertEquals("text/turtle", resource.getMetadata().getContentType());
+        }
     }
 
     @Test
@@ -110,10 +111,11 @@ class SolidResourceTest {
 
         assertEquals(200, response.statusCode());
 
-        final SolidResource resource = response.body();
-        assertEquals(uri, resource.getIdentifier());
-        assertTrue(resource.getMetadata().getType().contains(LDP.BasicContainer));
-        assertEquals(Optional.of(uri), resource.getMetadata().getStorage());
+        try (final SolidResource resource = response.body()) {
+            assertEquals(uri, resource.getIdentifier());
+            assertTrue(resource.getMetadata().getType().contains(LDP.BasicContainer));
+            assertEquals(Optional.of(uri), resource.getMetadata().getStorage());
+        }
     }
 
     @Test
@@ -132,24 +134,24 @@ class SolidResourceTest {
 
         assertEquals(200, response.statusCode());
 
-        final SolidContainer container = response.body();
-        assertEquals(resource, container.getIdentifier());
-        assertEquals(3, container.getContainedResources().count());
+        try (final SolidContainer container = response.body()) {
+            assertEquals(resource, container.getIdentifier());
+            assertEquals(3, container.getContainedResources().count());
 
-        final Set<URI> uris = new HashSet<>();
-        uris.add(URIBuilder.newBuilder(resource).path("test.txt").build());
-        uris.add(URIBuilder.newBuilder(resource).path("test2.txt").build());
-        uris.add(URIBuilder.newBuilder(resource).path("newContainer/").build());
+            final Set<URI> uris = new HashSet<>();
+            uris.add(URIBuilder.newBuilder(resource).path("test.txt").build());
+            uris.add(URIBuilder.newBuilder(resource).path("test2.txt").build());
+            uris.add(URIBuilder.newBuilder(resource).path("newContainer/").build());
 
-        container.getContainedResources().forEach(child ->
-            assertTrue(uris.contains(child.getIdentifier())));
+            container.getContainedResources().forEach(child ->
+                assertTrue(uris.contains(child.getIdentifier())));
+        }
     }
 
     @Test
     void testEmptyResourceBuilder() {
         final URI id = URI.create("https://resource.example/");
         try (final SolidResource res = new SolidResource(id, null, null)) {
-
             assertFalse(res.getMetadata().getStorage().isPresent());
             assertTrue(res.getMetadata().getAllowedPatchSyntaxes().isEmpty());
             assertEquals(0, res.size());
@@ -180,10 +182,10 @@ class SolidResourceTest {
 
         assertEquals(200, response.statusCode());
 
-        final SolidResource resource = response.body();
-        assertEquals(uri, resource.getIdentifier());
-        assertEquals("application/octet-stream", resource.getMetadata().getContentType());
-
+        try (final SolidResource resource = response.body()) {
+            assertEquals(uri, resource.getIdentifier());
+            assertEquals("application/octet-stream", resource.getMetadata().getContentType());
+        }
     }
 
     @Test


### PR DESCRIPTION
This cleans up a few items from #259 around ensuring that AutoCloseable resources are closed (e.g. Stream and Resource objects). This also adjusts some of the maven files to avoid a few warnings