### PR TITLE
JCL-67: CI for live testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    target-branch: "JCL-67-ci"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
-    target-branch: "JCL-67-ci"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17 ]
         environment-name: ["ESS PodSpaces"]
+        java: [ 11, 17 ]
         experimental: [false]
         include:
           - environment-name: "ESS DevNext"
-            experimental: true
             java: 11
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -33,12 +33,17 @@ jobs:
 
       - name: Build the code with Maven
         run: mvn -B -ntp verify -Pci
+        if: ${{ github.actor != 'dependabot[bot]' }}
         # for integration tests
         env:
           INRUPT_TEST_WEBID: ${{ secrets.INRUPT_TEST_WEBID }}
           INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
           INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
           INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
+
+      - name: Build the code with Maven (Dependabot)
+        run: mvn -B -ntp verify -Pci -pl -integration/uma,-integration/openid
+        if: ${{ github.actor == 'dependabot[bot]' }}
 
   dependencies:
     name: Dependency Check

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -31,6 +31,11 @@ jobs:
     strategy:
       matrix:
         java: [ 11 ]
+        environment-name: ["ESS PodSpaces"]
+        experimental: [false]
+        include:
+          - environment-name: "ESS DevNext"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -44,4 +49,10 @@ jobs:
 
       - name: Build the code with Maven
         run: mvn -B -ntp verify -Pdependencies
+        # for integration tests
+        env:
+          INRUPT_TEST_WEBID: ${{ secrets.INRUPT_TEST_WEBID }}
+          INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
+          INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
+          INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
 

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -11,26 +11,6 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
-          cache: 'maven'
-
-      - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pci
-
-  dependencies:
-    name: Dependency Check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [ 11 ]
         environment-name: ["ESS PodSpaces"]
         experimental: [false]
         include:
@@ -48,11 +28,31 @@ jobs:
           cache: 'maven'
 
       - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pdependencies
+        run: mvn -B -ntp verify -Pci
         # for integration tests
         env:
           INRUPT_TEST_WEBID: ${{ secrets.INRUPT_TEST_WEBID }}
           INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
           INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
           INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
+
+  dependencies:
+    name: Dependency Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: Build the code with Maven
+        run: mvn -B -ntp verify -Pdependencies
 

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -8,9 +8,18 @@ jobs:
   build:
     name: Java environment
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ matrix.environment-name }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
+        environment-name: ["ESS PodSpaces"]
         java: [ 11, 17 ]
+        experimental: [false]
+        include:
+          - environment-name: "ESS DevNext"
+            java: 11
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -24,6 +33,12 @@ jobs:
 
       - name: Build the code with Maven
         run: mvn -B -ntp verify -Pci
+        # for integration tests
+        env:
+          INRUPT_TEST_WEBID: ${{ secrets.INRUPT_TEST_WEBID }}
+          INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
+          INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
+          INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
 
   dependencies:
     name: Dependency Check
@@ -44,4 +59,3 @@ jobs:
 
       - name: Build the code with Maven
         run: mvn -B -ntp verify -Pdependencies
-

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -32,7 +32,10 @@ jobs:
           cache: 'maven'
 
       - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pci
+        run: mvn -B -ntp verify -Pci -pl -integration/uma,-integration/openid
+
+      - name: Integration tests (${{ matrix.environment-name }})
+        run: mvn -B -ntp verify -Pci -pl integration/uma,integration/openid
         if: ${{ github.actor != 'dependabot[bot]' }}
         # for integration tests
         env:
@@ -40,10 +43,6 @@ jobs:
           INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
           INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
           INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
-
-      - name: Build the code with Maven (Dependabot)
-        run: mvn -B -ntp verify -Pci -pl -integration/uma,-integration/openid
-        if: ${{ github.actor == 'dependabot[bot]' }}
 
   dependencies:
     name: Dependency Check

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -8,18 +8,9 @@ jobs:
   build:
     name: Java environment
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ matrix.environment-name }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        environment-name: ["ESS PodSpaces"]
         java: [ 11, 17 ]
-        experimental: [false]
-        include:
-          - environment-name: "ESS DevNext"
-            java: 11
-            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -33,12 +24,6 @@ jobs:
 
       - name: Build the code with Maven
         run: mvn -B -ntp verify -Pci
-        # for integration tests
-        env:
-          INRUPT_TEST_WEBID: ${{ secrets.INRUPT_TEST_WEBID }}
-          INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
-          INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
-          INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
 
   dependencies:
     name: Dependency Check

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - environment-name: "ESS DevNext"
             experimental: true
-            java: [ 11, 17 ]
+            java: 11
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -8,6 +8,9 @@ jobs:
   build:
     name: Java environment
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ matrix.environment-name }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         environment-name: ["ESS PodSpaces"]

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           - environment-name: "ESS DevNext"
             experimental: true
+            java: [ 11, 17 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         environment-name: ["ESS PodSpaces"]
         java: [ 11, 17 ]
-        experimental: [false]
+        experimental: [gating]
         include:
           - environment-name: "ESS DevNext"
             java: 11
-            experimental: true
+            experimental: non-gating
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         environment-name: ["ESS PodSpaces"]
         java: [ 11, 17 ]
-        experimental: [gating]
+        experimental: [false]
         include:
           - environment-name: "ESS DevNext"
             java: 11
-            experimental: non-gating
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This is based on 2 environments set up on GitHub secrets: ESS PodSpaces and ESS DevNext. Each of them defines:
* INRUPT_TEST_WEBID
* INRUPT_TEST_CLIENT_ID
* INRUPT_TEST_CLIENT_SECRET
* INRUPT_TEST_PUBLIC_RESOURCE_PATH

These are then read in the tests through the CI.
The CI is taken from a [Javascript project](https://github.com/inrupt/solid-client-js/blob/main/.github/workflows/e2e-browser.yml) (builds on top of their learnings). For example, DevNext tests are not gating on purpose.