### PR TITLE
JCL-318: Fix minor documentation typo

### DIFF
--- a/src/site/apt/client-options.apt.vm
+++ b/src/site/apt/client-options.apt.vm
@@ -116,11 +116,11 @@ public class ClientSample {
 
     Write operations such as <<<POST>>> and <<<PUT>>> will typically contain a request body. The low-level client provides a number of request body publishers for use by developers. These publishers make it easier to translate existing Java objects into HTTP requests. Some existing body publishers include:
 
-      * <<<Request.BodyPublisher.ofString(String)>>> This publisher accepts a <<<String>>> and will convert that into an HTTP request body.
+      * <<<Request.BodyPublishers.ofString(String)>>> This publisher accepts a <<<String>>> and will convert that into an HTTP request body.
 
-      * <<<Request.BodyPublisher.ofInputStream(InputStream)>>> This publisher accepts an <<<InputStream>>>.
+      * <<<Request.BodyPublishers.ofInputStream(InputStream)>>> This publisher accepts an <<<InputStream>>>.
 
-      * <<<Request.BodyPublisher.noBody()>>> This publisher uses an empty body in the HTTP request.
+      * <<<Request.BodyPublishers.noBody()>>> This publisher uses an empty body in the HTTP request.
 
     In addition, when working directly with RDF resources, there are Jena and RDF4J publishers that will serialize an RDF Model as an HTTP request. These handlers are useful in cases where applications are already using an RDF framework. In these cases, <<<JenaBodyPublishers.ofModel(Model, Lang)>>> or <<<RDF4JBodyPublishers.ofModel(Model, RDFFormat)>>> would be used.
 


### PR DESCRIPTION
This fixes a documentation typo in which the class names are missing an `s`