### PR TITLE
JCL-268: Adjust CD workflow for building the website

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -57,8 +57,11 @@ jobs:
           java-version: 11
           cache: 'maven'
 
+      - name: Build the code with Maven
+        run: mvn -B -ntp install -Pwebsite
+
       - name: Build the site with Maven
-        run: mvn -B -ntp install site site:stage -Pwebsite
+        run: mvn -B -ntp site site:stage -Pwebsite
 
       - name: Set site version
         run: |

--- a/.github/workflows/site-ci-config.yml
+++ b/.github/workflows/site-ci-config.yml
@@ -24,6 +24,9 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
+      - name: Build the code with Maven
+        run: mvn -B -ntp install -Pwebsite
+
       - name: Build the site with Maven
-        run: mvn -B -ntp install site -Pwebsite
+        run: mvn -B -ntp site -Pwebsite
 


### PR DESCRIPTION
I have noticed some flakiness with publishing the site. By running a full `./mvnw install` before building the site, this should help.