### PR TITLE
JCL-317: Deprecate use of stream in return types

### DIFF
--- a/archetypes/java/src/main/resources/archetype-resources/src/main/java/SolidApp.java
+++ b/archetypes/java/src/main/resources/archetype-resources/src/main/java/SolidApp.java
@@ -29,9 +29,8 @@ public class SolidApp {
         session.getPrincipal().ifPresent(webid -> {
             try (final var profile = client.read(webid, WebIdProfile.class)) {
                 profile.getStorage().stream().findFirst().ifPresent(storage -> {
-                    try (final var container = client.read(storage, SolidContainer.class);
-                            final var stream = container.getContainedResources()) {
-                        stream.map(Resource::getIdentifier).forEach(resources::add);
+                    try (final var container = client.read(storage, SolidContainer.class)) {
+                        container.getResources().forEach(resource -> resources.add(resource.getIdentifier()));
                     }
                 });
             }

--- a/examples/cli/src/main/java/com/inrupt/client/examples/cli/SolidApp.java
+++ b/examples/cli/src/main/java/com/inrupt/client/examples/cli/SolidApp.java
@@ -86,13 +86,12 @@ public class SolidApp implements QuarkusApplication {
                     profile.getStorage().stream().findFirst().ifPresent(storage -> {
                         printWriter.format("Storage %s ", storage);
                         printWriter.println();
-                        try (final var container = client.read(storage, SolidContainer.class);
-                            final var stream = container.getContainedResources()) {
-                            printWriter.format("Total number of contained resources are: %s ",
-                                container.getContainedResources().count());
+                        try (final var container = client.read(storage, SolidContainer.class)) {
+                            final var resources = container.getResources();
+                            printWriter.format("Total number of contained resources is: %s ", resources.size());
                             printWriter.println();
 
-                            stream.filter(r -> filterResource(r, cmd)).forEach(r -> {
+                            resources.stream().filter(r -> filterResource(r, cmd)).forEach(r -> {
                                 printWriter.format("Resource: %s, %s", r.getIdentifier(),
                                     principalType(r.getMetadata().getType()));
                                 printWriter.println();

--- a/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/SolidStorage.java
+++ b/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/SolidStorage.java
@@ -73,10 +73,11 @@ public class SolidStorage {
             return session.read(webid, WebIdProfile.class)
                 .thenCompose(profile -> profile.getStorage().stream().findFirst().map(storage ->
                             session.read(storage, SolidContainer.class).thenApply(container -> {
-                                try (container; final var stream = container.getContainedResources()) {
-                                    final var resources = stream.collect(Collectors.groupingBy(c ->
-                                                getPrincipalType(c.getMetadata().getType()), Collectors.mapping(c ->
-                                                    c.getIdentifier().toString(), Collectors.toList())));
+                                try (container) {
+                                    final var resources = container.getResources().stream()
+                                        .collect(Collectors.groupingBy(c -> getPrincipalType(c.getMetadata().getType()),
+                                                    Collectors.mapping(c -> c.getIdentifier().toString(),
+                                                        Collectors.toList())));
                                     return Templates.profile(profile, resources.get(LDP.BasicContainer),
                                             resources.get(LDP.RDFSource));
                                 }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -165,10 +165,14 @@ class SolidClientTest {
         client.read(uri, SolidContainer.class).thenAccept(container -> {
             try (final SolidContainer c = container) {
                 assertEquals(uri, c.getIdentifier());
-                assertEquals(0, c.getContainedResources().count());
+                assertEquals(0, c.getResources().size());
                 assertEquals(4, c.size());
                 assertEquals(2, c.stream(Optional.empty(), rdf.createIRI(uri.toString()),
                             rdf.createIRI("https://example.com/song"), null).count());
+
+                @SuppressWarnings("deprecation")
+                final long count = c.getContainedResources().count();
+                assertEquals(0, count);
 
                 assertDoesNotThrow(client.update(c).toCompletableFuture()::join);
                 assertDoesNotThrow(client.create(c).toCompletableFuture()::join);

--- a/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
@@ -136,14 +136,18 @@ class SolidRDFSourceTest {
 
         try (final SolidContainer container = response.body()) {
             assertEquals(resource, container.getIdentifier());
-            assertEquals(3, container.getContainedResources().count());
+            assertEquals(3, container.getResources().size());
+
+            @SuppressWarnings("deprecation")
+            final long count = container.getContainedResources().count();
+            assertEquals(3, count);
 
             final Set<URI> uris = new HashSet<>();
             uris.add(URIBuilder.newBuilder(resource).path("test.txt").build());
             uris.add(URIBuilder.newBuilder(resource).path("test2.txt").build());
             uris.add(URIBuilder.newBuilder(resource).path("newContainer/").build());
 
-            container.getContainedResources().forEach(child ->
+            container.getResources().forEach(child ->
                 assertTrue(uris.contains(child.getIdentifier())));
         }
     }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
@@ -138,12 +138,16 @@ class SolidSyncClientTest {
 
         try (final SolidContainer container = client.read(uri, SolidContainer.class)) {
             assertEquals(uri, container.getIdentifier());
-            assertEquals(0, container.getContainedResources().count());
+            assertEquals(0, container.getResources().size());
             assertEquals(4, container.size());
             try (final Stream<? extends Quad> stream = container.stream(Optional.empty(),
                         rdf.createIRI(uri.toString()), rdf.createIRI("https://example.com/song"), null)) {
                 assertEquals(2, stream.count());
             }
+
+            @SuppressWarnings("deprecation")
+            final long count = container.getContainedResources().count();
+            assertEquals(0, count);
 
             assertDoesNotThrow(() -> client.update(container));
             assertDoesNotThrow(() -> client.create(container));


### PR DESCRIPTION
This deprecates the `SolidContainer::getContainedResources` method and adds a new `SolidContainer::getResources` method.

The deprecated method returns a `Stream`, while the new one returns an immutable `Set`. This will make it easier to work with in Kotlin-based systems.