### PR TITLE
JCL-331: Convenience modules for integrators

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -90,6 +90,11 @@
       </dependency>
       <dependency>
         <groupId>com.inrupt.client</groupId>
+        <artifactId>inrupt-client-runtime</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-solid</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/integration/openid/src/main/java/com/inrupt/client/integration/openid/package-info.java
+++ b/integration/openid/src/main/java/com/inrupt/client/integration/openid/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * <h2>Integration testing for the OpenID module.</h2>
+ */
+package com.inrupt.client.integration.openid;

--- a/integration/uma/src/main/java/com/inrupt/client/integration/uma/package-info.java
+++ b/integration/uma/src/main/java/com/inrupt/client/integration/uma/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * <h2>Integration testing for the UMA module.</h2>
+ */
+package com.inrupt.client.integration.uma;

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
     <module>examples</module>
     <module>guava</module>
     <module>httpclient</module>
-    <module>integration</module>
     <module>jackson</module>
     <module>jena</module>
     <module>jsonb</module>
@@ -101,12 +100,14 @@
     <module>parser</module>
     <module>rdf4j</module>
     <module>rdf-legacy</module>
-    <module>reports</module>
     <module>solid</module>
     <module>test</module>
     <module>uma</module>
     <module>webid</module>
     <module>vocabulary</module>
+    <module>runtime</module>
+    <module>integration</module>
+    <module>reports</module>
     <module>archetypes</module>
   </modules>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>inrupt-client-report</artifactId>
-  <name>Inrupt Java Client Libraries - Report</name>
-  <packaging>pom</packaging>
+  <artifactId>inrupt-client-runtime</artifactId>
+  <name>Inrupt Java Client Libraries - Runtime Modules</name>
+  <description>
+    An artifact that references the standard Inrupt Java Client Libraries with a single dependency.
+  </description>
 
   <dependencies>
     <dependency>
@@ -34,7 +38,7 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-guava</artifactId>
+      <artifactId>inrupt-client-okhttp</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -49,42 +53,7 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-jsonb</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-openid</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-parser</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-okhttp</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-httpclient</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-rdf4j</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-rdf-legacy</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt.client</groupId>
-      <artifactId>inrupt-client-runtime</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -102,21 +71,10 @@
       <artifactId>inrupt-client-webid</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-vocabulary</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/runtime/src/main/java/com/inrupt/client/runtime/package-info.java
+++ b/runtime/src/main/java/com/inrupt/client/runtime/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+/**
+ * <h2>Convenience distribution of the Inrupt Java Client modules as a single dependency.</h2>
+ */
+package com.inrupt.client.runtime;
+


### PR DESCRIPTION
While a modular codebase is very useful and flexible, it also makes it harder for someone who is new to the system to know where to begin.

This PR introduces a new artifact to make this easier:

* `inrupt-client-runtime` -- an application developer can include this dependency in an application, and all of the recommended runtime libraries will be included.

~~* `inrupt-client-minimal` -- a library developer can include this dependency in their code. It is just like `inrupt-client-all` except it does not include the runtime modules.~~

