### PR TITLE
JCL-234: Add springboot example to build configuration

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -42,6 +42,7 @@
       </activation>
       <modules>
         <module>cli</module>
+        <module>springboot</module>
         <module>webapp</module>
       </modules>
     </profile>

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Vocabulary.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Vocabulary.java
@@ -21,6 +21,7 @@
 package com.inrupt.client.examples.springboot.model;
 
 import com.inrupt.client.util.URIBuilder;
+
 import java.net.URI;
 
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
The springboot module was omitted from the maven module list.