### PR TITLE
Example should show POSTing to a container

### DIFF
--- a/core/src/main/java/com/inrupt/client/core/package-info.java
+++ b/core/src/main/java/com/inrupt/client/core/package-info.java
@@ -39,7 +39,7 @@
 
     //Send POST UMA authenticated request
     Request request = Request.newBuilder()
-        .uri("https://example.example/postString"))
+        .uri("https://storage.example/container/"))
         .header("Content-Type", "text/plain")
         .POST(Request.BodyPublishers.ofString("Test String 1"))
         .build();


### PR DESCRIPTION
In Solid, a POST operation targets a container, which always will end in a slash. Our docs should reflect that.