### PR TITLE
JCL-328: Deprecate UmaSession

### DIFF
--- a/api/src/main/java/com/inrupt/client/auth/package-info.java
+++ b/api/src/main/java/com/inrupt/client/auth/package-info.java
@@ -36,9 +36,9 @@
  * for each implementation. Some examples:
  * 
  * <pre>{@code
-    Session session = OpenIdSession.ofIdToken(token);
-    Session sessionWithConfig = OpenIdSession.ofIdToken(token, config);
-    Session umaSession = UmaSession.of(session);
+    Session openidSession = OpenIdSession.ofIdToken(token);
+    Session openidSessionWithConfig = OpenIdSession.ofIdToken(token, config);
+    Session accessGrantSession = AccessGrantSession.ofAccessGrant(openidSession, accessGrant);
  * }</pre>
  * 
  * <h3>HTTP challenges</h3>

--- a/core/src/main/java/com/inrupt/client/core/package-info.java
+++ b/core/src/main/java/com/inrupt/client/core/package-info.java
@@ -44,7 +44,7 @@
         .POST(Request.BodyPublishers.ofString("Test String 1"))
         .build();
 
-    Response<Void> response = client.session(UmaSession.of(s))
+    Response<Void> response = client
         .send(request, Response.BodyHandlers.discarding())
         .toCompletableFuture().join();
  * }</pre>

--- a/core/src/test/java/com/inrupt/client/core/DefaultClientTest.java
+++ b/core/src/test/java/com/inrupt/client/core/DefaultClientTest.java
@@ -36,7 +36,6 @@ import com.inrupt.client.jena.JenaBodyHandlers;
 import com.inrupt.client.jena.JenaBodyPublishers;
 import com.inrupt.client.openid.OpenIdConfig;
 import com.inrupt.client.openid.OpenIdSession;
-import com.inrupt.client.uma.UmaSession;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -206,10 +205,10 @@ class DefaultClientTest {
         claims.put("azp", AZP);
         claims.put("cnf", Collections.singletonMap("jkt", ecJwk.calculateBase64urlEncodedThumbprint(SHA_256)));
         final String token = generateIdToken(claims);
-        final Session session = UmaSession.of(OpenIdSession.ofIdToken(token, config));
+        final Session session = OpenIdSession.ofIdToken(token, config);
         assertEquals(Optional.of(URI.create(WEBID)), session.getPrincipal());
 
-        final Session session2 = UmaSession.of();
+        final Session session2 = Session.anonymous();
         assertFalse(session2.getPrincipal().isPresent());
         assertNotEquals(session2.getId(), session.getId());
         assertFalse(session2.generateProof(null, null).isPresent());
@@ -327,7 +326,7 @@ class DefaultClientTest {
     }
 
     @Test
-    void testOfStringPublisherUmaSession() throws IOException, InterruptedException {
+    void testOfStringPublisherOpenidSession() throws IOException, InterruptedException {
         final Map<String, Object> claims = new HashMap<>();
         claims.put("webid", WEBID);
         claims.put("sub", SUB);
@@ -346,7 +345,7 @@ class DefaultClientTest {
         config.setProofKeyPairs(Collections.singletonMap("RS256",
                     new KeyPair(jwk.getPublicKey(), jwk.getPrivateKey())));
 
-        final Response<Void> response = client.session(UmaSession.of(OpenIdSession.ofIdToken(token, config)))
+        final Response<Void> response = client.session(OpenIdSession.ofIdToken(token, config))
             .send(request, Response.BodyHandlers.discarding())
             .toCompletableFuture().join();
 
@@ -361,7 +360,7 @@ class DefaultClientTest {
                 .POST(Request.BodyPublishers.ofString("Test String 1"))
                 .build();
 
-        final Response<Void> response = client.session(UmaSession.of())
+        final Response<Void> response = client.session(Session.anonymous())
             .send(request, Response.BodyHandlers.discarding())
             .toCompletableFuture().join();
 
@@ -375,7 +374,7 @@ class DefaultClientTest {
     }
 
     @Test
-    void testUmaSessionExpiredIdToken() throws Exception {
+    void testSessionExpiredIdToken() throws Exception {
         final Map<String, Object> claims = new HashMap<>();
         claims.put("webid", WEBID);
         claims.put("sub", SUB);
@@ -398,7 +397,7 @@ class DefaultClientTest {
                 .POST(Request.BodyPublishers.ofString("Test String 1"))
                 .build();
 
-        final Response<Void> response = client.session(UmaSession.of(s))
+        final Response<Void> response = client.session(s)
             .send(request, Response.BodyHandlers.discarding())
             .toCompletableFuture().join();
 

--- a/uma/src/main/java/com/inrupt/client/uma/UmaSession.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaSession.java
@@ -38,7 +38,10 @@ import java.util.concurrent.CompletionStage;
 
 /**
  * A session implementation for use with UMA Authorization Servers.
+ *
+ * @deprecated As of Beta3, this class is deprecated
  */
+@Deprecated
 public final class UmaSession implements Session {
 
     private final String id;

--- a/uma/src/main/java/com/inrupt/client/uma/package-info.java
+++ b/uma/src/main/java/com/inrupt/client/uma/package-info.java
@@ -23,23 +23,10 @@
  *
  * <p>UMA builds on the OAuth 2.0 authorization framework, defining a mechanism by which
  * a client can iteratively negotiate for an access token.
- * 
+ *
  * <p>{@code UmaClient} helps in the interaction with different endpoints, to construct helper
  * requests for authentication and to negotiate for a token.
- * 
- * <h3>Using a UMA session</h3>
  *
- * <p>This module has a session implementation, {@code UmaSession}, for use with UMA Authorization Servers.
- *
- * <p>This session implementation can be used to wrap other session objects, such as
- * ones that use OpenID Connect tokens.
- *
- * <pre>{@code
- *   Client client = ClientProvider.getClient();
- *   Session session = client.session(UmaSession.ofSession(OpenIdSession.ofIdToken(jwt)));
- *   Response res = session.send(req, bodyHandler);
- * }</pre>
- * 
  * <h3>Discovering the UMA configuration</h3>
  * 
  * <pre>{@code


### PR DESCRIPTION
While the `UmaAuthenticationProvider` is used extensively, the `UmaSession` is not really used at all.

Initially, the thought was that the `UmaSession` object would be used to wrap other session objects to make them usable in the context of UMA, but that's not how these APIs evolved. Now, the `UmaSession` is entirely superfluous.