### PR TITLE
JCL-263: Improve OpenIdException messages

### DIFF
--- a/openid/src/main/java/com/inrupt/client/openid/ErrorResponse.java
+++ b/openid/src/main/java/com/inrupt/client/openid/ErrorResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.openid;
+
+class ErrorResponse {
+    public String error;
+    public String errorDescription;
+}

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
@@ -92,7 +92,9 @@ class OpenIdMockHttpService {
                     .atPriority(1)
                     .withRequestBody(containing("code=none"))
                     .willReturn(aResponse()
-                        .withStatus(404)));
+                        .withStatus(400)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("token-error.json")));
 
         wireMockServer.stubFor(post(urlPathMatching("/oauth/oauth20/token"))
                 .withHeader("Content-Type", containing("application/x-www-form-urlencoded"))

--- a/openid/src/test/resources/__files/token-error.json
+++ b/openid/src/test/resources/__files/token-error.json
@@ -1,0 +1,4 @@
+{
+    "error": "invalid_grant",
+    "error_description": "Invalid authorization code value"
+}


### PR DESCRIPTION
This makes it possible to read a standard OAuth error response and include that data (if present) in the thrown exception.