### PR TITLE
JCL-67: Deactivate Integration tests on main

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -34,16 +34,6 @@ jobs:
       - name: Build the code with Maven
         run: mvn -B -ntp verify -Pci -pl -integration/uma,-integration/openid
 
-      - name: Integration tests (${{ matrix.environment-name }})
-        run: mvn -B -ntp verify -Pci -pl integration/uma,integration/openid
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        # for integration tests
-        env:
-          INRUPT_TEST_WEBID: ${{ secrets.INRUPT_TEST_WEBID }}
-          INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
-          INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
-          INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
-
   dependencies:
     name: Dependency Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because integration tets do not seem to read & use correct secrets -> the CI fails. 
To not break main CI, we simply deactivate them for now while we find a fix. 