### PR TITLE
JCL-73: Fix some internal links

### DIFF
--- a/src/site/apt/session-management.apt.vm
+++ b/src/site/apt/session-management.apt.vm
@@ -21,7 +21,7 @@ Session Management
       * Will this application run from the Command Line with a single user? If so, follow the steps for {{Command Line Applications}}.
 
 
-    There are other, more advanced options possible, but these will be the two most common patterns. Furthermore, both patterns also support the use of Access Grants, which is described in the {{Using Access Grants}} section.
+    There are other, more advanced options possible, but these will be the two most common patterns. Furthermore, both patterns also support the use of Access Grants, which is described in the {{Access Grants}} section.
 
     After deciding how to establish a <<<Session>>>, you will pass that value to your client to create a Session-constrained client, as described in {{Using Session objects with a Client}}.
 

--- a/src/site/apt/usage-examples.apt.vm
+++ b/src/site/apt/usage-examples.apt.vm
@@ -24,9 +24,9 @@ Usage Examples
 
         * {{<<High-Level Synchronous Client>>}}. This client simplifies the basic Create-Read-Update-Delete operations you would expect in a RESTful client, while supporting a data binding mechanism between Java objects and Solid resources.
 
-        * {{<<High-level Asynchronous Client>>}}. This client is exactly like the synchronous client except that all responses are wrapped in a <<<CompletionStage<T\>>>>.
+        * {{<<High-Level Asynchronous Client>>}}. This client is exactly like the synchronous client except that all responses are wrapped in a <<<CompletionStage<T\>>>>.
 
-        * {{<<Low-level Asynchronous Client>>}}. This client is considerably more verbose and gives developers full control over the HTTP requests and responses.
+        * {{<<Low-Level Asynchronous Client>>}}. This client is considerably more verbose and gives developers full control over the HTTP requests and responses.
 
 
     For the low-level client, there is a single method to perform an HTTP operation: <<<Client::send>>>.
@@ -78,7 +78,7 @@ public class ClientSample {
 }
 +----------------
 
-* Low-Level Client
+* Low-Level Asynchronous Client
 
     The low-level client API gives developers full control over HTTP requests and responses. This API is also considerably more verbose, while only including a single method: <<<::send>>>.
 


### PR DESCRIPTION
There are some broken internal links in our documentation because the names don't line up quite right.