### PR TITLE
JCL-330: Checkstyle configuration for Windows

### DIFF
--- a/build-tools/checkstyle/suppressions.xml
+++ b/build-tools/checkstyle/suppressions.xml
@@ -13,6 +13,6 @@
   <suppress checks="[a-zA-Z0-9]+" files="target[/\\]generated-sources"/>
   <suppress checks="[a-zA-Z0-9]+" files="target[/\\]generated-test-sources"/>
   <!-- allow GET/HEAD/POST methods -->
-  <suppress checks="MethodName" files="src/main/java/com/inrupt/client/Request.java"/>
+  <suppress checks="MethodName" files="src[/\\]main[/\\]java[/\\]com[/\\]inrupt[/\\]client[/\\]Request.java"/>
 </suppressions>
 


### PR DESCRIPTION
This adjusts the checkstyle path configuration to work with Windows-based paths