### PR TITLE
JCL-262: Remove matomo analytics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,19 +172,6 @@
             <header>
               <![CDATA[
                 <h2>Inrupt Java Client Libraries</h2>
-                <script>
-                      var _paq = window._paq = window._paq || [];
-                      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-                      _paq.push(['trackPageView']);
-                      _paq.push(['enableLinkTracking']);
-                      (function() {
-                        var u="https://inrupt.matomo.cloud/";
-                        _paq.push(['setTrackerUrl', u+'matomo.php']);
-                        _paq.push(['setSiteId', '3']);
-                        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-                        g.async=true; g.src='//cdn.matomo.cloud/inrupt.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
-                      })();
-                </script>
               ]]>
             </header>
             <tags>
@@ -204,7 +191,6 @@
                 <head>API Note:</head>
               </tag>
             </tags>
-            <additionalOptions>--allow-script-in-comments</additionalOptions>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
We are moving to Google Analytics, and we are adding the relevant scripts at the point of javadoc generation on the docs page. As such, there is no need to add matomo analytics for everyone who might possibly consume the javadoc jars.