### PR TITLE
JCL-321: Use com.inrupt.client for Maven groupId

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -20,7 +20,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -50,31 +50,31 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
      <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-uma</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -35,7 +35,7 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-commons</artifactId>
       <version>${inrupt.rdf.wrapping.version}</version>
     </dependency>

--- a/archetypes/java/pom.xml
+++ b/archetypes/java/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-archetype-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/archetypes/java/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/java/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-bom</artifactId>
         <version>${inrupt-client-version}</version>
         <type>pom</type>
@@ -37,39 +37,39 @@
 
   <dependencies>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-api</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-solid</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-core</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-okhttp</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-jackson</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-jena</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-openid</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-vocabulary</artifactId>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-webid</artifactId>
     </dependency>
 

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
@@ -19,82 +19,82 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-api</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-accessgrant</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-core</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-okhttp</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-httpclient</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-jackson</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-jena</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-jsonb</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-openid</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-parser</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-rdf4j</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-rdf-legacy</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-solid</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-uma</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-webid</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-vocabulary</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/build-tools/owasp/suppressions.xml
+++ b/build-tools/owasp/suppressions.xml
@@ -4,7 +4,7 @@
     <notes><![CDATA[
         This suppresses a false positive CPE match
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.inrupt/inrupt\-client\-openid@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/com\.inrupt\.client/inrupt\-client\-openid@.*$</packageUrl>
     <cpe>cpe:/a:openid:openid</cpe>
   </suppress>
   <suppress>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -32,12 +32,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-parser</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -99,31 +99,31 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-uma</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jena</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/examples/cli/pom.xml
+++ b/examples/cli/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-examples-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -40,47 +40,47 @@
       <artifactId>quarkus-arc</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-webid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jena</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-solid</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/examples/springboot/pom.xml
+++ b/examples/springboot/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-examples-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -36,47 +36,47 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jena</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-okhttp</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-solid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-webid</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/examples/webapp/pom.xml
+++ b/examples/webapp/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-examples-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -36,32 +36,32 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-webid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jena</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-okhttp</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -71,17 +71,17 @@
       <version>${okhttp.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-solid</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -15,7 +15,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -28,7 +28,7 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-integration-tests</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -20,47 +20,47 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-okhttp</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-jackson</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-jena</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-openid</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-solid</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-vocabulary</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.inrupt</groupId>
+            <groupId>com.inrupt.client</groupId>
             <artifactId>inrupt-client-webid</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-integration-tests</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -16,7 +16,7 @@
   <dependencies>
     <!-- test dependencies -->
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-integration-base-tests</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-integration-tests</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -20,13 +20,13 @@
         <version>${slf4j.version}</version>
     </dependency>
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-uma</artifactId>
         <version>${project.version}</version>
     </dependency>
     <!-- test dependencies -->
     <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-integration-base-tests</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -27,7 +27,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -46,7 +46,7 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -15,7 +15,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -32,13 +32,13 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -15,7 +15,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -32,7 +32,7 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -20,7 +20,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -37,7 +37,7 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -20,7 +20,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -54,13 +54,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.inrupt</groupId>
+  <groupId>com.inrupt.client</groupId>
   <artifactId>inrupt-client</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <name>Inrupt Java Client Libraries</name>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <okhttp.version>4.10.0</okhttp.version>
     <rdf4j.version>4.2.3</rdf4j.version>
     <slf4j.version>2.0.7</slf4j.version>
-    <inrupt.commons.rdf4j.version>0.5.0</inrupt.commons.rdf4j.version>
-    <inrupt.rdf.wrapping.version>0.3.0</inrupt.rdf.wrapping.version>
+    <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
+    <inrupt.rdf.wrapping.version>0.4.0</inrupt.rdf.wrapping.version>
 
     <!-- plugins -->
     <buildhelper.plugin.version>3.3.0</buildhelper.plugin.version>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -51,7 +51,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-commons-rdf4j</artifactId>
       <version>${inrupt.commons.rdf4j.version}</version>
     </dependency>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -46,7 +46,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -132,13 +132,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -46,7 +46,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-commons-rdf4j</artifactId>
       <version>${inrupt.commons.rdf4j.version}</version>
     </dependency>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -41,7 +41,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -118,13 +118,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -13,72 +13,72 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-accessgrant</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jena</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jsonb</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-parser</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-okhttp</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-rdf4j</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-solid</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-uma</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-webid</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -20,12 +20,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -50,19 +50,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-rdf4j</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -15,7 +15,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -20,7 +20,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -56,13 +56,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/vocabulary/pom.xml
+++ b/vocabulary/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
@@ -15,12 +15,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -33,25 +33,25 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-solid</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-rdf4j</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>


### PR DESCRIPTION
This changes the groupId of the client libraries from `com.inrupt` to `com.inrupt.client`