### PR TITLE
JCL-272: Add rdf-legacy to bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -75,6 +75,11 @@
       </dependency>
       <dependency>
         <groupId>com.inrupt</groupId>
+        <artifactId>inrupt-client-rdf-legacy</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.inrupt</groupId>
         <artifactId>inrupt-client-solid</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
I had intentionally omitted the `inrupt-client-rdf-legacy` module from the BOM, but upon reflection, this seems like a mistake.