### PR TITLE
JCL 273: Changing 'testing' Client Id for Springboot App

### DIFF
--- a/src/site/resources/clients/springboot.jsonld
+++ b/src/site/resources/clients/springboot.jsonld
@@ -2,18 +2,15 @@
     "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
     "client_id": "https://inrupt.github.io/solid-client-java/clients/springboot.jsonld",
     "redirect_uris": [
-      "http://localhost:8080/login/oauth2/code/podspaces"
+      "http://localhost:8080/login/oauth2/code/myApp"
     ],
     "post_logout_redirect_uris": [
       "http://localhost:8080",
       "http://localhost:8080/"
     ],
-    "client_name": "Test Application (Not for production use)",
+    "client_name": "Spring-Boot Demo App",
     "id_token_signed_response_alg": "ES256",
     "grant_types": [
       "authorization_code"
-    ],
-    "response_types": [
-      "code"
     ]
   }

--- a/src/site/resources/clients/springboot.jsonld
+++ b/src/site/resources/clients/springboot.jsonld
@@ -2,9 +2,6 @@
     "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
     "client_id": "https://inrupt.github.io/solid-client-java/clients/springboot.jsonld",
     "redirect_uris": [
-      "http://localhost:8080",
-      "http://localhost:8080/",
-      "http://localhost:8080/callback",
       "http://localhost:8080/login/oauth2/code/podspaces"
     ],
     "post_logout_redirect_uris": [

--- a/src/site/resources/clients/springboot.jsonld
+++ b/src/site/resources/clients/springboot.jsonld
@@ -1,0 +1,22 @@
+{
+    "@context": "https://www.w3.org/ns/solid/oidc-context.jsonld",
+    "client_id": "https://inrupt.github.io/solid-client-java/clients/springboot.jsonld",
+    "redirect_uris": [
+      "http://localhost:8080",
+      "http://localhost:8080/",
+      "http://localhost:8080/callback",
+      "http://localhost:8080/login/oauth2/code/podspaces"
+    ],
+    "post_logout_redirect_uris": [
+      "http://localhost:8080",
+      "http://localhost:8080/"
+    ],
+    "client_name": "Test Application (Not for production use)",
+    "id_token_signed_response_alg": "ES256",
+    "grant_types": [
+      "authorization_code"
+    ],
+    "response_types": [
+      "code"
+    ]
+  }

--- a/src/site/resources/clients/testing.jsonld
+++ b/src/site/resources/clients/testing.jsonld
@@ -4,19 +4,14 @@
   "redirect_uris": [
     "http://localhost:8080",
     "http://localhost:8080/",
-    "http://localhost:8080/callback",
-    "http://localhost:8080/login/oauth2/code/podspaces"
+    "http://localhost:8080/callback"
   ],
   "post_logout_redirect_uris": [
     "http://localhost:8080",
     "http://localhost:8080/"
   ],
   "client_name": "Test Application (Not for production use)",
-  "id_token_signed_response_alg": "ES256",
   "grant_types": [
     "authorization_code"
-  ],
-  "response_types": [
-    "code"
   ]
 }

--- a/src/site/resources/clients/testing.jsonld
+++ b/src/site/resources/clients/testing.jsonld
@@ -4,14 +4,19 @@
   "redirect_uris": [
     "http://localhost:8080",
     "http://localhost:8080/",
-    "http://localhost:8080/callback"
+    "http://localhost:8080/callback",
+    "http://localhost:8080/login/oauth2/code/podspaces"
   ],
   "post_logout_redirect_uris": [
     "http://localhost:8080",
     "http://localhost:8080/"
   ],
   "client_name": "Test Application (Not for production use)",
+  "id_token_signed_response_alg": "ES256",
   "grant_types": [
     "authorization_code"
+  ],
+  "response_types": [
+    "code"
   ]
 }


### PR DESCRIPTION
I noticed that this document was originally quite an abstract example of a clientId document. I'm not sure if the changes needed justify having an example client Id document exclusively for our springboot app. 