### PR TITLE
JCL-324: Warn on OSS Index problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -604,6 +604,7 @@
         </executions>
         <configuration>
           <failBuildOnCVSS>7</failBuildOnCVSS>
+          <ossIndexWarnOnlyOnRemoteErrors>true</ossIndexWarnOnlyOnRemoteErrors>
           <formats>
             <format>HTML</format>
             <format>JSON</format>


### PR DESCRIPTION
The OSS index is periodically unavailable, but this in itself should not cause the builds to fail. This change configures the plugin to warn (not error) in such circumstances.