### PR TITLE
JCL-227: Header decorator

### DIFF
--- a/api/src/main/java/com/inrupt/client/Request.java
+++ b/api/src/main/java/com/inrupt/client/Request.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -342,6 +343,9 @@ public final class Request {
          * @return the request
          */
         public Request build() {
+            // Set a default user agent
+            headers.putIfAbsent("User-Agent",
+                    Arrays.asList("InruptJavaClient/" + Request.class.getPackage().getImplementationVersion()));
             return new Request(uri, method, headers, publisher, timeout);
         }
 

--- a/core/src/test/java/com/inrupt/client/core/MockHttpService.java
+++ b/core/src/test/java/com/inrupt/client/core/MockHttpService.java
@@ -25,6 +25,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.inrupt.client.Request;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,6 +35,8 @@ import org.apache.commons.io.IOUtils;
 
 class MockHttpService {
 
+    private static final String USER_AGENT = "InruptJavaClient/" + Request.class
+        .getPackage().getImplementationVersion();
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String APPLICATION_JSON = "application/json";
     private static final String TEXT_TURTLE = "text/turtle";
@@ -59,12 +62,14 @@ class MockHttpService {
 
     private void setupMocks() {
         wireMockServer.stubFor(get(urlEqualTo("/file"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader(CONTENT_TYPE, TEXT_TURTLE)
                         .withBodyFile("clarissa-sample.txt")));
 
         wireMockServer.stubFor(get(urlEqualTo("/example"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader(CONTENT_TYPE, TEXT_TURTLE)
@@ -75,6 +80,7 @@ class MockHttpService {
                     .withRequestBody(matching(
                             ".*<http://example.test/s>\\s+" +
                             "<http://example.test/p>\\s+\"object\"\\s+\\..*"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withHeader(CONTENT_TYPE, containing(TEXT_TURTLE))
                     .withHeader("Authorization", containing("DPoP "))
                     .withHeader("DPoP", containing("eyJhbGciOiJFUzI1NiIsInR5cCI6ImRwb3Arand0Iiw" +
@@ -86,12 +92,14 @@ class MockHttpService {
 
         wireMockServer.stubFor(put(urlEqualTo("/putRDF"))
                     .atPriority(2)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withStatus(401)
                         .withHeader("WWW-Authenticate", "Bearer, DPoP algs=\"ES256 PS256\"")));
 
 
         wireMockServer.stubFor(post(urlEqualTo("/postOneTriple"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withStatus(401)
                         .withHeader("WWW-Authenticate", "Unknown, Bearer, " +
@@ -100,6 +108,7 @@ class MockHttpService {
 
         wireMockServer.stubFor(post(urlEqualTo("/postBearerToken"))
                     .atPriority(1)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withRequestBody(matching(
                             ".*<http://example.test/s>\\s+" +
                             "<http://example.test/p>\\s+\"object\"\\s+\\..*"))
@@ -114,12 +123,14 @@ class MockHttpService {
 
         wireMockServer.stubFor(post(urlEqualTo("/postBearerToken"))
                     .atPriority(2)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withStatus(401)
                         .withHeader("WWW-Authenticate", "Bearer,DPoP algs=\"ES256\"")));
 
         wireMockServer.stubFor(post(urlEqualTo("/postString"))
                     .atPriority(1)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withRequestBody(matching("Test String 1"))
                     .withHeader(CONTENT_TYPE, containing(TEXT_PLAIN))
                     .withHeader("Authorization", containing("Bearer token-67890"))
@@ -129,29 +140,34 @@ class MockHttpService {
 
         wireMockServer.stubFor(post(urlEqualTo("/postString"))
                     .atPriority(2)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withStatus(401)
                         .withHeader("WWW-Authenticate", "Bearer, DPoP algs=\"ES256\", " +
                             "UMA ticket=\"ticket-67890\", as_uri=\"" + wireMockServer.baseUrl() + "\"")));
 
         wireMockServer.stubFor(get(urlEqualTo("/solid.png"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withHeader(CONTENT_TYPE, "image/png")
                         .withBodyFile("SolidOS.png")
                         .withStatus(200)));
 
         wireMockServer.stubFor(get(urlEqualTo("/.well-known/uma2-configuration"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBody(getResource("/uma2-configuration.json", wireMockServer.baseUrl()))));
 
         wireMockServer.stubFor(get(urlEqualTo("/uma/jwks"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBodyFile("uma-jwks.json")));
 
         wireMockServer.stubFor(post(urlEqualTo("/uma/token"))
                     .atPriority(1)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withRequestBody(containing("claim_token_format=" +
                             "http%3A%2F%2Fopenid.net%2Fspecs%2Fopenid-connect-core-1_0.html%23IDToken"))
                     .withRequestBody(containing("ticket=ticket-67890"))
@@ -162,6 +178,7 @@ class MockHttpService {
 
         wireMockServer.stubFor(post(urlEqualTo("/uma/token"))
                     .atPriority(2)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withRequestBody(containing("ticket=ticket-67890"))
                     .willReturn(aResponse()
                         .withStatus(403)
@@ -170,6 +187,7 @@ class MockHttpService {
 
         wireMockServer.stubFor(post(urlEqualTo("/uma/token"))
                     .atPriority(2)
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withRequestBody(containing("ticket=ticket-12345"))
                     .willReturn(aResponse()
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -178,12 +196,14 @@ class MockHttpService {
 
         wireMockServer.stubFor(get(urlEqualTo("/protected/resource"))
                     .withHeader("Accept", containing(TEXT_TURTLE))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()
                         .withStatus(401)
                         .withHeader("WWW-Authenticate",
                             "UMA ticket=\"ticket-12345\", as_uri=\"" + wireMockServer.baseUrl() + "\"")));
 
         wireMockServer.stubFor(get(urlEqualTo("/protected/resource"))
+                    .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withHeader("Authorization", equalTo("Bearer token-12345"))
                     .withHeader("Accept", containing(TEXT_TURTLE))
                     .willReturn(aResponse()

--- a/pom.xml
+++ b/pom.xml
@@ -280,6 +280,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${jar.plugin.version}</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              </manifest>
+            </archive>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -22,6 +22,7 @@ package com.inrupt.client.solid;
 
 import com.inrupt.client.Client;
 import com.inrupt.client.ClientProvider;
+import com.inrupt.client.Headers;
 import com.inrupt.client.Request;
 import com.inrupt.client.Resource;
 import com.inrupt.client.Response;
@@ -31,6 +32,10 @@ import com.inrupt.client.util.IOUtils;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
 import org.apache.commons.rdf.api.Dataset;
@@ -41,16 +46,23 @@ import org.apache.commons.rdf.api.RDFSyntax;
  */
 public class SolidClient {
 
+    static final Headers EMPTY_HEADERS = Headers.of(Collections.emptyMap());
+
+    private static final String USER_AGENT = "User-Agent";
     private static final String ACCEPT = "Accept";
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String IF_NONE_MATCH = "If-None-Match";
     private static final String TEXT_TURTLE = "text/turtle";
     private static final String WILDCARD = "*";
+    private static final String DEFAULT_USER_AGENT = "InruptJavaClient/" + SolidClient.class
+        .getPackage().getImplementationVersion();
 
     private final Client client;
+    private final Headers defaultHeaders;
 
-    SolidClient(final Client client) {
-        this.client = client;
+    SolidClient(final Client client, final Headers headers) {
+        this.client = Objects.requireNonNull(client, "Client may not be null!");
+        this.defaultHeaders = Objects.requireNonNull(headers, "Headers may not be null!");
     }
 
     /**
@@ -60,7 +72,7 @@ public class SolidClient {
      * @return a session-scoped client
      */
     public SolidClient session(final Session session) {
-        return new SolidClient(client.session(session));
+        return new SolidClient(client.session(session), defaultHeaders);
     }
 
     /**
@@ -85,11 +97,30 @@ public class SolidClient {
      * @return the next stage of completion, including the new resource
      */
     public <T extends Resource> CompletionStage<T> read(final URI identifier, final Class<T> clazz) {
-        final Request req = Request.newBuilder(identifier)
-            .header(ACCEPT, TEXT_TURTLE)
-            .GET().build();
+        return read(identifier, EMPTY_HEADERS, clazz);
+    }
 
-        return client.send(req, Response.BodyHandlers.ofByteArray())
+    /**
+     * Read a Solid Resource into a particular defined type.
+     *
+     * @param identifier the identifier
+     * @param headers headers to add to this request
+     * @param clazz the desired resource type
+     * @param <T> the resource type
+     * @return the next stage of completion, including the new resource
+     */
+    public <T extends Resource> CompletionStage<T> read(final URI identifier, final Headers headers,
+            final Class<T> clazz) {
+        final Request.Builder builder = Request.newBuilder(identifier).GET();
+
+        decorateHeaders(builder, defaultHeaders);
+        decorateHeaders(builder, headers);
+
+        builder.setHeader(ACCEPT, TEXT_TURTLE);
+        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
+                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+
+        return client.send(builder.build(), Response.BodyHandlers.ofByteArray())
             .thenApply(response -> {
                 if (response.statusCode() >= 400) {
                     throw new SolidClientException("Unable to read resource at " + identifier, identifier,
@@ -125,13 +156,28 @@ public class SolidClient {
      * @return the next stage of completion
      */
     public <T extends Resource> CompletionStage<Response<Void>> create(final T resource) {
-        final Request req = Request.newBuilder(resource.getIdentifier())
-            .header(CONTENT_TYPE, TEXT_TURTLE)
-            .header(IF_NONE_MATCH, WILDCARD)
-            .PUT(cast(resource))
-            .build();
+        return create(resource, EMPTY_HEADERS);
+    }
 
-        return client.send(req, Response.BodyHandlers.discarding());
+    /**
+     * Create a new Solid Resource.
+     *
+     * @param resource the resource
+     * @param headers headers to add to this request
+     * @param <T> the resource type
+     * @return the next stage of completion
+     */
+    public <T extends Resource> CompletionStage<Response<Void>> create(final T resource, final Headers headers) {
+        final Request.Builder builder = Request.newBuilder(resource.getIdentifier()).PUT(cast(resource));
+
+        decorateHeaders(builder, defaultHeaders);
+        decorateHeaders(builder, headers);
+
+        builder.setHeader(CONTENT_TYPE, TEXT_TURTLE).setHeader(IF_NONE_MATCH, WILDCARD);
+        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
+                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+
+        return client.send(builder.build(), Response.BodyHandlers.discarding());
     }
 
     /**
@@ -142,12 +188,28 @@ public class SolidClient {
      * @return the next stage of completion
      */
     public <T extends Resource> CompletionStage<Response<Void>> update(final T resource) {
-        final Request req = Request.newBuilder(resource.getIdentifier())
-            .header(CONTENT_TYPE, TEXT_TURTLE)
-            .PUT(cast(resource))
-            .build();
+        return update(resource, EMPTY_HEADERS);
+    }
 
-        return client.send(req, Response.BodyHandlers.discarding());
+    /**
+     * Update an existing Solid Resource.
+     *
+     * @param resource the resource
+     * @param headers headers to add to this request
+     * @param <T> the resource type
+     * @return the next stage of completion
+     */
+    public <T extends Resource> CompletionStage<Response<Void>> update(final T resource, final Headers headers) {
+        final Request.Builder builder = Request.newBuilder(resource.getIdentifier()).PUT(cast(resource));
+
+        decorateHeaders(builder, defaultHeaders);
+        decorateHeaders(builder, headers);
+
+        builder.setHeader(CONTENT_TYPE, TEXT_TURTLE);
+        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
+                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+
+        return client.send(builder.build(), Response.BodyHandlers.discarding());
     }
 
     /**
@@ -158,20 +220,27 @@ public class SolidClient {
      * @return the next stage of completion
      */
     public <T extends Resource> CompletionStage<Response<Void>> delete(final T resource) {
-        final Request req = Request.newBuilder(resource.getIdentifier())
-            .DELETE()
-            .build();
-        return client.send(req, Response.BodyHandlers.discarding());
+        return delete(resource, EMPTY_HEADERS);
     }
 
     /**
-     * Create a new SolidClient from an underlying {@link Client} instance.
+     * Delete an existing Solid Resource.
      *
-     * @param client the client
-     * @return the new solid client
+     * @param resource the resource
+     * @param headers headers to add to this request
+     * @param <T> the resource type
+     * @return the next stage of completion
      */
-    public static SolidClient of(final Client client) {
-        return new SolidClient(client);
+    public <T extends Resource> CompletionStage<Response<Void>> delete(final T resource, final Headers headers) {
+        final Request.Builder builder = Request.newBuilder(resource.getIdentifier()).DELETE();
+
+        decorateHeaders(builder, defaultHeaders);
+        decorateHeaders(builder, headers);
+
+        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
+                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+
+        return client.send(builder.build(), Response.BodyHandlers.discarding());
     }
 
     /**
@@ -180,7 +249,60 @@ public class SolidClient {
      * @return the client instance
      */
     public static SolidClient getClient() {
-        return SolidClient.of(ClientProvider.getClient());
+        return getClientBuilder().build();
+    }
+
+    /**
+     * Get a {@link SolidClient.Builder} for the current application.
+     *
+     * @return a client builder
+     */
+    public static SolidClient.Builder getClientBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder class for a {@link SolidClient}.
+     */
+    public static class Builder {
+        private Client builderClient;
+        private Headers builderHeaders;
+
+        Builder() {
+        }
+
+        /**
+         * Set a pre-configured {@link Client}.
+         *
+         * @param client the client
+         * @return this builder
+         */
+        public Builder client(final Client client) {
+            this.builderClient = client;
+            return this;
+        }
+
+        /**
+         * Set a collection of headers to be used with each request.
+         *
+         * @param headers the headers
+         * @return this builder
+         */
+        public Builder headers(final Headers headers) {
+            this.builderHeaders = headers;
+            return this;
+        }
+
+        /**
+         * Build the {@link SolidClient}.
+         *
+         * @return the Solid client
+         */
+        public SolidClient build() {
+            final Client c = builderClient == null ? ClientProvider.getClient() : builderClient;
+            final Headers h = builderHeaders == null ? EMPTY_HEADERS : builderHeaders;
+            return new SolidClient(c, h);
+        }
     }
 
     static <T extends Resource> T construct(final URI identifier, final Class<T> clazz,
@@ -193,6 +315,14 @@ public class SolidClient {
             // Fall back to an arity-2 ctor
             return clazz.getConstructor(URI.class, Dataset.class)
                         .newInstance(identifier, dataset);
+        }
+    }
+
+    static void decorateHeaders(final Request.Builder builder, final Headers headers) {
+        for (final Map.Entry<String, List<String>> entry : headers.asMap().entrySet()) {
+            for (final String item : entry.getValue()) {
+                builder.header(entry.getKey(), item);
+            }
         }
     }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -54,8 +54,6 @@ public class SolidClient {
     private static final String IF_NONE_MATCH = "If-None-Match";
     private static final String TEXT_TURTLE = "text/turtle";
     private static final String WILDCARD = "*";
-    private static final String DEFAULT_USER_AGENT = "InruptJavaClient/" + SolidClient.class
-        .getPackage().getImplementationVersion();
 
     private final Client client;
     private final Headers defaultHeaders;
@@ -117,8 +115,9 @@ public class SolidClient {
         decorateHeaders(builder, headers);
 
         builder.setHeader(ACCEPT, TEXT_TURTLE);
-        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
-                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+
+        defaultHeaders.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
+        headers.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
 
         return client.send(builder.build(), Response.BodyHandlers.ofByteArray())
             .thenApply(response -> {
@@ -174,8 +173,8 @@ public class SolidClient {
         decorateHeaders(builder, headers);
 
         builder.setHeader(CONTENT_TYPE, TEXT_TURTLE).setHeader(IF_NONE_MATCH, WILDCARD);
-        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
-                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+        defaultHeaders.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
+        headers.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
 
         return client.send(builder.build(), Response.BodyHandlers.discarding());
     }
@@ -206,8 +205,8 @@ public class SolidClient {
         decorateHeaders(builder, headers);
 
         builder.setHeader(CONTENT_TYPE, TEXT_TURTLE);
-        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
-                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+        defaultHeaders.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
+        headers.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
 
         return client.send(builder.build(), Response.BodyHandlers.discarding());
     }
@@ -237,8 +236,8 @@ public class SolidClient {
         decorateHeaders(builder, defaultHeaders);
         decorateHeaders(builder, headers);
 
-        builder.setHeader(USER_AGENT, defaultHeaders.firstValue(USER_AGENT).orElseGet(() ->
-                    headers.firstValue(USER_AGENT).orElse(DEFAULT_USER_AGENT)));
+        defaultHeaders.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
+        headers.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
 
         return client.send(builder.build(), Response.BodyHandlers.discarding());
     }

--- a/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
@@ -22,6 +22,7 @@ package com.inrupt.client.solid;
 
 import com.inrupt.client.Client;
 import com.inrupt.client.ClientProvider;
+import com.inrupt.client.Headers;
 import com.inrupt.client.Request;
 import com.inrupt.client.Resource;
 import com.inrupt.client.Response;
@@ -37,6 +38,10 @@ import java.util.concurrent.CompletionStage;
 public class SolidSyncClient {
 
     private final SolidClient client;
+
+    SolidSyncClient(final Client client, final Headers headers) {
+        this(new SolidClient(client, headers));
+    }
 
     SolidSyncClient(final SolidClient client) {
         this.client = client;
@@ -110,22 +115,60 @@ public class SolidSyncClient {
     }
 
     /**
-     * Create a new SolidClient from an underlying {@link Client} instance.
-     *
-     * @param client the client
-     * @return the new solid client
-     */
-    public static SolidSyncClient of(final Client client) {
-        return new SolidSyncClient(new SolidClient(client));
-    }
-
-    /**
      * Get the {@link SolidSyncClient} for the current application.
      *
      * @return the client instance
      */
     public static SolidSyncClient getClient() {
-        return SolidSyncClient.of(ClientProvider.getClient());
+        return getClientBuilder().build();
+    }
+
+    public static Builder getClientBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder class for a {@link SolidSyncClient}.
+     */
+    public static class Builder {
+        private Client builderClient;
+        private Headers builderHeaders;
+
+        Builder() {
+        }
+
+        /**
+         * Set a pre-configured {@link Client}.
+         *
+         * @param client the client
+         * @return this builder
+         */
+        public Builder client(final Client client) {
+            this.builderClient = client;
+            return this;
+        }
+
+        /**
+         * Set a collection of headers to be used with each request.
+         *
+         * @param headers the headers
+         * @return this builder
+         */
+        public Builder headers(final Headers headers) {
+            this.builderHeaders = headers;
+            return this;
+        }
+
+        /**
+         * Build the {@link SolidSyncClient}.
+         *
+         * @return the Solid client
+         */
+        public SolidSyncClient build() {
+            final Client c = builderClient == null ? ClientProvider.getClient() : builderClient;
+            final Headers h = builderHeaders == null ? SolidClient.EMPTY_HEADERS : builderHeaders;
+            return new SolidSyncClient(c, h);
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/solid/src/main/java/com/inrupt/client/solid/package-info.java
+++ b/solid/src/main/java/com/inrupt/client/solid/package-info.java
@@ -41,7 +41,7 @@
  * <p>The above line is equivalent to:
  * <pre>{@code
     Client classPathClient = ClientProvider.getClient();
-    SolidClient client = SolidClient.of(classPathClient);
+    SolidClient client = SolidClient.getClientBuilder().client(classPathClient).build();
     }
  * </pre>
  * 

--- a/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
@@ -25,6 +25,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.inrupt.client.Headers.Link;
+import com.inrupt.client.Request;
 import com.inrupt.client.vocabulary.LDP;
 import com.inrupt.client.vocabulary.PIM;
 
@@ -34,6 +35,8 @@ import java.util.Map;
 
 public class SolidMockHttpService {
 
+    private static final String USER_AGENT = "InruptJavaClient/" + Request.class
+        .getPackage().getImplementationVersion();
     private final WireMockServer wireMockServer;
 
     public SolidMockHttpService() {
@@ -46,6 +49,7 @@ public class SolidMockHttpService {
 
     private void setupMocks() {
         wireMockServer.stubFor(get(urlEqualTo("/"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withHeader("Content-Type", "text/turtle")
@@ -57,6 +61,7 @@ public class SolidMockHttpService {
         );
 
         wireMockServer.stubFor(get(urlEqualTo("/solid/"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withHeader("Content-Type", "text/turtle")
@@ -74,6 +79,7 @@ public class SolidMockHttpService {
         );
 
         wireMockServer.stubFor(get(urlEqualTo("/recipe"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withHeader("Content-Type", "text/turtle")
@@ -90,7 +96,39 @@ public class SolidMockHttpService {
             )
         );
 
+        wireMockServer.stubFor(get(urlEqualTo("/custom-agent"))
+            .withHeader("User-Agent", equalTo("TestClient/1.0"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/turtle")
+                .withHeader("Link", Link.of(LDP.RDFSource, "type").toString())
+                .withHeader("Link", Link.of(URI.create("http://storage.example/"), PIM.storage).toString())
+                .withHeader("Link", Link.of(URI.create("https://history.test/"), "timegate").toString())
+                .withHeader("WAC-Allow", "user=\"read write\",public=\"read\"")
+                .withHeader("Allow", "POST, PUT, PATCH")
+                .withHeader("Accept-Post", "application/ld+json, text/turtle")
+                .withHeader("Accept-Put", "application/ld+json, text/turtle")
+                .withHeader("Accept-Patch", "application/sparql-update, text/n3")
+                .withBodyFile("playlist.ttl")
+            )
+        );
+
+        wireMockServer.stubFor(put(urlEqualTo("/custom-agent"))
+            .withHeader("User-Agent", equalTo("TestClient/1.0"))
+            .withHeader("Content-Type", containing("text/turtle"))
+            .withRequestBody(containing(
+                    "<https://library.test/12345/song1.mp3>"))
+            .willReturn(aResponse()
+                .withStatus(204)));
+
+        wireMockServer.stubFor(delete(urlEqualTo("/custom-agent"))
+            .withHeader("User-Agent", equalTo("TestClient/1.0"))
+            .willReturn(aResponse()
+                .withStatus(204)));
+
+
         wireMockServer.stubFor(get(urlEqualTo("/playlist"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withHeader("Content-Type", "text/turtle")
@@ -108,6 +146,7 @@ public class SolidMockHttpService {
         );
 
         wireMockServer.stubFor(put(urlEqualTo("/playlist"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
             .withHeader("Content-Type", containing("text/turtle"))
             .withRequestBody(containing(
                     "<https://library.test/12345/song1.mp3>"))
@@ -115,34 +154,40 @@ public class SolidMockHttpService {
                 .withStatus(204)));
 
         wireMockServer.stubFor(delete(urlEqualTo("/playlist"))
-                .willReturn(aResponse()
-                    .withStatus(204)));
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(204)));
 
         wireMockServer.stubFor(get(urlEqualTo("/nonRDF"))
-                .willReturn(aResponse()
-                    .withStatus(200)
-                    .withHeader("Content-Type", "text/turtle")
-                    .withBody("This isn't valid turtle.")));
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/turtle")
+                .withBody("This isn't valid turtle.")));
 
         wireMockServer.stubFor(get(urlEqualTo("/missing"))
-                .willReturn(aResponse()
-                    .withStatus(404)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("{\"error\": \"missing resource\"}")));
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(404)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"error\": \"missing resource\"}")));
 
         wireMockServer.stubFor(get(urlEqualTo("/unauthorized"))
-                .willReturn(aResponse()
-                    .withStatus(401)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("{\"error\": \"unauthorized\"}")));
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(401)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"error\": \"unauthorized\"}")));
 
         wireMockServer.stubFor(get(urlEqualTo("/forbidden"))
-                .willReturn(aResponse()
-                    .withStatus(403)
-                    .withHeader("Content-Type", "application/json")
-                    .withBody("{\"error\": \"forbidden\"}")));
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(403)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\"error\": \"forbidden\"}")));
 
         wireMockServer.stubFor(get(urlEqualTo("/noContentType"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withBodyFile("solidResourceExample.ttl")));


### PR DESCRIPTION
This adds a mechanism for adding headers to requests in the high-level client API. The existing API stays the same with an additional option added. For example:

```java
MyCustomType obj = client.read(uri, customHeaders, MyCustomType.class);
```

In addition, a header collection can be added to all requests when constructing the client:

```java
SolidClient client = SolidClient.getClientBuilder().headers(customHeaders).build();
```

The `Builder` mechanism is new and replaces the (inconsistent) `SolidClient.of(...)` methods.

In addition, a default `User-Agent` header is now added to each request (this can be overridden by a developer). By default, this is `InruptJavaClient/{version}`.