### PR TITLE
JCL-275: Better support for NonRDF resources

### DIFF
--- a/api/src/main/java/com/inrupt/client/NonRDFSource.java
+++ b/api/src/main/java/com/inrupt/client/NonRDFSource.java
@@ -20,24 +20,45 @@
  */
 package com.inrupt.client;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import com.inrupt.client.spi.RDFFactory;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
+import java.util.Objects;
 
-import org.apache.commons.rdf.api.RDF;
-import org.junit.jupiter.api.Test;
+public class NonRDFSource implements Resource {
 
-class ResourceTest {
+    private final URI identifier;
+    private final String contentType;
+    private final InputStream entity;
 
-    static final RDF rdf = RDFFactory.getInstance();
+    protected NonRDFSource(final URI identifier, final String contentType, final InputStream entity) {
+        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null!");
+        this.contentType = Objects.requireNonNull(contentType, "contentType may not be null!");
+        this.entity = Objects.requireNonNull(entity, "entity may not be null!");
+    }
 
-    @Test
-    void testValidate() {
-        final URI id = URI.create("https://resource.test/path");
-        try (final Resource resource = new Resource(id, null)) {
-            assertDoesNotThrow(() -> resource.validate());
+    @Override
+    public URI getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public InputStream getEntity() throws IOException {
+        return entity;
+    }
+
+    @Override
+    public void close() {
+        try {
+            entity.close();
+        } catch (final IOException ex) {
+            throw new UncheckedIOException("Unable to close NonRDFSource entity", ex);
         }
     }
 }

--- a/api/src/main/java/com/inrupt/client/RDFSource.java
+++ b/api/src/main/java/com/inrupt/client/RDFSource.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client;
+
+import com.inrupt.client.spi.RDFFactory;
+import com.inrupt.client.spi.ServiceProvider;
+import com.inrupt.rdf.wrapping.commons.WrapperDataset;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.RDFSyntax;
+
+/**
+ * A base class for resource mapping.
+ *
+ * <p>This class can be used as a basis for object mapping with higher-level client applications.
+ */
+public class RDFSource extends WrapperDataset implements Resource {
+
+    /**
+     * The RDF Factory instance.
+     */
+    protected static final RDF rdf = RDFFactory.getInstance();
+
+    private final URI identifier;
+
+    /**
+     * Create a new resource.
+     *
+     * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
+     *
+     * @param identifier the resource identifier
+     * @param dataset the dataset corresponding to this resource, may be {@code null}
+     */
+    protected RDFSource(final URI identifier, final Dataset dataset) {
+        super(dataset == null ? rdf.createDataset() : dataset);
+        this.identifier = identifier;
+    }
+
+    /**
+     * Get the identifier for this resource.
+     *
+     * @return the resource identifier
+     */
+    @Override
+    public URI getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public String getContentType() {
+        return RDFSyntax.TURTLE.mediaType();
+    }
+
+    @Override
+    public InputStream getEntity() throws IOException {
+        try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            serialize(RDFSyntax.TURTLE, out);
+            return new ByteArrayInputStream(out.toByteArray());
+        }
+    }
+
+    /**
+     * Serialize this object with a defined RDF syntax.
+     *
+     * @param syntax the RDF syntax
+     * @param out the output stream
+     * @throws IOException in the case of an I/O error
+     */
+    public void serialize(final RDFSyntax syntax, final OutputStream out) throws IOException {
+        ServiceProvider.getRdfService().fromDataset(this, syntax, out);
+    }
+
+    /**
+     * Validate the dataset for this object.
+     *
+     * <p>Subclasses may override this method to perform validation on the provided dataset.
+     * By default, this method is a no-op.
+     *
+     * @return the validation result
+     */
+    public ValidationResult validate() {
+        return new ValidationResult(true);
+    }
+
+
+    @Override
+    public void close() {
+        try {
+            super.close();
+        } catch (final Exception ex) {
+            throw new InruptClientException("Error closing dataset", ex);
+        }
+    }
+}

--- a/api/src/main/java/com/inrupt/client/RDFSource.java
+++ b/api/src/main/java/com/inrupt/client/RDFSource.java
@@ -36,7 +36,7 @@ import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.rdf.api.RDFSyntax;
 
 /**
- * A base class for resource mapping.
+ * A base class for RDF-based resource mapping.
  *
  * <p>This class can be used as a basis for object mapping with higher-level client applications.
  */
@@ -50,7 +50,7 @@ public class RDFSource extends WrapperDataset implements Resource {
     private final URI identifier;
 
     /**
-     * Create a new resource.
+     * Create a new RDF-bearing resource.
      *
      * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
      *
@@ -62,11 +62,6 @@ public class RDFSource extends WrapperDataset implements Resource {
         this.identifier = identifier;
     }
 
-    /**
-     * Get the identifier for this resource.
-     *
-     * @return the resource identifier
-     */
     @Override
     public URI getIdentifier() {
         return identifier;

--- a/api/src/main/java/com/inrupt/client/RDFSource.java
+++ b/api/src/main/java/com/inrupt/client/RDFSource.java
@@ -48,6 +48,7 @@ public class RDFSource extends WrapperDataset implements Resource {
     protected static final RDF rdf = RDFFactory.getInstance();
 
     private final URI identifier;
+    private final RDFSyntax syntax;
 
     /**
      * Create a new RDF-bearing resource.
@@ -58,8 +59,22 @@ public class RDFSource extends WrapperDataset implements Resource {
      * @param dataset the dataset corresponding to this resource, may be {@code null}
      */
     protected RDFSource(final URI identifier, final Dataset dataset) {
+        this(identifier, RDFSyntax.TURTLE, dataset);
+    }
+
+    /**
+     * Create a new RDF-bearing resource.
+     *
+     * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
+     *
+     * @param identifier the resource identifier
+     * @param syntax the original RDF syntax in use
+     * @param dataset the dataset corresponding to this resource, may be {@code null}
+     */
+    protected RDFSource(final URI identifier, final RDFSyntax syntax, final Dataset dataset) {
         super(dataset == null ? rdf.createDataset() : dataset);
         this.identifier = identifier;
+        this.syntax = syntax;
     }
 
     @Override
@@ -69,13 +84,13 @@ public class RDFSource extends WrapperDataset implements Resource {
 
     @Override
     public String getContentType() {
-        return RDFSyntax.TURTLE.mediaType();
+        return syntax.mediaType();
     }
 
     @Override
     public InputStream getEntity() throws IOException {
         try (final ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-            serialize(RDFSyntax.TURTLE, out);
+            serialize(syntax, out);
             return new ByteArrayInputStream(out.toByteArray());
         }
     }

--- a/api/src/main/java/com/inrupt/client/Resource.java
+++ b/api/src/main/java/com/inrupt/client/Resource.java
@@ -24,11 +24,32 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 
+/**
+ * A base class for all resources.
+ *
+ * <p>This class can be used as a basis for higher-level client applications.
+ */
 public interface Resource extends AutoCloseable {
 
+    /**
+     * The resource identifier.
+     *
+     * @return the identifier
+     */
     URI getIdentifier();
 
+    /**
+     * The content type of the resource.
+     *
+     * @return the content type
+     */
     String getContentType();
 
+    /**
+     * The resource entity.
+     *
+     * @return the resource entity
+     * @throws IOException in the case of an error when generating the entity
+     */
     InputStream getEntity() throws IOException;
 }

--- a/api/src/test/java/com/inrupt/client/RDFSourceTest.java
+++ b/api/src/test/java/com/inrupt/client/RDFSourceTest.java
@@ -20,15 +20,24 @@
  */
 package com.inrupt.client;
 
-import java.io.IOException;
-import java.io.InputStream;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.spi.RDFFactory;
+
 import java.net.URI;
 
-public interface Resource extends AutoCloseable {
+import org.apache.commons.rdf.api.RDF;
+import org.junit.jupiter.api.Test;
 
-    URI getIdentifier();
+class RDFSourceTest {
 
-    String getContentType();
+    static final RDF rdf = RDFFactory.getInstance();
 
-    InputStream getEntity() throws IOException;
+    @Test
+    void testValidate() {
+        final URI id = URI.create("https://resource.test/path");
+        try (final RDFSource resource = new RDFSource(id, null)) {
+            assertDoesNotThrow(() -> resource.validate());
+        }
+    }
 }

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Book.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Book.java
@@ -21,7 +21,7 @@
 package com.inrupt.client.examples.springboot.model;
 
 import com.inrupt.client.solid.Metadata;
-import com.inrupt.client.solid.SolidResource;
+import com.inrupt.client.solid.SolidRDFSource;
 import com.inrupt.rdf.wrapping.commons.TermMappings;
 import com.inrupt.rdf.wrapping.commons.ValueMappings;
 import com.inrupt.rdf.wrapping.commons.WrapperIRI;
@@ -33,7 +33,7 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
 
-public class Book extends SolidResource {
+public class Book extends SolidRDFSource {
 
     private final Node bookId;
     private final IRI title = rdf.createIRI(Vocabulary.DC_TITLE);

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/BookLibrary.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/BookLibrary.java
@@ -21,7 +21,7 @@
 package com.inrupt.client.examples.springboot.model;
 
 import com.inrupt.client.solid.Metadata;
-import com.inrupt.client.solid.SolidResource;
+import com.inrupt.client.solid.SolidRDFSource;
 import com.inrupt.rdf.wrapping.commons.TermMappings;
 import com.inrupt.rdf.wrapping.commons.ValueMappings;
 import com.inrupt.rdf.wrapping.commons.WrapperIRI;
@@ -35,7 +35,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
 
 
-public class BookLibrary extends SolidResource {
+public class BookLibrary extends SolidRDFSource {
 
     private Node bookLibraryId;
     private final IRI contains = rdf.createIRI(Vocabulary.CONTAINS_BOOK);

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -31,7 +31,7 @@ import com.inrupt.client.auth.Session;
 import com.inrupt.client.openid.OpenIdException;
 import com.inrupt.client.openid.OpenIdSession;
 import com.inrupt.client.solid.SolidClientException;
-import com.inrupt.client.solid.SolidResource;
+import com.inrupt.client.solid.SolidRDFSource;
 import com.inrupt.client.solid.SolidSyncClient;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.webid.WebIdProfile;
@@ -170,10 +170,10 @@ public class AuthenticationScenarios {
     void fetchPublicResourceUnauthenticatedTest() {
         LOGGER.info("Integration Test - Unauthenticated fetch of public resource");
         //create a public resource
-        final SolidResource testResource = new SolidResource(publicResourceURL, null, null);
+        final SolidRDFSource testResource = new SolidRDFSource(publicResourceURL, null, null);
         final SolidSyncClient client = SolidSyncClient.getClient();
         assertDoesNotThrow(() -> client.create(testResource));
-        assertDoesNotThrow(() -> client.read(publicResourceURL, SolidResource.class));
+        assertDoesNotThrow(() -> client.read(publicResourceURL, SolidRDFSource.class));
         assertDoesNotThrow(() -> client.delete(testResource));
     }
 
@@ -185,12 +185,12 @@ public class AuthenticationScenarios {
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
 
-        final SolidResource testResource = new SolidResource(privateResourceURL, null, null);
+        final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null);
         assertDoesNotThrow(() -> authClient.create(testResource));
 
         final SolidSyncClient client = SolidSyncClient.getClient();
         final SolidClientException err = assertThrows(SolidClientException.class,
-                () -> client.read(privateResourceURL, SolidResource.class));
+                () -> client.read(privateResourceURL, SolidRDFSource.class));
         assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
         assertDoesNotThrow(() -> authClient.delete(testResource));
@@ -203,11 +203,11 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - AuAuthenticatedth fetch of public resource");
         //create public resource
         final SolidSyncClient client = SolidSyncClient.getClient();
-        final SolidResource testResource = new SolidResource(publicResourceURL, null, null);
+        final SolidRDFSource testResource = new SolidRDFSource(publicResourceURL, null, null);
         assertDoesNotThrow(() -> client.create(testResource));
 
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        assertDoesNotThrow(() -> authClient.read(publicResourceURL, SolidResource.class));
+        assertDoesNotThrow(() -> authClient.read(publicResourceURL, SolidRDFSource.class));
 
         assertDoesNotThrow(() -> client.delete(testResource));
     }
@@ -219,10 +219,10 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of private resource");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        final SolidResource testResource = new SolidResource(privateResourceURL, null, null);
+        final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null);
         assertDoesNotThrow(() -> authClient.create(testResource));
 
-        assertDoesNotThrow(() -> authClient.read(privateResourceURL, SolidResource.class));
+        assertDoesNotThrow(() -> authClient.read(privateResourceURL, SolidRDFSource.class));
 
         assertDoesNotThrow(() -> authClient.delete(testResource));
     }
@@ -234,16 +234,16 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Unauthenticated, then auth fetch of private resource");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        final SolidResource testResource = new SolidResource(privateResourceURL, null, null);
+        final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null);
         assertDoesNotThrow(() -> authClient.create(testResource));
 
         final SolidSyncClient client = SolidSyncClient.getClient();
         final SolidClientException err = assertThrows(SolidClientException.class,
-                () -> client.read(privateResourceURL, SolidResource.class));
+                () -> client.read(privateResourceURL, SolidRDFSource.class));
         assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
         final SolidSyncClient authClient2 = client.session(session);
-        assertDoesNotThrow(() -> authClient2.read(privateResourceURL, SolidResource.class));
+        assertDoesNotThrow(() -> authClient2.read(privateResourceURL, SolidRDFSource.class));
 
         assertDoesNotThrow(() -> authClient2.delete(testResource));
     }
@@ -254,7 +254,7 @@ public class AuthenticationScenarios {
     void multiSessionTest(final Session session) {
         LOGGER.info("Integration Test - Multiple sessions authenticated in parallel");
         //create private resource
-        final SolidResource testResource = new SolidResource(privateResourceURL, null, null);
+        final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null);
         final SolidSyncClient authClient1 = SolidSyncClient.getClient().session(session);
         assertDoesNotThrow(() -> authClient1.create(testResource));
 
@@ -263,18 +263,18 @@ public class AuthenticationScenarios {
             .path(State.PRIVATE_RESOURCE_PATH)
             .path("resource2.ttl")
             .build();
-        final SolidResource testResource2 = new SolidResource(privateResourceURL2, null, null);
+        final SolidRDFSource testResource2 = new SolidRDFSource(privateResourceURL2, null, null);
         final SolidSyncClient authClient2 =
                 SolidSyncClient.getClient().session(session);
         assertDoesNotThrow(() -> authClient2.create(testResource2));
 
         //read the other resource created with the other client
-        assertDoesNotThrow(() -> authClient1.read(privateResourceURL2, SolidResource.class));
-        assertDoesNotThrow(() -> authClient2.read(privateResourceURL, SolidResource.class));
+        assertDoesNotThrow(() -> authClient1.read(privateResourceURL2, SolidRDFSource.class));
+        assertDoesNotThrow(() -> authClient2.read(privateResourceURL, SolidRDFSource.class));
 
         final SolidSyncClient client = SolidSyncClient.getClient();
         final SolidClientException err = assertThrows(SolidClientException.class,
-                () -> client.read(privateResourceURL, SolidResource.class));
+                () -> client.read(privateResourceURL, SolidRDFSource.class));
         assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
         //delete both resources with whichever client

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -32,7 +32,7 @@ import com.inrupt.client.Response;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.jena.JenaBodyHandlers;
 import com.inrupt.client.jena.JenaBodyPublishers;
-import com.inrupt.client.solid.SolidResource;
+import com.inrupt.client.solid.SolidRDFSource;
 import com.inrupt.client.solid.SolidResourceHandlers;
 import com.inrupt.client.solid.SolidSyncClient;
 import com.inrupt.client.util.URIBuilder;
@@ -320,8 +320,8 @@ public class CoreModulesResource {
         assertTrue(Utils.isSuccessful(responseCreate.statusCode()));
 
         final Request req = Request.newBuilder(URI.create(fileURL)).GET().build();
-        final Response<SolidResource> headerResponse =
-                client.send(req, SolidResourceHandlers.ofSolidResource());
+        final Response<SolidRDFSource> headerResponse =
+                client.send(req, SolidResourceHandlers.ofSolidRDFSource());
 
         assertTrue(headerResponse.body().getMetadata().getContentType().contains(Utils.PLAIN_TEXT));
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -28,7 +28,7 @@ import com.inrupt.client.Response;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.solid.SolidClientException;
 import com.inrupt.client.solid.SolidContainer;
-import com.inrupt.client.solid.SolidResource;
+import com.inrupt.client.solid.SolidRDFSource;
 import com.inrupt.client.solid.SolidResourceHandlers;
 import com.inrupt.client.solid.SolidSyncClient;
 import com.inrupt.client.spi.RDFFactory;
@@ -161,10 +161,10 @@ public class DomainModulesResource {
         final Dataset dataset = rdf.createDataset();
         dataset.add(rdf.createQuad(newResourceNode, newResourceNode, newPredicateNode, object));
 
-        try (final SolidResource newResource = new SolidResource(URI.create(newResourceName), dataset, null)) {
+        try (final SolidRDFSource newResource = new SolidRDFSource(URI.create(newResourceName), dataset, null)) {
             assertDoesNotThrow(() -> client.create(newResource));
 
-            try (final SolidResource resource = client.read(URI.create(newResourceName), SolidResource.class)) {
+            try (final SolidRDFSource resource = client.read(URI.create(newResourceName), SolidRDFSource.class)) {
                 assertEquals(newResource.getIdentifier(), resource.getIdentifier());
                 assertEquals(1, resource.size());
 
@@ -175,7 +175,7 @@ public class DomainModulesResource {
                             rdf.createQuad(quad.getSubject(), quad.getSubject(), quad.getPredicate(), newObject))
                         .forEach(newDataset::add);
                 }
-                try (final SolidResource updatedResource = new SolidResource(URI.create(newResourceName),
+                try (final SolidRDFSource updatedResource = new SolidRDFSource(URI.create(newResourceName),
                     newDataset, null)) {
                     assertDoesNotThrow(() -> client.update(updatedResource));
                     assertDoesNotThrow(() -> client.delete(updatedResource));
@@ -219,10 +219,10 @@ public class DomainModulesResource {
         final BlankNode bn = rdf.createBlankNode("blank");
         dataset.add(rdf.createQuad(newResourceNode, newResourceNode, newBNPredicateNode, bn));
 
-        try (final SolidResource newResource = new SolidResource(URI.create(newResourceName), dataset, null)) {
+        try (final SolidRDFSource newResource = new SolidRDFSource(URI.create(newResourceName), dataset, null)) {
             assertDoesNotThrow(() -> client.create(newResource));
 
-            try (final SolidResource resource = client.read(URI.create(newResourceName), SolidResource.class)) {
+            try (final SolidRDFSource resource = client.read(URI.create(newResourceName), SolidRDFSource.class)) {
                 assertEquals(URI.create(newResourceName), resource.getIdentifier());
                 assertEquals(2, resource.size());
 
@@ -242,7 +242,7 @@ public class DomainModulesResource {
                 allQuads.add(toAddQuad);
                 allQuads.forEach(newDataset::add);
 
-                try (final SolidResource updatedResource = new SolidResource(URI.create(newResourceName),
+                try (final SolidRDFSource updatedResource = new SolidRDFSource(URI.create(newResourceName),
                     newDataset, null)) {
                     assertDoesNotThrow(() -> client.update(updatedResource));
                     assertDoesNotThrow(() -> client.delete(updatedResource));
@@ -286,8 +286,8 @@ public class DomainModulesResource {
         final URI storage = URI.create(PIM.getNamespace() + "Storage");
         while (tempURL.chars().filter(ch -> ch == '/').count() >= 3) {
             final Request req = Request.newBuilder(URI.create(tempURL)).GET().build();
-            final Response<SolidResource> headerResponse =
-                    client.send(req, SolidResourceHandlers.ofSolidResource());
+            final Response<SolidRDFSource> headerResponse =
+                    client.send(req, SolidResourceHandlers.ofSolidRDFSource());
             final var headers = headerResponse.headers();
             final var isRoot = headers.allValues("Link").stream()
                 .flatMap(l -> Headers.Link.parse(l).stream())
@@ -304,7 +304,7 @@ public class DomainModulesResource {
     private void recursiveDeleteLDPcontainers(final String leafPath) {
         String tempURL = leafPath;
         while (!tempURL.equals(podUrl) && !tempURL.equals(podUrl + "/")) {
-            final var url = new SolidResource(URI.create(tempURL),null, null);
+            final var url = new SolidRDFSource(URI.create(tempURL),null, null);
             client.delete(url);
             tempURL = tempURL.substring(0, tempURL.lastIndexOf("/"));
             tempURL = tempURL.substring(0, tempURL.lastIndexOf("/") + 1);
@@ -317,7 +317,7 @@ public class DomainModulesResource {
             tempURL.path(UUID.randomUUID().toString());
         }
         final String newURL = tempURL.build() + Utils.FOLDER_SEPARATOR;
-        final var resource = new SolidResource(URI.create(newURL));
+        final var resource = new SolidRDFSource(URI.create(newURL));
         client.create(resource);
         return newURL;
     }

--- a/integration/base/src/test/java/com/inrupt/client/integration/base/Playlist.java
+++ b/integration/base/src/test/java/com/inrupt/client/integration/base/Playlist.java
@@ -21,7 +21,7 @@
 package com.inrupt.client.integration.base;
 
 import com.inrupt.client.solid.Metadata;
-import com.inrupt.client.solid.SolidResource;
+import com.inrupt.client.solid.SolidRDFSource;
 import com.inrupt.rdf.wrapping.commons.TermMappings;
 import com.inrupt.rdf.wrapping.commons.ValueMappings;
 import com.inrupt.rdf.wrapping.commons.WrapperIRI;
@@ -34,7 +34,7 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
 
-class Playlist extends SolidResource {
+class Playlist extends SolidRDFSource {
 
     private final IRI dcTitle;
     private final IRI exSong;

--- a/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
+++ b/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
@@ -121,7 +121,7 @@ class ServerTest {
 
         final var reqGet =
                 Request.newBuilder().uri(resourceUri).header(Utils.ACCEPT, Utils.TEXT_TURTLE).GET().build();
-        final var resGet = client.send(reqGet, SolidResourceHandlers.ofSolidResource());
+        final var resGet = client.send(reqGet, SolidResourceHandlers.ofSolidRDFSource());
 
         assertTrue(Utils.isSuccessful(resGet.statusCode()));
 
@@ -179,7 +179,7 @@ class ServerTest {
 
         final var reqGet = Request.newBuilder().uri(resourceUri)
                 .header(Utils.ACCEPT, Utils.TEXT_TURTLE).GET().build();
-        final var resGet = client.send(reqGet, SolidResourceHandlers.ofSolidResource());
+        final var resGet = client.send(reqGet, SolidResourceHandlers.ofSolidRDFSource());
 
         assertEquals(Utils.UNAUTHORIZED, resGet.statusCode());
         final var challenges = WwwAuthenticate.parse(
@@ -212,7 +212,7 @@ class ServerTest {
 
         final var reqGet = Request.newBuilder().uri(resourceUri)
                 .header(Utils.ACCEPT, Utils.TEXT_TURTLE).GET().build();
-        final var resGet = client.send(reqGet, SolidResourceHandlers.ofSolidResource());
+        final var resGet = client.send(reqGet, SolidResourceHandlers.ofSolidRDFSource());
 
         assertTrue(Utils.isSuccessful(resGet.statusCode()));
 

--- a/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
+++ b/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.rdf.api.RDFSyntax;
 import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.jws.AlgorithmIdentifiers;
 import org.jose4j.jws.JsonWebSignature;
@@ -226,14 +225,12 @@ class ServerTest {
     }
 
     private Request.BodyPublisher cast(final Resource resource) {
-        return com.inrupt.client.util.IOUtils.buffer(out -> {
-            try {
-                resource.serialize(RDFSyntax.TURTLE, out);
-            } catch (final IOException ex) {
-                throw new SolidResourceException("Unable to serialize " + resource.getClass().getName() +
-                        " into Solid Resource", ex);
-            }
-        });
+        try {
+            return Request.BodyPublishers.ofInputStream(resource.getEntity());
+        } catch (final IOException ex) {
+            throw new SolidResourceException("Unable to serialize " + resource.getClass().getName() +
+                    " into Solid Resource", ex);
+        }
     }
 
     static String setupIdToken(final String webid, final String username, final String issuer) {

--- a/solid/src/main/java/com/inrupt/client/solid/SolidBinary.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidBinary.java
@@ -18,17 +18,25 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client;
+package com.inrupt.client.solid;
 
-import java.io.IOException;
+import com.inrupt.client.NonRDFSource;
+
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Objects;
 
-public interface Resource extends AutoCloseable {
+public class SolidBinary extends NonRDFSource {
 
-    URI getIdentifier();
+    private final Metadata metadata;
 
-    String getContentType();
+    public SolidBinary(final URI identifier, final String contentType, final InputStream entity,
+            final Metadata metadata) {
+        super(identifier, contentType, entity);
+        this.metadata = Objects.requireNonNull(metadata, "metadata may not be null!");
+    }
 
-    InputStream getEntity() throws IOException;
+    public Metadata getMetadata() {
+        return metadata;
+    }
 }

--- a/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
@@ -36,7 +36,7 @@ import org.apache.commons.rdf.api.RDFTerm;
 /**
  * A Solid Container Object.
  */
-public class SolidContainer extends SolidResource {
+public class SolidContainer extends SolidRDFSource {
 
     /**
      * Create a new SolidContainer.
@@ -61,7 +61,7 @@ public class SolidContainer extends SolidResource {
                 final Metadata.Builder builder = Metadata.newBuilder();
                 getMetadata().getStorage().ifPresent(builder::storage);
                 child.getTypes().forEach(builder::type);
-                return new SolidResource(URI.create(child.getIRIString()), null, builder.build());
+                return new SolidResourceReference(URI.create(child.getIRIString()), builder.build());
             });
     }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
@@ -24,18 +24,37 @@ import com.inrupt.client.NonRDFSource;
 
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Objects;
 
-public class SolidBinary extends NonRDFSource {
+/**
+ * A non-RDF-bearing Solid Resource.
+ */
+public class SolidNonRDFSource extends NonRDFSource implements SolidResource {
 
     private final Metadata metadata;
 
-    public SolidBinary(final URI identifier, final String contentType, final InputStream entity,
+    /**
+     * Create a non-RDF-bearing Solid Resource.
+     *
+     * @param identifier the resource identifier
+     * @param contentType the content type
+     * @param entity the entity
+     * @param metadata the metadata, may be {@code null}
+     */
+    public SolidNonRDFSource(final URI identifier, final String contentType, final InputStream entity,
             final Metadata metadata) {
         super(identifier, contentType, entity);
-        this.metadata = Objects.requireNonNull(metadata, "metadata may not be null!");
+        if (metadata == null) {
+            this.metadata = Metadata.newBuilder().build();
+        } else {
+            this.metadata = metadata;
+        }
     }
 
+    /**
+     * Get the metadata for this resource.
+     *
+     * @return the metadata
+     */
     public Metadata getMetadata() {
         return metadata;
     }

--- a/solid/src/main/java/com/inrupt/client/solid/SolidRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidRDFSource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.RDFSource;
+
+import java.net.URI;
+
+import org.apache.commons.rdf.api.Dataset;
+
+/**
+ * A Solid Resource Object.
+ */
+public class SolidRDFSource extends RDFSource implements SolidResource {
+
+    private final Metadata metadata;
+
+    /**
+     * Create a Solid resource.
+     *
+     * @param identifier the Solid Resource identifier
+     */
+    public SolidRDFSource(final URI identifier) {
+        this(identifier, null);
+    }
+
+    /**
+     * Create a Solid resource.
+     *
+     * @param identifier the Solid Resource identifier
+     * @param dataset the resource dataset, may be {@code null}
+     */
+    public SolidRDFSource(final URI identifier, final Dataset dataset) {
+        this(identifier, dataset, null);
+    }
+
+    /**
+     * Create a Solid resource.
+     *
+     * @param identifier the Solid Resource identifier
+     * @param dataset the resource dataset, may be {@code null}
+     * @param metadata metadata associated with this resource, may be {@code null}
+     */
+    public SolidRDFSource(final URI identifier, final Dataset dataset, final Metadata metadata) {
+        super(identifier, dataset);
+        if (metadata == null) {
+            this.metadata = Metadata.newBuilder().build();
+        } else {
+            this.metadata = metadata;
+        }
+    }
+
+    @Override
+    public Metadata getMetadata() {
+        return metadata;
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResource.java
@@ -20,7 +20,7 @@
  */
 package com.inrupt.client.solid;
 
-import com.inrupt.client.Resource;
+import com.inrupt.client.RDFSource;
 
 import java.net.URI;
 
@@ -29,7 +29,7 @@ import org.apache.commons.rdf.api.Dataset;
 /**
  * A Solid Resource Object.
  */
-public class SolidResource extends Resource {
+public class SolidResource extends RDFSource {
 
     private final Metadata metadata;
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResource.java
@@ -20,53 +20,9 @@
  */
 package com.inrupt.client.solid;
 
-import com.inrupt.client.RDFSource;
+import com.inrupt.client.Resource;
 
-import java.net.URI;
-
-import org.apache.commons.rdf.api.Dataset;
-
-/**
- * A Solid Resource Object.
- */
-public class SolidResource extends RDFSource {
-
-    private final Metadata metadata;
-
-    /**
-     * Create a Solid resource.
-     *
-     * @param identifier the Solid Resource identifier
-     */
-    public SolidResource(final URI identifier) {
-        this(identifier, null);
-    }
-
-    /**
-     * Create a Solid resource.
-     *
-     * @param identifier the Solid Resource identifier
-     * @param dataset the resource dataset, may be {@code null}
-     */
-    public SolidResource(final URI identifier, final Dataset dataset) {
-        this(identifier, dataset, null);
-    }
-
-    /**
-     * Create a Solid resource.
-     *
-     * @param identifier the Solid Resource identifier
-     * @param dataset the resource dataset, may be {@code null}
-     * @param metadata metadata associated with this resource, may be {@code null}
-     */
-    public SolidResource(final URI identifier, final Dataset dataset, final Metadata metadata) {
-        super(identifier, dataset);
-        if (metadata == null) {
-            this.metadata = Metadata.newBuilder().build();
-        } else {
-            this.metadata = metadata;
-        }
-    }
+public interface SolidResource extends Resource {
 
     /**
      * Get the associated metadata about this resource.
@@ -76,7 +32,6 @@ public class SolidResource extends RDFSource {
      *
      * @return the metadata
      */
-    public Metadata getMetadata() {
-        return metadata;
-    }
+    Metadata getMetadata();
+
 }

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResourceHandlers.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResourceHandlers.java
@@ -50,15 +50,15 @@ public final class SolidResourceHandlers {
      *
      * @return an HTTP body handler
      */
-    public static Response.BodyHandler<SolidResource> ofSolidResource() {
+    public static Response.BodyHandler<SolidRDFSource> ofSolidRDFSource() {
         return responseInfo -> {
             final Metadata metadata = buildMetadata(responseInfo.uri(), responseInfo.headers());
 
             return responseInfo.headers().firstValue(CONTENT_TYPE)
                 .flatMap(contentType ->
                         buildDataset(contentType, responseInfo.body().array(), responseInfo.uri().toString()))
-                .map(dataset -> new SolidResource(responseInfo.uri(), dataset, metadata))
-                .orElseGet(() -> new SolidResource(responseInfo.uri(), null, metadata));
+                .map(dataset -> new SolidRDFSource(responseInfo.uri(), dataset, metadata))
+                .orElseGet(() -> new SolidRDFSource(responseInfo.uri(), null, metadata));
         };
     }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
@@ -18,38 +18,33 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-package com.inrupt.client;
+package com.inrupt.client.solid;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.Objects;
 
 /**
- * A base class for non-RDF-bearing resources.
- *
- * <p>This class can be used as a basis for object mapping with the high-level client operations.
+ * A reference to a Solid Resource without any corresponding data.
  */
-public class NonRDFSource implements Resource {
+public class SolidResourceReference implements SolidResource {
 
-    private final URI identifier;
-    private final String contentType;
     private final InputStream entity;
+    private final Metadata metadata;
+    private final URI identifier;
 
     /**
-     * Create a new non-RDF-bearing resource.
-     *
-     * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
+     * Create a reference to a Solid resource.
      *
      * @param identifier the resource identifier
-     * @param contentType the content type of the resource
-     * @param entity the resource entity
+     * @param metadata the resource metadata
      */
-    protected NonRDFSource(final URI identifier, final String contentType, final InputStream entity) {
-        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null!");
-        this.contentType = Objects.requireNonNull(contentType, "contentType may not be null!");
-        this.entity = Objects.requireNonNull(entity, "entity may not be null!");
+    public SolidResourceReference(final URI identifier, final Metadata metadata) {
+        this.identifier = identifier;
+        this.metadata = metadata;
+        this.entity = new ByteArrayInputStream(new byte[0]);
     }
 
     @Override
@@ -58,8 +53,8 @@ public class NonRDFSource implements Resource {
     }
 
     @Override
-    public String getContentType() {
-        return contentType;
+    public Metadata getMetadata() {
+        return metadata;
     }
 
     @Override
@@ -68,11 +63,16 @@ public class NonRDFSource implements Resource {
     }
 
     @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
     public void close() {
         try {
             entity.close();
         } catch (final IOException ex) {
-            throw new UncheckedIOException("Unable to close NonRDFSource entity", ex);
+            throw new UncheckedIOException("Unable to close empty entity", ex);
         }
     }
 }

--- a/solid/src/test/java/com/inrupt/client/solid/InvalidType.java
+++ b/solid/src/test/java/com/inrupt/client/solid/InvalidType.java
@@ -26,7 +26,7 @@ import java.net.URI;
 
 import org.apache.commons.rdf.api.RDFSyntax;
 
-public class InvalidType extends SolidResource {
+public class InvalidType extends SolidRDFSource {
     public InvalidType(final URI identifier) {
         super(identifier, null, null);
     }

--- a/solid/src/test/java/com/inrupt/client/solid/Playlist.java
+++ b/solid/src/test/java/com/inrupt/client/solid/Playlist.java
@@ -33,7 +33,7 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
 
-public class Playlist extends SolidResource {
+public class Playlist extends SolidRDFSource {
 
     private final IRI dcTitle;
     private final IRI exSong;

--- a/solid/src/test/java/com/inrupt/client/solid/Recipe.java
+++ b/solid/src/test/java/com/inrupt/client/solid/Recipe.java
@@ -20,7 +20,7 @@
  */
 package com.inrupt.client.solid;
 
-import com.inrupt.client.Resource;
+import com.inrupt.client.RDFSource;
 import com.inrupt.rdf.wrapping.commons.TermMappings;
 import com.inrupt.rdf.wrapping.commons.ValueMappings;
 import com.inrupt.rdf.wrapping.commons.WrapperIRI;
@@ -33,7 +33,7 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
 
-public class Recipe extends Resource {
+public class Recipe extends RDFSource {
 
     private final IRI dcTitle;
     private final IRI exIngredient;

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -139,8 +139,8 @@ class SolidClientTest {
     void testGetResource() throws IOException, InterruptedException {
         final URI uri = URI.create(config.get("solid_resource_uri") + "/playlist");
 
-        client.read(uri, SolidResource.class).thenAccept(resource -> {
-            try (final SolidResource r = resource) {
+        client.read(uri, SolidRDFSource.class).thenAccept(resource -> {
+            try (final SolidRDFSource r = resource) {
                 assertEquals(uri, r.getIdentifier());
                 assertEquals(4, r.size());
                 assertEquals(2, r.stream(Optional.empty(), rdf.createIRI(uri.toString()),
@@ -178,14 +178,14 @@ class SolidClientTest {
     void testGetBinary() {
         final URI uri = URI.create(config.get("solid_resource_uri") + "/binary");
 
-        client.read(uri, SolidBinary.class).thenAccept(container -> {
-            try (final SolidBinary c = container) {
-                assertEquals(uri, c.getIdentifier());
-                assertEquals("text/plain", c.getContentType());
+        client.read(uri, SolidNonRDFSource.class).thenAccept(binary -> {
+            try (final SolidNonRDFSource b = binary) {
+                assertEquals(uri, b.getIdentifier());
+                assertEquals("text/plain", b.getContentType());
 
-                assertDoesNotThrow(client.update(c).toCompletableFuture()::join);
-                assertDoesNotThrow(client.create(c).toCompletableFuture()::join);
-                assertDoesNotThrow(client.delete(c).toCompletableFuture()::join);
+                assertDoesNotThrow(client.update(b).toCompletableFuture()::join);
+                assertDoesNotThrow(client.create(b).toCompletableFuture()::join);
+                assertDoesNotThrow(client.delete(b).toCompletableFuture()::join);
             }
         }).toCompletableFuture().join();
     }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -175,6 +175,22 @@ class SolidClientTest {
     }
 
     @Test
+    void testGetBinary() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/binary");
+
+        client.read(uri, SolidBinary.class).thenAccept(container -> {
+            try (final SolidBinary c = container) {
+                assertEquals(uri, c.getIdentifier());
+                assertEquals("text/plain", c.getContentType());
+
+                assertDoesNotThrow(client.update(c).toCompletableFuture()::join);
+                assertDoesNotThrow(client.create(c).toCompletableFuture()::join);
+                assertDoesNotThrow(client.delete(c).toCompletableFuture()::join);
+            }
+        }).toCompletableFuture().join();
+    }
+
+    @Test
     void testGetInvalidType() {
         final URI uri = URI.create(config.get("solid_resource_uri") + "/playlist");
         final CompletionException err1 = assertThrows(CompletionException.class,

--- a/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
@@ -158,6 +158,26 @@ public class SolidMockHttpService {
             .willReturn(aResponse()
                 .withStatus(204)));
 
+        wireMockServer.stubFor(get(urlEqualTo("/binary"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/plain")
+                .withBody("This is a plain text document.")));
+
+        wireMockServer.stubFor(put(urlEqualTo("/binary"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .withHeader("Content-Type", containing("text/plain"))
+            .withRequestBody(containing(
+                    "This is a plain text document."))
+            .willReturn(aResponse()
+                .withStatus(204)));
+
+        wireMockServer.stubFor(delete(urlEqualTo("/binary"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(204)));
+
         wireMockServer.stubFor(get(urlEqualTo("/nonRDF"))
             .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()

--- a/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class SolidResourceTest {
+class SolidRDFSourceTest {
 
     private static final SolidMockHttpService mockHttpServer = new SolidMockHttpService();
     private static Map<String, String> config = new HashMap<>();
@@ -62,18 +62,18 @@ class SolidResourceTest {
     }
 
     @Test
-    void testGetOfSolidResource() throws IOException, InterruptedException {
+    void testGetOfSolidRDFSource() throws IOException, InterruptedException {
         final URI uri = URI.create(config.get("solid_resource_uri") + "/solid/");
         final Request request =
                 Request.newBuilder().uri(uri).header("Accept", "text/turtle").GET().build();
 
-        final Response<SolidResource> response =
-                client.send(request, SolidResourceHandlers.ofSolidResource()).toCompletableFuture()
+        final Response<SolidRDFSource> response =
+                client.send(request, SolidResourceHandlers.ofSolidRDFSource()).toCompletableFuture()
                         .join();
 
         assertEquals(200, response.statusCode());
 
-        try (final SolidResource resource = response.body()) {
+        try (final SolidRDFSource resource = response.body()) {
             assertEquals(uri, resource.getIdentifier());
             assertTrue(resource.getMetadata().getType().contains(LDP.BasicContainer));
             assertEquals(Optional.of(URI.create("http://storage.example/")),
@@ -96,7 +96,7 @@ class SolidResourceTest {
     }
 
     @Test
-    void testCheckRootOfSolidResource() throws IOException, InterruptedException {
+    void testCheckRootOfSolidRDFSource() throws IOException, InterruptedException {
         final URI uri = URI.create(config.get("solid_resource_uri") + "/");
         final Request request = Request.newBuilder()
             .uri(uri)
@@ -104,14 +104,14 @@ class SolidResourceTest {
             .GET()
             .build();
 
-        final Response<SolidResource> response = client.send(
+        final Response<SolidRDFSource> response = client.send(
             request,
-            SolidResourceHandlers.ofSolidResource()
+            SolidResourceHandlers.ofSolidRDFSource()
         ).toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
 
-        try (final SolidResource resource = response.body()) {
+        try (final SolidRDFSource resource = response.body()) {
             assertEquals(uri, resource.getIdentifier());
             assertTrue(resource.getMetadata().getType().contains(LDP.BasicContainer));
             assertEquals(Optional.of(uri), resource.getMetadata().getStorage());
@@ -151,7 +151,7 @@ class SolidResourceTest {
     @Test
     void testEmptyResourceBuilder() {
         final URI id = URI.create("https://resource.example/");
-        try (final SolidResource res = new SolidResource(id, null, null)) {
+        try (final SolidRDFSource res = new SolidRDFSource(id, null, null)) {
             assertFalse(res.getMetadata().getStorage().isPresent());
             assertTrue(res.getMetadata().getAllowedPatchSyntaxes().isEmpty());
             assertEquals(0, res.size());
@@ -176,13 +176,13 @@ class SolidResourceTest {
         final Request request =
                 Request.newBuilder().uri(uri).header("Accept", "text/turtle").GET().build();
 
-        final Response<SolidResource> response =
-                client.send(request, SolidResourceHandlers.ofSolidResource()).toCompletableFuture()
+        final Response<SolidRDFSource> response =
+                client.send(request, SolidResourceHandlers.ofSolidRDFSource()).toCompletableFuture()
                         .join();
 
         assertEquals(200, response.statusCode());
 
-        try (final SolidResource resource = response.body()) {
+        try (final SolidRDFSource resource = response.body()) {
             assertEquals(uri, resource.getIdentifier());
             assertEquals("application/octet-stream", resource.getMetadata().getContentType());
         }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
@@ -93,7 +93,7 @@ class SolidSyncClientTest {
     void testGetResource() {
         final URI uri = URI.create(config.get("solid_resource_uri") + "/playlist");
 
-        try (final SolidResource resource = client.read(uri, SolidResource.class)) {
+        try (final SolidRDFSource resource = client.read(uri, SolidRDFSource.class)) {
             assertEquals(uri, resource.getIdentifier());
             assertEquals(4, resource.size());
             try (final Stream<? extends Quad> stream = resource.stream(Optional.empty(),

--- a/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
+++ b/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
@@ -20,7 +20,7 @@
  */
 package com.inrupt.client.webid;
 
-import com.inrupt.client.Resource;
+import com.inrupt.client.RDFSource;
 import com.inrupt.client.vocabulary.PIM;
 import com.inrupt.client.vocabulary.RDF;
 import com.inrupt.client.vocabulary.RDFS;
@@ -40,7 +40,7 @@ import org.apache.commons.rdf.api.RDFTerm;
 /**
  * A WebID Profile for use with Solid.
  */
-public class WebIdProfile extends Resource {
+public class WebIdProfile extends RDFSource {
 
     private final IRI rdfType;
     private final IRI oidcIssuer;


### PR DESCRIPTION
This is an alternative to #367 (an improvement IMO)

There are a number of key features of this PR.

In the `com.inrupt.client` package:

* The type hierarchy is more rational: the lowest level resource type is the `Resource` (this becomes an `interface` and is independent of the RDF wrapping, because java does not support multiple inheritance of concrete classes)
* The former `Resource` class is now called `RDFSource` and implements `Resource`. This class extends the RDF Wrapping code.
* There is a new class called `NonRDFSource` which is also implements `Resource`

Classes that previously extended `Resource` will now need to extend `RDFSource`

In the `com.inrupt.client.solid` package:
* There is a `SolidBinary` class that extends `NonRDFSource` in the same way that `SolidResource` extends `RDFSource`. (We could consider some more significant renaming here, but I'm trying to have as light a touch as possible).

Otherwise, the high-level API looks the same.

There is no change to the low-level API.

*Note*: I have not added any Javadocs because I would like an initial review of this API before spending time on docs.