### PR TITLE
JCL-268: Configure site publication to keep existing files

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -69,6 +69,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.actor != 'dependabot[bot]' && startsWith(github.event.ref, 'refs/tags/inrupt-client')
         with:
+          keep_files: true
           publish_dir: ./target/staging/
           personal_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -76,6 +76,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.actor != 'dependabot[bot]'
         with:
+          keep_files: true
           publish_dir: ./target/staging/
           destination_dir: ${{ env.VERSION_DIR }}
           personal_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At present, during a release, existing deployed files are removed, which isn't what we want. This adjusts the configuration to keep existing files in place