### PR TITLE
JCL-271: remove 'what you will need'

### DIFF
--- a/src/site/apt/data-modeling.apt.vm
+++ b/src/site/apt/data-modeling.apt.vm
@@ -2,16 +2,6 @@ Data Modeling
 
     The high-level <<<SolidClient>>> and <<<SolidSyncClient>>> make it easy to bind your Java objects to RDF-based Solid resources. This guide will help you structure your class definitions to make this possible.
 
-* What you will need
-
-    * About 15 minutes
-
-    * Your favorite text editor or IDE
-
-    * Java 11 or later
-
-    * Maven 3.5 or later
-
 * How to complete
 
     The solution involves creating a wrapper class so that your class can act not only as an RDF Graph

--- a/src/site/apt/session-management.apt.vm
+++ b/src/site/apt/session-management.apt.vm
@@ -2,16 +2,6 @@ Session Management
 
     All authentication and authorization in the Inrupt Java Client Libraries occur in the context of a <<<Session>>> object. By default, all client interactions use an anonymous session. For any interaction with non-public resources, you will need a mechanism for authenticating users. This guide will help you determine how best to create and manage these sessions in your Solid application.
 
-* What you will need
-
-    * About 15 minutes
-
-    * Your favorite text editor or IDE
-
-    * Java 11 or later
-
-    * Maven 3.5 or later
-
 * How to complete
 
     The first step is to consider how users will interact with your application.

--- a/src/site/apt/usage-examples.apt.vm
+++ b/src/site/apt/usage-examples.apt.vm
@@ -2,16 +2,6 @@ Usage Examples
 
     An application can obtain a client for interacting with Solid data in several ways. This guide will help you decide how your application will retrieve, configure and use a client.
 
-* What you will need
-
-    * About 15 minutes
-
-    * Your favorite text editor or IDE
-
-    * Java 11 or later
-
-    * Maven 3.5 or later
-
 * How to complete
 
     The first step is to decide which client is appropriate for your application.


### PR DESCRIPTION
A feedback point was “every single page contains what you need  -> on getting started is enough, cause you build on top of that anyway.”
This is removing that section in following pages. 