### PR TITLE
JCL-268: Add client identifier documents to site

### DIFF
--- a/src/site/resources/clients/android.jsonld
+++ b/src/site/resources/clients/android.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
+  "client_id": "https://inrupt.github.io/solid-client-java/clients/android.jsonld",
+  "redirect_uris": [
+    "com.inrupt.client.android.demo:/oauth2redirect"
+  ],
+  "client_name": "Android Demo App",
+  "grant_types": [
+    "authorization_code", "refresh_token"
+  ],
+  "response_types": [
+    "code"
+  ]
+}

--- a/src/site/resources/clients/testing.jsonld
+++ b/src/site/resources/clients/testing.jsonld
@@ -1,0 +1,17 @@
+{
+  "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
+  "client_id": "https://inrupt.github.io/solid-client-java/clients/testing.jsonld",
+  "redirect_uris": [
+    "http://localhost:8080",
+    "http://localhost:8080/",
+    "http://localhost:8080/callback"
+  ],
+  "post_logout_redirect_uris": [
+    "http://localhost:8080",
+    "http://localhost:8080/"
+  ],
+  "client_name": "Test Application (Not for production use)",
+  "grant_types": [
+    "authorization_code"
+  ]
+}


### PR DESCRIPTION
This adds the client identifier documents to the site so that they don't get inadvertently removed in the future.