### PR TITLE
JCL-297: Add explicit version for spring boot plugin

### DIFF
--- a/examples/springboot/pom.xml
+++ b/examples/springboot/pom.xml
@@ -92,6 +92,7 @@
         <!-- for building a jar -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${springboot.version}</version>
         <executions>
             <execution>
                 <goals>


### PR DESCRIPTION
This ensures that we manage the version of the springboot plug-in. (otherwise, maven just uses the latest version)