### PR TITLE
Remove unused quarkus plugin

### DIFF
--- a/examples/cli/pom.xml
+++ b/examples/cli/pom.xml
@@ -110,11 +110,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-        <version>${quarkus.version}</version>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>

--- a/examples/webapp/pom.xml
+++ b/examples/webapp/pom.xml
@@ -118,11 +118,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-        <version>${quarkus.version}</version>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
The quarkus bootstrap plugin is not used by these example projects: it is for extension writers (plus, it is deprecated in favor of another plugin).
