### PR TITLE
JCL-279: Cache abstraction with Guava and Caffeine implementations

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -57,6 +57,12 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-caffeine</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/api/src/main/java/com/inrupt/client/ClientCache.java
+++ b/api/src/main/java/com/inrupt/client/ClientCache.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client;
+
+/**
+ * A generic caching abstraction for use in the Inrupt Client Libraries.
+ *
+ * @param <T> the key type
+ * @param <U> the value type
+ */
+public interface ClientCache<T, U> {
+
+    /**
+     * Retrieve a cached value.
+     *
+     * @param key the key
+     * @return the cached value, may be {@code null} if not present
+     */
+    U get(T key);
+
+    /**
+     * Set a cached value.
+     *
+     * @param key the key, not {@code null}
+     * @param value the value, not {@code null}
+     */
+    void put(T key, U value);
+
+    /**
+     * Invalidate a single cached value.
+     *
+     * @param key the key, not {@code null}
+     */
+    void invalidate(T key);
+
+    /**
+     * Invalidate all values in the cache.
+     */
+    void invalidateAll();
+}

--- a/api/src/main/java/com/inrupt/client/spi/CacheBuilderService.java
+++ b/api/src/main/java/com/inrupt/client/spi/CacheBuilderService.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.spi;
+
+import com.inrupt.client.ClientCache;
+
+import java.time.Duration;
+
+/**
+ * A cache builder abstraction for use with different cache implementations.
+ */
+public interface CacheBuilderService {
+
+    /**
+     * Build a cache.
+     *
+     * @param maximumSize the maximum cache size
+     * @param expiration the duration after which items should expire from the cache
+     * @param <T> the key type
+     * @param <U> the value type
+     * @return the cache
+     */
+    <T, U> ClientCache<T, U> build(int maximumSize, Duration expiration);
+
+}

--- a/api/src/main/java/com/inrupt/client/spi/NoopCache.java
+++ b/api/src/main/java/com/inrupt/client/spi/NoopCache.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.spi;
+
+import com.inrupt.client.ClientCache;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * A no-op cache implementation.
+ *
+ * @param <T> the key type
+ * @param <U> the value type
+ */
+class NoopCache<T, U> implements ClientCache<T, U> {
+
+    @Override
+    public U get(final T key) {
+        Objects.requireNonNull(key, "cache key may not be null!");
+        return null;
+    }
+
+    @Override
+    public void put(final T key, final U value) {
+        /* no-op */
+        Objects.requireNonNull(key, "cache key may not be null!");
+        Objects.requireNonNull(value, "cache value may not be null!");
+    }
+
+    @Override
+    public void invalidate(final T key) {
+        /* no-op */
+        Objects.requireNonNull(key, "cache key may not be null!");
+    }
+
+    @Override
+    public void invalidateAll() {
+        /* no-op */
+    }
+
+    public static class NoopCacheBuilder implements CacheBuilderService {
+        @Override
+        public <T, U> ClientCache<T, U> build(final int size, final Duration duration) {
+            return new NoopCache<T, U>();
+        }
+    }
+}

--- a/api/src/main/java/com/inrupt/client/spi/ServiceProvider.java
+++ b/api/src/main/java/com/inrupt/client/spi/ServiceProvider.java
@@ -33,6 +33,7 @@ public final class ServiceProvider {
     private static HttpService httpService;
     private static DpopService dpopService;
     private static HeaderParser headerParser;
+    private static CacheBuilderService cacheBuilder;
 
     /**
      * Get the {@link JsonService} for this application.
@@ -120,6 +121,25 @@ public final class ServiceProvider {
             }
         }
         return headerParser;
+    }
+
+    /**
+     * Get the {@link CacheBuilderService} for this application.
+     *
+     * @return a service capable of building a cache.
+     */
+    public static CacheBuilderService getCacheBuilder() {
+        if (cacheBuilder == null) {
+            synchronized (ServiceProvider.class) {
+                if (cacheBuilder != null) {
+                    return cacheBuilder;
+                }
+                final Iterator<CacheBuilderService> iter = ServiceLoader.load(CacheBuilderService.class,
+                        ServiceProvider.class.getClassLoader()).iterator();
+                cacheBuilder = iter.hasNext() ? iter.next() : new NoopCache.NoopCacheBuilder();
+            }
+        }
+        return cacheBuilder;
     }
 
     static <T> T loadSpi(final Class<T> clazz, final ClassLoader cl) {

--- a/api/src/test/java/com/inrupt/client/spi/NoopCacheTest.java
+++ b/api/src/test/java/com/inrupt/client/spi/NoopCacheTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.spi;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.ClientCache;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class NoopCacheTest {
+
+    @Test
+    void testServiceLoader() {
+
+        final CacheBuilderService svc = ServiceProvider.getCacheBuilder();
+        assertTrue(svc instanceof NoopCache.NoopCacheBuilder);
+    }
+
+    @Test
+    void testCacheBuilder() {
+        final CacheBuilderService svc = ServiceProvider.getCacheBuilder();
+        final ClientCache<String, Integer> cache = svc.build(10, Duration.ofMinutes(5));
+
+        cache.put("one", 1);
+        cache.put("two", 2);
+        cache.put("three", 3);
+
+        assertNull(cache.get("zero"));
+        assertNull(cache.get("one"));
+        assertNull(cache.get("two"));
+        assertNull(cache.get("three"));
+
+        cache.invalidate("one");
+        assertNull(cache.get("one"));
+        assertNull(cache.get("two"));
+        assertNull(cache.get("three"));
+
+        cache.invalidateAll();
+        assertNull(cache.get("one"));
+        assertNull(cache.get("two"));
+        assertNull(cache.get("three"));
+    }
+}

--- a/archetypes/java/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/java/src/main/resources/archetype-resources/pom.xml
@@ -46,6 +46,10 @@
     </dependency>
     <dependency>
         <groupId>com.inrupt.client</groupId>
+        <artifactId>inrupt-client-caffeine</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-core</artifactId>
     </dependency>
     <dependency>
@@ -63,6 +67,10 @@
     <dependency>
         <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-openid</artifactId>
+    </dependency>
+    <dependency>
+        <groupId>com.inrupt.client</groupId>
+        <artifactId>inrupt-client-uma</artifactId>
     </dependency>
     <dependency>
         <groupId>com.inrupt.client</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,17 @@
       </dependency>
       <dependency>
         <groupId>com.inrupt.client</groupId>
+        <artifactId>inrupt-client-caffeine</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.inrupt.client</groupId>
+        <artifactId>inrupt-client-guava</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/caffeine/pom.xml
+++ b/caffeine/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.inrupt.client</groupId>
+    <artifactId>inrupt-client</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>inrupt-client-caffeine</artifactId>
+  <name>Inrupt Java Client Libraries - Caffeine Cache</name>
+  <description>
+      Caffeine cache integration for the Inrupt Java Client Libraries.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>${caffeine.version}</version>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables />
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables />
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCache.java
+++ b/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCache.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.caffeine;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.inrupt.client.ClientCache;
+
+import java.util.Objects;
+
+/**
+ * A cache implementation using Caffeine.
+ *
+ * @param <T> the key type
+ * @param <U> the value type
+ */
+public class CaffeineCache<T, U> implements ClientCache<T, U> {
+
+    private final Cache<T, U> cache;
+
+    /**
+     * Wrap an existing caffeine {@link Cache}.
+     *
+     * @param cache the caffeine cache
+     */
+    public CaffeineCache(final Cache<T, U> cache) {
+        this.cache = Objects.requireNonNull(cache, "cache may not be null!");
+    }
+
+    @Override
+    public U get(final T key) {
+        Objects.requireNonNull(key, "cache key may not be null!");
+        return cache.getIfPresent(key);
+    }
+
+    @Override
+    public void put(final T key, final U value) {
+        Objects.requireNonNull(key, "cache key may not be null!");
+        Objects.requireNonNull(value, "cache value may not be null!");
+        cache.put(key, value);
+    }
+
+    @Override
+    public void invalidate(final T key) {
+        Objects.requireNonNull(key, "cache key may not be null!");
+        cache.invalidate(key);
+    }
+
+    @Override
+    public void invalidateAll() {
+        cache.invalidateAll();
+    }
+}

--- a/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCacheBuilder.java
+++ b/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCacheBuilder.java
@@ -36,7 +36,7 @@ public class CaffeineCacheBuilder implements CacheBuilderService {
     public <T, U> ClientCache<T, U> build(final int maximumSize, final Duration duration) {
         return ofCache(Caffeine.newBuilder()
                 .maximumSize(maximumSize)
-                .expireAfterAccess(duration)
+                .expireAfterWrite(duration)
                 .build());
     }
 

--- a/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCacheBuilder.java
+++ b/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCacheBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.caffeine;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.inrupt.client.ClientCache;
+import com.inrupt.client.spi.CacheBuilderService;
+
+import java.time.Duration;
+
+/**
+ * A {@link CacheBuilderService} using a Caffeine-based cache.
+ */
+public class CaffeineCacheBuilder implements CacheBuilderService {
+
+    @Override
+    public <T, U> ClientCache<T, U> build(final int maximumSize, final Duration duration) {
+        return ofCache(Caffeine.newBuilder()
+                .maximumSize(maximumSize)
+                .expireAfterAccess(duration)
+                .build());
+    }
+
+    /**
+     * Create a {@link ClientCache} directly from an existing Caffeine {@link Cache}.
+     *
+     * @param cache the pre-built cache
+     * @param <T> the key type
+     * @param <U> the value type
+     * @return a cache suitable for use in the Inrupt Client libraries
+     */
+    public static <T, U> ClientCache<T, U> ofCache(final Cache<T, U> cache) {
+        return new CaffeineCache<T, U>(cache);
+    }
+}
+
+

--- a/caffeine/src/main/resources/META-INF/services/com.inrupt.client.spi.CacheBuilderService
+++ b/caffeine/src/main/resources/META-INF/services/com.inrupt.client.spi.CacheBuilderService
@@ -1,0 +1,1 @@
+com.inrupt.client.caffeine.CaffeineCacheBuilder

--- a/caffeine/src/test/java/com/inrupt/client/caffeine/CaffeineCacheTest.java
+++ b/caffeine/src/test/java/com/inrupt/client/caffeine/CaffeineCacheTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.caffeine;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.ClientCache;
+import com.inrupt.client.spi.CacheBuilderService;
+import com.inrupt.client.spi.ServiceProvider;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class CaffeineCacheTest {
+
+    @Test
+    void testServiceLoader() {
+
+        final CacheBuilderService svc = ServiceProvider.getCacheBuilder();
+        assertTrue(svc instanceof CaffeineCacheBuilder);
+    }
+
+    @Test
+    void testCacheBuilder() {
+        final CacheBuilderService svc = ServiceProvider.getCacheBuilder();
+        final ClientCache<String, Integer> cache = svc.build(10, Duration.ofMinutes(5));
+
+        cache.put("one", 1);
+        cache.put("two", 2);
+        cache.put("three", 3);
+
+        assertNull(cache.get("zero"));
+        assertEquals(1, cache.get("one"));
+        assertEquals(2, cache.get("two"));
+        assertEquals(3, cache.get("three"));
+
+        cache.invalidate("one");
+        assertNull(cache.get("one"));
+        assertEquals(2, cache.get("two"));
+        assertEquals(3, cache.get("three"));
+
+        cache.invalidateAll();
+        assertNull(cache.get("one"));
+        assertNull(cache.get("two"));
+        assertNull(cache.get("three"));
+    }
+}

--- a/examples/cli/pom.xml
+++ b/examples/cli/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-caffeine</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jena</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/examples/springboot/pom.xml
+++ b/examples/springboot/pom.xml
@@ -62,7 +62,17 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-caffeine</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-uma</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/examples/webapp/pom.xml
+++ b/examples/webapp/pom.xml
@@ -52,6 +52,11 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-caffeine</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jena</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.inrupt.client</groupId>
+    <artifactId>inrupt-client</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>inrupt-client-guava</artifactId>
+  <name>Inrupt Java Client Libraries - Guava Cache</name>
+  <description>
+      Guava cache integration for the Inrupt Java Client Libraries.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables />
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables />
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/guava/src/main/java/com/inrupt/client/guava/GuavaCache.java
+++ b/guava/src/main/java/com/inrupt/client/guava/GuavaCache.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.guava;
+
+import com.google.common.cache.Cache;
+import com.inrupt.client.ClientCache;
+
+import java.util.Objects;
+
+/**
+ * A cache implementation using Guava.
+ *
+ * @param <T> the key type
+ * @param <U> the value type
+ */
+public class GuavaCache<T, U> implements ClientCache<T, U> {
+
+    private final Cache<T, U> cache;
+
+    /**
+     * Wrap an existing guava {@link Cache}.
+     *
+     * @param cache the guava cache
+     */
+    public GuavaCache(final Cache<T, U> cache) {
+        this.cache = Objects.requireNonNull(cache, "cache may not be null!");
+    }
+
+    @Override
+    public U get(final T key) {
+        Objects.requireNonNull(key, "cache key may not be null!");
+        return cache.getIfPresent(key);
+    }
+
+    @Override
+    public void put(final T key, final U value) {
+        Objects.requireNonNull(key, "cache key may not be null!");
+        Objects.requireNonNull(value, "cache value may not be null!");
+        cache.put(key, value);
+    }
+
+    @Override
+    public void invalidate(final T key) {
+        Objects.requireNonNull(key, "cache key may not be null!");
+        cache.invalidate(key);
+    }
+
+    @Override
+    public void invalidateAll() {
+        cache.invalidateAll();
+    }
+}

--- a/guava/src/main/java/com/inrupt/client/guava/GuavaCacheBuilder.java
+++ b/guava/src/main/java/com/inrupt/client/guava/GuavaCacheBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.guava;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.inrupt.client.ClientCache;
+import com.inrupt.client.spi.CacheBuilderService;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link CacheBuilderService} using a Guava-based cache.
+ */
+public class GuavaCacheBuilder implements CacheBuilderService {
+
+    @Override
+    public <T, U> ClientCache<T, U> build(final int maximumSize, final Duration duration) {
+        return ofCache(CacheBuilder.newBuilder()
+                .maximumSize(maximumSize)
+                .expireAfterAccess(duration.getSeconds(), TimeUnit.SECONDS)
+                .build());
+    }
+
+    /**
+     * Create a {@link ClientCache} directly from an existing Guava {@link Cache}.
+     *
+     * @param cache the pre-built cache
+     * @param <T> the key type
+     * @param <U> the value type
+     * @return a cache suitable for use in the Inrupt Client libraries
+     */
+    public static <T, U> ClientCache<T, U> ofCache(final Cache<T, U> cache) {
+        return new GuavaCache<T, U>(cache);
+    }
+}
+
+

--- a/guava/src/main/java/com/inrupt/client/guava/GuavaCacheBuilder.java
+++ b/guava/src/main/java/com/inrupt/client/guava/GuavaCacheBuilder.java
@@ -37,7 +37,7 @@ public class GuavaCacheBuilder implements CacheBuilderService {
     public <T, U> ClientCache<T, U> build(final int maximumSize, final Duration duration) {
         return ofCache(CacheBuilder.newBuilder()
                 .maximumSize(maximumSize)
-                .expireAfterAccess(duration.getSeconds(), TimeUnit.SECONDS)
+                .expireAfterWrite(duration.getSeconds(), TimeUnit.SECONDS)
                 .build());
     }
 

--- a/guava/src/main/resources/META-INF/services/com.inrupt.client.spi.CacheBuilderService
+++ b/guava/src/main/resources/META-INF/services/com.inrupt.client.spi.CacheBuilderService
@@ -1,0 +1,1 @@
+com.inrupt.client.guava.GuavaCacheBuilder

--- a/guava/src/test/java/com/inrupt/client/guava/GuavaCacheTest.java
+++ b/guava/src/test/java/com/inrupt/client/guava/GuavaCacheTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.guava;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.ClientCache;
+import com.inrupt.client.spi.CacheBuilderService;
+import com.inrupt.client.spi.ServiceProvider;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class GuavaCacheTest {
+
+    @Test
+    void testServiceLoader() {
+
+        final CacheBuilderService svc = ServiceProvider.getCacheBuilder();
+        assertTrue(svc instanceof GuavaCacheBuilder);
+    }
+
+    @Test
+    void testCacheBuilder() {
+        final CacheBuilderService svc = ServiceProvider.getCacheBuilder();
+        final ClientCache<String, Integer> cache = svc.build(10, Duration.ofMinutes(5));
+
+        cache.put("one", 1);
+        cache.put("two", 2);
+        cache.put("three", 3);
+
+        assertNull(cache.get("zero"));
+        assertEquals(1, cache.get("one"));
+        assertEquals(2, cache.get("two"));
+        assertEquals(3, cache.get("three"));
+
+        cache.invalidate("one");
+        assertNull(cache.get("one"));
+        assertEquals(2, cache.get("two"));
+        assertEquals(3, cache.get("three"));
+
+        cache.invalidateAll();
+        assertNull(cache.get("one"));
+        assertNull(cache.get("two"));
+        assertNull(cache.get("three"));
+    }
+}

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -55,6 +55,12 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-caffeine</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,12 @@
 
     <!-- dependencies -->
     <antlr.version>4.12.0</antlr.version>
-    <caffeine.version>3.1.2</caffeine.version>
+    <caffeine.version>3.1.5</caffeine.version>
     <commons.codec.version>1.15</commons.codec.version>
     <commons.cli.version>1.5.0</commons.cli.version>
     <commons.io.version>2.11.0</commons.io.version>
     <commons.rdf.version>0.5.0</commons.rdf.version>
+    <guava.version>31.1-jre</guava.version>
     <jackson.version>2.14.2</jackson.version>
     <jakarta.json.version>1.1.6</jakarta.json.version>
     <jena.version>4.7.0</jena.version>
@@ -86,8 +87,10 @@
     <module>access-grant</module>
     <module>api</module>
     <module>bom</module>
+    <module>caffeine</module>
     <module>core</module>
     <module>examples</module>
+    <module>guava</module>
     <module>httpclient</module>
     <module>integration</module>
     <module>jackson</module>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -24,7 +24,17 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-caffeine</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-guava</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -57,6 +57,12 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-guava</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-httpclient</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/uma/src/test/java/com/inrupt/client/uma/UmaClientTest.java
+++ b/uma/src/test/java/com/inrupt/client/uma/UmaClientTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class UmaClientTest {
 
+    private static final UmaClient client = new UmaClient();
     private static final MockAuthorizationServer as = new MockAuthorizationServer();
     private static final Map<String, String> config = new HashMap<>();
     private static final URI ID_TOKEN_CLAIM_TOKEN_FORMAT =
@@ -60,7 +61,6 @@ class UmaClientTest {
     @Test
     void testMetadataAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final Metadata metadata = client.metadata(asUri).toCompletableFuture().join();
         checkMetadata(metadata);
     }
@@ -68,7 +68,6 @@ class UmaClientTest {
     @Test
     void testMetadataNotFoundAsync() {
         final URI asUri = URI.create(config.get("as_uri") + "/not-found");
-        final UmaClient client = new UmaClient();
         final CompletionException err = assertThrows(CompletionException.class,
                 client.metadata(asUri).toCompletableFuture()::join);
         assertTrue(err.getCause() instanceof UmaException);
@@ -77,7 +76,6 @@ class UmaClientTest {
     @Test
     void testMetadataMalformedAsync() {
         final URI asUri = URI.create(config.get("as_uri") + "/malformed");
-        final UmaClient client = new UmaClient();
         final CompletionException err = assertThrows(CompletionException.class,
                 client.metadata(asUri).toCompletableFuture()::join);
         assertTrue(err.getCause() instanceof UmaException);
@@ -86,7 +84,6 @@ class UmaClientTest {
     @Test
     void testSimpleTokenNegotiationInvalidTicketAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final String ticket = "ticket-invalid-grant";
         final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
@@ -104,7 +101,6 @@ class UmaClientTest {
     @Test
     void testSimpleTokenNegotiationRequestDeniedAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final String ticket = "ticket-request-denied";
         final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
@@ -123,7 +119,6 @@ class UmaClientTest {
     @MethodSource
     void testSimpleTokenErrorAsync(final String ticket) {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
         final CompletionException err =
@@ -145,7 +140,6 @@ class UmaClientTest {
     @Test
     void testSimpleTokenInvalidScopeAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final String ticket = "ticket-invalid-scope";
         final TokenRequest req = new TokenRequest(ticket, null, null, null, Arrays.asList("invalid-scope"));
 
@@ -163,7 +157,6 @@ class UmaClientTest {
     @Test
     void testSimpleTokenNegotiationAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final String ticket = "ticket-12345";
         final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
@@ -179,7 +172,6 @@ class UmaClientTest {
     @Test
     void testTokenNegotiationMissingResponseTicketAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final String ticket = "ticket-need-info-no-response-ticket";
         final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
@@ -197,7 +189,6 @@ class UmaClientTest {
     @Test
     void testTokenNegotiationNullResponseAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final String ticket = "ticket-need-info-with-ticket";
         final TokenRequest req = new TokenRequest(ticket, null, null, null, null);
 
@@ -214,7 +205,6 @@ class UmaClientTest {
     @Test
     void testTokenNegotiationOidcMapperAsync() {
         final URI asUri = URI.create(config.get("as_uri"));
-        final UmaClient client = new UmaClient();
         final String idToken = "oidc-id-token";
         final String ticket = "ticket-need-info-oidc-requirement";
         final TokenRequest req = new TokenRequest(ticket, null, null, null, null);


### PR DESCRIPTION
This adds a cache abstraction to the client libraries along with two implementations.

The new interfaces are:

* `com.inrupt.client.ClientCache` - A generalizable cache abstraction with `::get`, `::put` and `::invalidate` methods
* `com.inrupt.client.spi.CacheBuilderService` - A generalizable cache builder with a method defining the size and retention duration

There are two new modules that implement these interfaces:

* Caffeine (`inrupt-client-caffeine`) - this implementation is reportedly faster than guava and has some nice features that we will want to use later
* Guava (`inrupt-client-guava`) - this implementation is widely used and will also work on Android

There is also a no-op implementation for cases where no cache support is desired. The no-op implementation is the default if no other service is registered, which also gives the code backwards compatibility.

This code is integrated into the OpenID, UMA and AccessGrant modules for handling metadata caching.