### PR TITLE
JCL-341: Omit Accept Turtle header when reading non-RDF resources

### DIFF
--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -123,7 +123,9 @@ public class SolidClient {
         decorateHeaders(builder, defaultHeaders);
         decorateHeaders(builder, headers);
 
-        builder.setHeader(ACCEPT, TEXT_TURTLE);
+        if (RDFSource.class.isAssignableFrom(clazz)) {
+            builder.setHeader(ACCEPT, TEXT_TURTLE);
+        }
 
         defaultHeaders.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
         headers.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));

--- a/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
@@ -159,6 +159,14 @@ public class SolidMockHttpService {
                 .withStatus(204)));
 
         wireMockServer.stubFor(get(urlEqualTo("/binary"))
+            .atPriority(1)
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .withHeader("Accept", containing("text/turtle"))
+            .willReturn(aResponse()
+                .withStatus(406)));
+
+        wireMockServer.stubFor(get(urlEqualTo("/binary"))
+            .atPriority(2)
             .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()
                 .withStatus(200)


### PR DESCRIPTION
At present, the `SolidClient::read` sends an `Accept: text/turtle` header for all requests. This is incorrect for non-RDF resources, which may respond with a 406 Not Acceptable to such requests.