### PR TITLE
excluded commons-fileupload

### DIFF
--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -102,6 +102,12 @@
             <artifactId>wiremock-jre8</artifactId>
             <version>${wiremock.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-fileupload</groupId>
+                    <artifactId>commons-fileupload</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -54,6 +54,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -54,12 +54,6 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,6 +42,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+            <groupId>commons-fileupload</groupId>
+            <artifactId>commons-fileupload</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Vulnerability fix. It was initially found in wiremock-jre8 for integration-base and test modules. 