### PR TITLE
JCL-315: Add slf4j logger to rdf4j modules

### DIFF
--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -56,6 +56,11 @@
       <version>${inrupt.commons.rdf4j.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-api</artifactId>
     </dependency>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -51,6 +51,11 @@
       <version>${inrupt.commons.rdf4j.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-rio-api</artifactId>
     </dependency>


### PR DESCRIPTION
This adds the SLF4J API logger dependency to the RDF4J modules.

The issue is that the test code uses RDF4J, but pulls in a different version of the API via transitive dependencies. This allows us to align all those dependencies.