### PR TITLE
JCL 339: Upgrade JsonB module to use Jakarta EE 10

### DIFF
--- a/build-tools/checkstyle/checkstyle.xml
+++ b/build-tools/checkstyle/checkstyle.xml
@@ -52,7 +52,7 @@
       <property name="sortStaticImportsAlphabetically" value="true"/>
       <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
       <property name="separated" value="true"/>
-      <property name="groups" value="com,io,jakarta,java,javax,org"/>
+      <property name="groups" value="com,io,jakarta,java,org"/>
     </module>
 
     <module name="ModifierOrder">

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
-      <version>${jakarta.json.version}</version>
+      <version>${glassfish.json.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jsonb/src/main/java/com/inrupt/client/jsonb/JsonbService.java
+++ b/jsonb/src/main/java/com/inrupt/client/jsonb/JsonbService.java
@@ -22,17 +22,17 @@ package com.inrupt.client.jsonb;
 
 import com.inrupt.client.spi.JsonService;
 
+import jakarta.json.JsonException;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbConfig;
+import jakarta.json.bind.JsonbException;
+import jakarta.json.bind.config.PropertyNamingStrategy;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
-
-import javax.json.JsonException;
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbConfig;
-import javax.json.bind.JsonbException;
-import javax.json.bind.config.PropertyNamingStrategy;
 
 /**
  * A {@link JsonService} using the JakartaEE JSON Bind API.

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <commons.rdf.version>0.5.0</commons.rdf.version>
     <guava.version>31.1-jre</guava.version>
     <jackson.version>2.14.2</jackson.version>
-    <jakarta.json.version>2.0.1</jakarta.json.version>
+    <jakarta.json.version>2.1.1</jakarta.json.version>
     <jena.version>4.7.0</jena.version>
     <jose4j.version>0.9.3</jose4j.version>
     <json.bind.version>3.0.0</json.bind.version>
@@ -69,6 +69,7 @@
     <!-- testing -->
     <awaitility.version>4.2.0</awaitility.version>
     <equalsverifier.version>3.14.1</equalsverifier.version>
+    <glassfish.json.version>2.0.1</glassfish.json.version>
     <junit.version>5.9.2</junit.version>
     <yasson.version>3.0.3</yasson.version>
     <wiremock.version>2.35.0</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,10 @@
     <commons.rdf.version>0.5.0</commons.rdf.version>
     <guava.version>31.1-jre</guava.version>
     <jackson.version>2.14.2</jackson.version>
-    <jakarta.json.version>1.1.6</jakarta.json.version>
+    <jakarta.json.version>2.0.1</jakarta.json.version>
     <jena.version>4.7.0</jena.version>
     <jose4j.version>0.9.3</jose4j.version>
-    <json.bind.version>1.0.2</json.bind.version>
+    <json.bind.version>3.0.0</json.bind.version>
     <okhttp.version>4.10.0</okhttp.version>
     <rdf4j.version>4.2.3</rdf4j.version>
     <slf4j.version>2.0.7</slf4j.version>
@@ -70,7 +70,7 @@
     <awaitility.version>4.2.0</awaitility.version>
     <equalsverifier.version>3.14.1</equalsverifier.version>
     <junit.version>5.9.2</junit.version>
-    <yasson.version>1.0.3</yasson.version>
+    <yasson.version>3.0.3</yasson.version>
     <wiremock.version>2.35.0</wiremock.version>
 
     <!-- disable by default (enabled by profile in CI) -->

--- a/src/site/apt/sessions/session-web-applications.apt.vm
+++ b/src/site/apt/sessions/session-web-applications.apt.vm
@@ -43,10 +43,10 @@ Web Applications
 +---
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.openid.OpenIdSession;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import io.quarkus.oidc.IdToken;
 


### PR DESCRIPTION
I had to change `<jakarta.json.version>` from 1.1.6 to 2.0.1 (which was the most recent and popular version that didn't cause conflicts). This wasn't explicitly mentioned in the ticket but the package `jakarta.json.JsonException` wasn't recognised in 1.1.6. Would appreciate any feedback as I'm unsure which version would be most appropriate. 