### PR TITLE
Ensure consistency in package descriptions

### DIFF
--- a/jackson/src/main/java/com/inrupt/client/jackson/package-info.java
+++ b/jackson/src/main/java/com/inrupt/client/jackson/package-info.java
@@ -25,7 +25,7 @@
  * JSON parser. In the Java ecosystem, there are several widely used JSON
  * parsing libraries. This package adds support for the Jackson JSON libraries.
  *
- * <p>A user of this module should ensure that the Jackson implementation is
+ * <p>A user of the {@code JacksonService} should ensure that the Jackson implementation is
  * available on the classpath by adding the following dependency:
  *
  * <pre>

--- a/jena/src/main/java/com/inrupt/client/jena/package-info.java
+++ b/jena/src/main/java/com/inrupt/client/jena/package-info.java
@@ -23,7 +23,18 @@
  *
  * <p>The Jena module gives two possibilities to read RDF data: through the Service {@link JenaService}
  * and through the BodyHandler {@link JenaBodyHandlers}.
+ * 
+ * <p>A user of the {@code JenaService} should ensure that this implementation is
+ * available on the classpath by adding the following dependency:
  *
+ * <pre>
+ *     &lt;dependency&gt;
+ *            &lt;groupId&gt;com.inrupt&lt;/groupId&gt;
+ *            &lt;artifactId&gt;inrupt-client-jena&lt;/artifactId&gt;
+ *            &lt;version&gt;${project.version}&lt;/version&gt;
+ *     &lt;/dependency&gt;
+ * </pre>
+ * 
  * <h3>Example of using the Jena Service toDataset() method to read triples
  * from a trig file into a {@code Dataset}:</h3>
  *
@@ -70,16 +81,5 @@
 
     System.out.println("HTTP status code: " + response.statusCode());
  * }</pre>
- * 
- * <p>A user of the {@code JenaService} should ensure that this implementation is
- * available on the classpath by adding the following dependency:
- *
- * <pre>
- *     &lt;dependency&gt;
- *            &lt;groupId&gt;com.inrupt&lt;/groupId&gt;
- *            &lt;artifactId&gt;inrupt-client-jena&lt;/artifactId&gt;
- *            &lt;version&gt;${project.version}&lt;/version&gt;
- *     &lt;/dependency&gt;
- * </pre>
  */
 package com.inrupt.client.jena;

--- a/jsonb/src/main/java/com/inrupt/client/jsonb/package-info.java
+++ b/jsonb/src/main/java/com/inrupt/client/jsonb/package-info.java
@@ -25,7 +25,7 @@
  * JSON parser. In the Java ecosystem, there are several widely used JSON
  * parsing libraries. This package adds support for the JakartaEE 8 JSON APIs.
  *
- * <p>This module depends on the JakartaEE APIs. A user of this module should
+ * <p>This module depends on the JakartaEE APIs. A user of the {@code JsonbService} should
  * ensure that the relevant JakartaEE JSON implementations are available on the
  * classpath in addition to Jsonb.
  * Example:
@@ -38,13 +38,13 @@
  *     &lt;/dependency&gt;
  * </pre>
  *
- * <h3>Example of using the JSON service fromJson() method to read a custom type:</h3>
+ * <h3>Example of using the JSON service fromJson() method to deserialize data into a custom type:</h3>
  *
  * <pre>{@code
     JsonService service = ServiceProvider.getJsonService();
     try (InputStream is = Test.class.getResourceAsStream("customType.json")) {
         CustomType obj = service.fromJson(is, CustomType.class);
-        System.out.println("The Custom Type Id is: " + obj.id);
+        System.out.println("Custom Type Id is: " + obj.id);
     }
  * }</pre>
  */

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
@@ -24,6 +24,17 @@
  * <p>The RDF4J module gives two possibilities to read RDF data: through the Service {@link RDF4JService}
  * and through the BodyHandler {@link RDF4JBodyHandlers}.
  *
+ * <p>A user of the {@code RDF4JService} should ensure that this implementation is
+ * available on the classpath by adding the following dependency:
+ *
+ * <pre>
+ *     &lt;dependency&gt;
+ *            &lt;groupId&gt;com.inrupt&lt;/groupId&gt;
+ *            &lt;artifactId&gt;inrupt-client-rdf4j&lt;/artifactId&gt;
+ *            &lt;version&gt;${project.version}&lt;/version&gt;
+ *     &lt;/dependency&gt;
+ * </pre>
+ *
  * <h3>Example of using the RDF4J Service toDataset() method to read triples
  * from a trig file into a {@code Dataset}:</h3>
  *
@@ -35,17 +46,6 @@
     }
     System.out.println("Number of triples in file: " + dataset.size());
  * }</pre>
- *
- * <p>A user of {@code RDF4JService} should ensure that this implementation is
- * available on the classpath by adding the following dependency:
- *
- * <pre>
- *     &lt;dependency&gt;
- *            &lt;groupId&gt;com.inrupt&lt;/groupId&gt;
- *            &lt;artifactId&gt;inrupt-client-rdf4j&lt;/artifactId&gt;
- *            &lt;version&gt;${project.version}&lt;/version&gt;
- *     &lt;/dependency&gt;
- * </pre>
  *
  * <h3>Example of using the RDF4J BodyHandler ofModel() method to read the triples
  * from the same trig file into a {@code Model}:</h3>


### PR DESCRIPTION
Where we have multiple service implementations I made the package-info more consistent:
* Same introduction and examples
* Move dependency information to the top, before examples