### PR TITLE
JCL-277: Introduce a java 17 profile for example projects

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/examples/cli/pom.xml
+++ b/examples/cli/pom.xml
@@ -16,6 +16,9 @@
   </description>
 
   <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+
     <quarkus.version>2.16.4.Final</quarkus.version>
   </properties>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,11 +14,6 @@
   </description>
   <packaging>pom</packaging>
 
-  <modules>
-    <module>cli</module>
-    <module>webapp</module>
-  </modules>
-
   <build>
     <plugins>
       <plugin>
@@ -30,4 +25,17 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java-17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <modules>
+        <module>cli</module>
+        <module>webapp</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/examples/webapp/pom.xml
+++ b/examples/webapp/pom.xml
@@ -16,6 +16,9 @@
   </description>
 
   <properties>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+
     <quarkus.version>2.16.4.Final</quarkus.version>
   </properties>
 


### PR DESCRIPTION
Quarkus recommends using Java 17, and when we support Spring Boot, version 3.x _requires_ Java 17.

At the same time, the Java client libraries mostly need a Java 8 source target and need to be tested on Java 11.

This PR introduces a dynamic maven profile that is activated when the build system uses Java 17+. Thus, when Java 17 is in use, the Quarkus example projects will be built. When using a Java 11 build system, they will be skipped.

This structure will allow us to support Spring Boot 3.x-based projects, while otherwise we will need to remain on version 2.x indefinitely.