### PR TITLE
Adjust CI Workflow name

### DIFF
--- a/.github/workflows/site-ci-config.yml
+++ b/.github/workflows/site-ci-config.yml
@@ -1,4 +1,4 @@
-name: Solid Java Client CI
+name: Solid Java Client Site
 
 on:
   # Build pull requests for any branch


### PR DESCRIPTION
We currently have two workflows with the same name
![image](https://user-images.githubusercontent.com/1265883/217352009-495af788-a9c9-4799-9755-9a2163c7500b.png)

This changes the name of the site generation workflow so that it's easier to distinguish from the GitHub UI