### PR TITLE
JCL-272: Upgrade commons-rdf4j library to make dependency mgmt easier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <okhttp.version>4.10.0</okhttp.version>
     <rdf4j.version>4.2.3</rdf4j.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <inrupt.commons.rdf4j.version>0.4.0</inrupt.commons.rdf4j.version>
+    <inrupt.commons.rdf4j.version>0.5.0</inrupt.commons.rdf4j.version>
     <inrupt.rdf.wrapping.version>0.2.0</inrupt.rdf.wrapping.version>
 
     <!-- plugins -->


### PR DESCRIPTION
This upgrades the `inrupt-commons-rdf4j` dependency to 0.5, which uses `provided` scope for RDF4J, allowing downstream libraries to more effectively manage the version of RDF4J used. This is especially important for Android support.