### PR TITLE
JCL-306: added example for working with nested Solid resources

### DIFF
--- a/src/site/apt/data-modeling.apt.vm
+++ b/src/site/apt/data-modeling.apt.vm
@@ -4,6 +4,8 @@ Data Modeling
 
 * What you will need
 
+    * {{{https://start.inrupt.com/profile}A Solid Pod}}
+
     * About 15 minutes
 
     * Your favorite text editor or IDE
@@ -14,162 +16,14 @@ Data Modeling
 
 * How to complete
 
-    The solution involves creating a wrapper class so that your class can act not only as an RDF Graph
-    but also as a domain-specific type.
+    At first you need to know (or choose) how your data is modeled on the Solid Pod.
+    Than one can model your data wite the available domain-specific types of with the class wrapper.
 
-* 1. Subclass the RDFSource type
+* Different data model approaches
 
-    The first step involves ensuring that your class extends the <<<com.inrupt.client.RDFSource>>> class.
-    Afterwards, consider the methods you expect in your class.
+    Let's work with an example to describe the data model options. 
 
-+---
-import com.inrupt.client.RDFSource;
-import java.net.URI;
-import java.util.Set;
-import org.apache.commons.rdf.api.Dataset;
-
-public class Playlist extends RDFSource {
-
-    public Playlist(URI identifier, Dataset dataset) {
-        super(identifier, dataset);
-    }
-
-    public String getTitle() {
-        ...
-    }
-
-    public void setTitle(String title) {
-        ...
-    }
-
-    public Set<URI> getSongs() {
-        ...
-    }
-
-}
-+---
-
-
-* 2. Create the wrapper node
-
-    Next, you will create an inner class that binds the data between RDF and your class.
-
-+---
-import com.inrupt.client.RDFSource;
-import com.inrupt.rdf.wrapping.commons.TermMappings;
-import com.inrupt.rdf.wrapping.commons.ValueMappings;
-import com.inrupt.rdf.wrapping.commons.WrapperIRI;
-import java.net.URI;
-import java.util.Set;
-import org.apache.commons.rdf.api.Dataset;
-import org.apache.commons.rdf.api.Graph;
-import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTerm;
-
-public class Playlist extends RDFSource {
-
-    ...
-
-    static IRI DC_TITLE = rdf.createIRI("http://purl.org/dc/terms/title");
-    static IRI EX_SONG = rdf.createIRI("http://music.example/song");
-
-    class Node extends WrapperIRI {
-        Node(RDFTerm original, Graph graph) {
-            super(original, graph);
-        }
-
-        String getTitle() {
-            return anyOrNull(DC_TITLE, ValueMappings::literalAsString);
-        }
-
-        void setTitle(String value) {
-            overwriteNullable(DC_TITLE, value, TermMappings::asStringLiteral);
-        }
-
-        Set<URI> getSongs() {
-            return objects(EX_SONG, TermMappings::asIri, ValueMappings::iriAsUri);
-        }
-
-    }
-}
-+---
-
-    Your inner class (<<<Node>>> in this example) will have access to a variety of functions
-    to aid in mapping between the underlying RDF Graph and your Java type. {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.html}These methods}} are summarized in the <<<inrupt-rdf-wrapping-commons>>> Javadocs.
-
-    Similarly, the built-in {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/TermMappings.html}TermMappings}}
-    and {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/ValueMappings.html}ValueMappings}}
-    are described in the {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/package-summary.html}Javadocs}} for the <<<inrupt-rdf-wrapping-commons>>> library.
-
-* 3. Connect your public methods to the wrapper node
-
-    Now you are ready to link your public methods to the methods from your inner class.
-
-+---
-import com.inrupt.client.RDFSource;
-import com.inrupt.rdf.wrapping.commons.TermMappings;
-import com.inrupt.rdf.wrapping.commons.ValueMappings;
-import com.inrupt.rdf.wrapping.commons.WrapperIRI;
-import java.net.URI;
-import java.util.Set;
-import org.apache.commons.rdf.api.Dataset;
-import org.apache.commons.rdf.api.Graph;
-import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTerm;
-
-public class Playlist extends RDFSource {
-
-    private Node subject;
-
-    public Playlist(URI identifier, Dataset dataset) {
-        super(identifier, dataset);
-
-        subject = new Node(rdf.createIRI(identifier.toString()), getGraph());
-    }
-
-    public String getTitle() {
-        return subject.getTitle();
-    }
-
-    public void setTitle(String title) {
-        subject.setTitle(title);
-    }
-
-    public Set<URI> getSongs() {
-        return subject.getSongs();
-    }
-
-    ...
-
-+---
-
-* 4. Use your class in the high-level client
-
-    Now, you can use your class with the high-level Solid client, mapping data seamlessly between your
-    Java application and an RDF resource.
-
-+---
-import com.inrupt.client.auth.Session;
-import com.inrupt.client.openid.OpenIdSession;
-import java.net.URI;
-
-public class MyApplication {
-
-    public void run() {
-        Session session = OpenIdSession.ofClientCredentials(issuer, clientId, clientSecret, "client_secret_basic");
-        SolidSyncClient client = SolidSyncClient.getClient().session(session);
-
-        URI uri = URI.create("https://storage.example/playlists/910b509c-1ca5-4d6a-a093-377e8e1b390e");
-        try (Playlist playlist = client.read(uri, Playlist.class)) {
-            System.out.println(playlist.getTitle());
-
-            // Set the playlist title
-            playlist.setTitle(title);
-
-            // Update the playlist in your storage
-            client.update(playlist);
-        }
-    }
-}
-+---
+    We want to model a Book Library on the Pod:
+    * One Solid Resource - we have a Book Library Solid Resource which contains all the book descriptions part of that library it one Solid Resource or
+    * Multiple Solid Resources - we have a Book Library Solid Container which holds more Solid Resources. Each Resource, in turn, contains the description of only one Book.
 

--- a/src/site/apt/data-modeling/multiple-resources.apt.vm
+++ b/src/site/apt/data-modeling/multiple-resources.apt.vm
@@ -1,0 +1,46 @@
+Data Modeling for multiple Solid Resources
+
+* How to complete
+
+    The solution involves working with domain-specific type such as <<<SolidContainer>>> and <<<SolidResource>>>. 
+
+* Working with Solid Containers
+
+    We have to access the contained resources of a Solid Container. We assume that all Solid RDF Resources are Books. 
+
+    You can use a wrapper class (describe on the {{{./one-resource.html}One Solid Resource}} page) with the high-level Solid client, mapping data seamlessly between your Java application and an RDF resource.
+
++---
+import com.inrupt.client.auth.Session;
+import com.inrupt.client.openid.OpenIdSession;
+import com.inrupt.client.solid.SolidContainer;
+import java.net.URI;
+
+public class MyApplication {
+
+    public void run() {
+        Session session = OpenIdSession.ofClientCredentials(issuer, clientId, clientSecret, "client_secret_basic");
+        SolidSyncClient client = SolidSyncClient.getClient().session(session);
+
+        URI uri = URI.create("https://storage.example/booklibrary/");
+        try (final SolidContainer container = client.read(uri, SolidContainer.class)) {
+            final var resources = container.getResources();
+            resources.stream().forEach(r -> {
+                if (!(r.getIdentifier().toString().endsWith("/"))) { //if it ends in a '/' it is a container
+                    try (Playlist playlist = client.read(r.getIdentifier(), Playlist.class)) {
+                        System.out.println(playlist.getTitle());
+
+                        // Set the playlist title
+                        playlist.setTitle(title);
+
+                        // Update the playlist in your storage
+                        client.update(playlist);
+                    }
+                }
+            });
+        }
+        
+    }
+}
++---
+

--- a/src/site/apt/data-modeling/multiple-resources.apt.vm
+++ b/src/site/apt/data-modeling/multiple-resources.apt.vm
@@ -25,7 +25,7 @@ public class MyApplication {
         URI uri = URI.create("https://storage.example/booklibrary/");
         try (final SolidContainer container = client.read(uri, SolidContainer.class)) {
             final var resources = container.getResources();
-            resources.stream().forEach(r -> {
+            resources.forEach(r -> {
                 if (!(r.getIdentifier().toString().endsWith("/"))) { //if it ends in a '/' it is a container
                     final Request req = Request.newBuilder(r.getIdentifier())
                         .HEAD(Request.BodyPublishers.noBody())

--- a/src/site/apt/data-modeling/multiple-resources.apt.vm
+++ b/src/site/apt/data-modeling/multiple-resources.apt.vm
@@ -28,9 +28,10 @@ public class MyApplication {
             resources.forEach(r -> {
                 if (!(r.getIdentifier().toString().endsWith("/"))) { //if it ends in a '/' it is a container
                     final Request req = Request.newBuilder(r.getIdentifier())
-                        .HEAD(Request.BodyPublishers.noBody())
+                        .HEAD()
                         .build();
-                    if (req.headers().firstValue("Content-Type").get().equalsIgnoreCase("text/turtle")) {
+                    final var contentType = req.headers().firstValue("Content-Type");
+                    if (contentType.isPresent() && (contentType.get().toLowerCase().contains("text/turtle"))) {
                         try (Playlist playlist = client.read(r.getIdentifier(), Playlist.class)) {
                             System.out.println(playlist.getTitle());
 

--- a/src/site/apt/data-modeling/multiple-resources.apt.vm
+++ b/src/site/apt/data-modeling/multiple-resources.apt.vm
@@ -27,14 +27,19 @@ public class MyApplication {
             final var resources = container.getResources();
             resources.stream().forEach(r -> {
                 if (!(r.getIdentifier().toString().endsWith("/"))) { //if it ends in a '/' it is a container
-                    try (Playlist playlist = client.read(r.getIdentifier(), Playlist.class)) {
-                        System.out.println(playlist.getTitle());
+                    final Request req = Request.newBuilder(r.getIdentifier())
+                        .HEAD(Request.BodyPublishers.noBody())
+                        .build();
+                    if (req.headers().firstValue("Content-Type").get().equalsIgnoreCase("text/turtle")) {
+                        try (Playlist playlist = client.read(r.getIdentifier(), Playlist.class)) {
+                            System.out.println(playlist.getTitle());
 
-                        // Set the playlist title
-                        playlist.setTitle(title);
+                            // Set the playlist title
+                            playlist.setTitle(title);
 
-                        // Update the playlist in your storage
-                        client.update(playlist);
+                            // Update the playlist in your storage
+                            client.update(playlist);
+                        }
                     }
                 }
             });

--- a/src/site/apt/data-modeling/one-resource.apt.vm
+++ b/src/site/apt/data-modeling/one-resource.apt.vm
@@ -1,0 +1,163 @@
+Data Modeling for one Solid Resource
+
+* How to complete
+
+    The solution involves creating a wrapper class so that your class can act not only as an RDF Graph
+    but also as a domain-specific type.
+
+* 1. Subclass the SolidRDFSource type
+
+    The first step involves ensuring that your class extends the <<<com.inrupt.client.SolidRDFSource>>> class.
+    Afterwards, consider the methods you expect in your class.
+
++---
+import com.inrupt.client.SolidRDFSource;
+import java.net.URI;
+import java.util.Set;
+import org.apache.commons.rdf.api.Dataset;
+
+public class Playlist extends SolidRDFSource {
+
+    public Playlist(URI identifier, Dataset dataset) {
+        super(identifier, dataset);
+    }
+
+    public String getTitle() {
+        ...
+    }
+
+    public void setTitle(String title) {
+        ...
+    }
+
+    public Set<URI> getSongs() {
+        ...
+    }
+
+}
++---
+
+
+* 2. Create the wrapper node
+
+    Next, you will create an inner class that binds the data between RDF and your class.
+
++---
+import com.inrupt.client.SolidRDFSource;
+import com.inrupt.rdf.wrapping.commons.TermMappings;
+import com.inrupt.rdf.wrapping.commons.ValueMappings;
+import com.inrupt.rdf.wrapping.commons.WrapperIRI;
+import java.net.URI;
+import java.util.Set;
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDFTerm;
+
+public class Playlist extends SolidRDFSource {
+
+    ...
+
+    static IRI DC_TITLE = rdf.createIRI("http://purl.org/dc/terms/title");
+    static IRI EX_SONG = rdf.createIRI("http://music.example/song");
+
+    class Node extends WrapperIRI {
+        Node(RDFTerm original, Graph graph) {
+            super(original, graph);
+        }
+
+        String getTitle() {
+            return anyOrNull(DC_TITLE, ValueMappings::literalAsString);
+        }
+
+        void setTitle(String value) {
+            overwriteNullable(DC_TITLE, value, TermMappings::asStringLiteral);
+        }
+
+        Set<URI> getSongs() {
+            return objects(EX_SONG, TermMappings::asIri, ValueMappings::iriAsUri);
+        }
+
+    }
+}
++---
+
+    Your inner class (<<<Node>>> in this example) will have access to a variety of functions
+    to aid in mapping between the underlying RDF Graph and your Java type. {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.html}These methods}} are summarized in the <<<inrupt-rdf-wrapping-commons>>> Javadocs.
+
+    Similarly, the built-in {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/TermMappings.html}TermMappings}}
+    and {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/ValueMappings.html}ValueMappings}}
+    are described in the {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/package-summary.html}Javadocs}} for the <<<inrupt-rdf-wrapping-commons>>> library.
+
+* 3. Connect your public methods to the wrapper node
+
+    Now you are ready to link your public methods to the methods from your inner class.
+
++---
+import com.inrupt.client.SolidRDFSource;
+import com.inrupt.rdf.wrapping.commons.TermMappings;
+import com.inrupt.rdf.wrapping.commons.ValueMappings;
+import com.inrupt.rdf.wrapping.commons.WrapperIRI;
+import java.net.URI;
+import java.util.Set;
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.Graph;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDFTerm;
+
+public class Playlist extends SolidRDFSource {
+
+    private Node subject;
+
+    public Playlist(URI identifier, Dataset dataset) {
+        super(identifier, dataset);
+
+        subject = new Node(rdf.createIRI(identifier.toString()), getGraph());
+    }
+
+    public String getTitle() {
+        return subject.getTitle();
+    }
+
+    public void setTitle(String title) {
+        subject.setTitle(title);
+    }
+
+    public Set<URI> getSongs() {
+        return subject.getSongs();
+    }
+
+    ...
+
++---
+
+* 4. Use your class in the high-level client
+
+    Now, you can use your class with the high-level Solid client, mapping data seamlessly between your
+    Java application and an RDF resource.
+
++---
+import com.inrupt.client.auth.Session;
+import com.inrupt.client.openid.OpenIdSession;
+import java.net.URI;
+
+public class MyApplication {
+
+    public void run() {
+        Session session = OpenIdSession.ofClientCredentials(issuer, clientId, clientSecret, "client_secret_basic");
+        SolidSyncClient client = SolidSyncClient.getClient().session(session);
+
+        URI uri = URI.create("https://storage.example/playlists/910b509c-1ca5-4d6a-a093-377e8e1b390e");
+        try (Playlist playlist = client.read(uri, Playlist.class)) {
+            System.out.println(playlist.getTitle());
+
+            // Set the playlist title
+            playlist.setTitle(title);
+
+            // Update the playlist in your storage
+            client.update(playlist);
+        }
+    }
+}
++---
+

--- a/src/site/apt/data-modeling/one-resource.apt.vm
+++ b/src/site/apt/data-modeling/one-resource.apt.vm
@@ -83,11 +83,11 @@ public class Playlist extends SolidRDFSource {
 +---
 
     Your inner class (<<<Node>>> in this example) will have access to a variety of functions
-    to aid in mapping between the underlying RDF Graph and your Java type. {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.html}These methods}} are summarized in the <<<inrupt-rdf-wrapping-commons>>> Javadocs.
+    to aid in mapping between the underlying RDF Graph and your Java type. {{{https://docs.inrupt.com/developer-tools/api/java/inrupt-client/latest/com/inrupt/rdf/wrapping/commons/package-summary.html}These methods}} are summarized in the <<<inrupt-rdf-wrapping-commons>>> Javadocs.
 
-    Similarly, the built-in {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/TermMappings.html}TermMappings}}
-    and {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/ValueMappings.html}ValueMappings}}
-    are described in the {{{https://javadoc.io/doc/com.inrupt/inrupt-rdf-wrapping-commons/latest/com/inrupt/rdf/wrapping/commons/package-summary.html}Javadocs}} for the <<<inrupt-rdf-wrapping-commons>>> library.
+    Similarly, the built-in {{{https://docs.inrupt.com/developer-tools/api/java/inrupt-client/latest/com/inrupt/rdf/wrapping/commons/TermMappings.html}TermMappings}}
+    and {{{https://docs.inrupt.com/developer-tools/api/java/inrupt-client/latest/com/inrupt/rdf/wrapping/commons/ValueMappings.html}ValueMappings}}
+    are described in the {{{https://docs.inrupt.com/developer-tools/api/java/inrupt-client/latest/com/inrupt/rdf/wrapping/commons/package-summary.html}Javadocs}} for the <<<inrupt-rdf-wrapping-commons>>> library.
 
 * 3. Connect your public methods to the wrapper node
 

--- a/src/site/apt/session-management.apt.vm
+++ b/src/site/apt/session-management.apt.vm
@@ -4,6 +4,8 @@ Session Management
 
 * What you will need
 
+    * {{{https://start.inrupt.com/profile}A Solid Pod}}
+    
     * About 15 minutes
 
     * Your favorite text editor or IDE

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -17,7 +17,10 @@
         <item name="Command Line Apps" href="/sessions/session-clis.html"/>
         <item name="Access Grants" href="/sessions/session-access-grants.html"/>
       </item>
-      <item name="Data Modeling" href="data-modeling.html"/>
+      <item name="Data Modeling" href="data-modeling.html" collapse="true">
+        <item name="One Solid Resource" href="/data-modeling/one-resource.html"/>
+        <item name="Multiple Solid Resources" href="/data-modeling/multiple-resources.html"/>
+      </item>
       <item name="Documentation" href="apidocs/"/>
       <item name="License" href="licenses.html"/>
       <item name="Modules" href="modules.html"/>


### PR DESCRIPTION
In the site documentation, I have added an example for the use case
"I would like to model each book as a separate resource so that I can control access on a per book basis. And then I want to link the books with my library which is also a Solid resource,"

This can be then used in the docs.inrupt.com