### PR TITLE
consistency in tests in regards to usage of POST

### DIFF
--- a/core/src/test/java/com/inrupt/client/core/DefaultClientTest.java
+++ b/core/src/test/java/com/inrupt/client/core/DefaultClientTest.java
@@ -336,7 +336,7 @@ class DefaultClientTest {
         final String token = generateIdToken(claims);
 
         final Request request = Request.newBuilder()
-                .uri(URI.create(baseUri.get() + "/postString"))
+                .uri(URI.create(baseUri.get() + "/postStringContainer/"))
                 .header("Content-Type", "text/plain")
                 .POST(Request.BodyPublishers.ofString("Test String 1"))
                 .build();
@@ -356,7 +356,7 @@ class DefaultClientTest {
     @Test
     void testOfStringPublisherUmaAnonSession() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
-                .uri(URI.create(baseUri.get() + "/postString"))
+                .uri(URI.create(baseUri.get() + "/postStringContainer/"))
                 .header("Content-Type", "text/plain")
                 .POST(Request.BodyPublishers.ofString("Test String 1"))
                 .build();
@@ -387,7 +387,7 @@ class DefaultClientTest {
         await().atMost(5, SECONDS).until(() -> !s.getCredential(OpenIdSession.ID_TOKEN, null).isPresent());
 
         final Request request = Request.newBuilder()
-                .uri(URI.create(baseUri.get() + "/postString"))
+                .uri(URI.create(baseUri.get() + "/postStringContainer/"))
                 .header("Content-Type", "text/plain")
                 .POST(Request.BodyPublishers.ofString("Test String 1"))
                 .build();

--- a/core/src/test/java/com/inrupt/client/core/MockHttpService.java
+++ b/core/src/test/java/com/inrupt/client/core/MockHttpService.java
@@ -128,7 +128,7 @@ class MockHttpService {
                         .withStatus(401)
                         .withHeader("WWW-Authenticate", "Bearer,DPoP algs=\"ES256\"")));
 
-        wireMockServer.stubFor(post(urlEqualTo("/postString"))
+        wireMockServer.stubFor(post(urlEqualTo("/postStringContainer/"))
                     .atPriority(1)
                     .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withRequestBody(matching("Test String 1"))
@@ -138,7 +138,7 @@ class MockHttpService {
                     .willReturn(aResponse()
                         .withStatus(201)));
 
-        wireMockServer.stubFor(post(urlEqualTo("/postString"))
+        wireMockServer.stubFor(post(urlEqualTo("/postStringContainer/"))
                     .atPriority(2)
                     .withHeader("User-Agent", equalTo(USER_AGENT))
                     .willReturn(aResponse()

--- a/test/src/main/java/com/inrupt/client/test/HttpMockService.java
+++ b/test/src/main/java/com/inrupt/client/test/HttpMockService.java
@@ -83,7 +83,7 @@ class HttpMockService {
                         .withHeader(CONTENT_TYPE, TEXT_TURTLE)
                         .withBodyFile("profileExample.ttl")));
 
-        wireMockServer.stubFor(post(urlEqualTo("/rdf"))
+        wireMockServer.stubFor(post(urlEqualTo("/rdf/"))
                     .withRequestBody(equalTo(
                             "<http://example.test/s> " +
                             "<http://example.test/p> \"object\" ."))

--- a/test/src/main/java/com/inrupt/client/test/HttpServices.java
+++ b/test/src/main/java/com/inrupt/client/test/HttpServices.java
@@ -103,7 +103,7 @@ public class HttpServices {
 
     @Test
     void testPostTriple() throws IOException {
-        final URI uri = URI.create(config.get(HTTP_URI) + "/rdf");
+        final URI uri = URI.create(config.get(HTTP_URI) + "/rdf/");
         final String triple = "<http://example.test/s> <http://example.test/p> \"object\" .";
         final Request request = Request.newBuilder()
                 .uri(uri)


### PR DESCRIPTION
Because Irving just had the same problem that Kay had some time ago about POST and PUT of a NonRDF resource to the server. I know Aaron improved the doc for it, but I also wanted to improve our test code.