### PR TITLE
ESS-3821: Bump inrupt-rdf-wrapping from 0.1.4 to 0.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <rdf4j.version>4.2.2</rdf4j.version>
     <slf4j.version>1.7.36</slf4j.version>
     <inrupt.commons.rdf4j.version>0.4.0</inrupt.commons.rdf4j.version>
-    <inrupt.rdf.wrapping.version>0.1.4</inrupt.rdf.wrapping.version>
+    <inrupt.rdf.wrapping.version>0.2.0</inrupt.rdf.wrapping.version>
 
     <!-- plugins -->
     <buildhelper.plugin.version>3.3.0</buildhelper.plugin.version>


### PR DESCRIPTION
I'm doing this manually instead of Dependabot to make sure changes in inrupt/rdf-wrapping#21 are compatible.