### PR TITLE
JCL-342: Use correct data subject property for access requests

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -103,7 +103,12 @@ public class AccessGrant {
                 final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
                 final Optional<URI> controller = asUri(consent.get("isProvidedToController"));
                 final Optional<URI> other = asUri(consent.get("isProvidedTo"));
-                this.grantee = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
+                final Optional<URI> dataSubject = asUri(consent.get("isConsentForDataSubject"));
+                if (subject.containsKey("hasConsent")) {
+                    this.grantee = dataSubject.orElse(null);
+                } else {
+                    this.grantee = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
+                }
                 this.modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
                 this.resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -175,6 +175,9 @@ public class AccessGrantClient {
      */
     public CompletionStage<AccessGrant> issue(final URI type, final URI agent, final Set<URI> resources,
             final Set<String> modes, final Set<String> purposes, final Instant expiration) {
+        Objects.requireNonNull(type, "Access Grant type may not be null!");
+        Objects.requireNonNull(resources, "Resources may not be null!");
+        Objects.requireNonNull(modes, "Access modes may not be null!");
         return v1Metadata().thenCompose(metadata -> {
             final Map<String, Object> data;
             if (ACCESS_GRANT.equals(type)) {
@@ -522,6 +525,7 @@ public class AccessGrantClient {
 
     static Map<String, Object> buildAccessGrantv1(final URI agent, final Set<URI> resources, final Set<String> modes,
             final Instant expiration, final Set<String> purposes) {
+        Objects.requireNonNull(agent, "Access grant agent may not be null!");
         final Map<String, Object> consent = new HashMap<>();
         consent.put(MODE, modes);
         consent.put(HAS_STATUS, "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven");
@@ -536,7 +540,9 @@ public class AccessGrantClient {
 
         final Map<String, Object> credential = new HashMap<>();
         credential.put(CONTEXT, Arrays.asList(VC_CONTEXT_URI, INRUPT_CONTEXT_URI));
-        credential.put("expirationDate", expiration.truncatedTo(ChronoUnit.SECONDS).toString());
+        if (expiration != null) {
+            credential.put("expirationDate", expiration.truncatedTo(ChronoUnit.SECONDS).toString());
+        }
         credential.put(CREDENTIAL_SUBJECT, subject);
 
         final Map<String, Object> data = new HashMap<>();
@@ -547,10 +553,12 @@ public class AccessGrantClient {
     static Map<String, Object> buildAccessRequestv1(final URI agent, final Set<URI> resources, final Set<String> modes,
             final Instant expiration, final Set<String> purposes) {
         final Map<String, Object> consent = new HashMap<>();
-        consent.put(MODE, modes);
         consent.put(HAS_STATUS, "https://w3id.org/GConsent#ConsentStatusRequested");
+        consent.put(MODE, modes);
         consent.put(FOR_PERSONAL_DATA, resources);
-        consent.put(IS_PROVIDED_TO_PERSON, agent);
+        if (agent != null) {
+            consent.put("isConsentForDataSubject", agent);
+        }
         if (!purposes.isEmpty()) {
             consent.put("forPurpose", purposes);
         }
@@ -560,7 +568,9 @@ public class AccessGrantClient {
 
         final Map<String, Object> credential = new HashMap<>();
         credential.put(CONTEXT, Arrays.asList(VC_CONTEXT_URI, INRUPT_CONTEXT_URI));
-        credential.put("expirationDate", expiration.truncatedTo(ChronoUnit.SECONDS).toString());
+        if (expiration != null) {
+            credential.put("expirationDate", expiration.truncatedTo(ChronoUnit.SECONDS).toString());
+        }
         credential.put(CREDENTIAL_SUBJECT, subject);
 
         final Map<String, Object> data = new HashMap<>();

--- a/access-grant/src/test/resources/vc-5.json
+++ b/access-grant/src/test/resources/vc-5.json
@@ -19,7 +19,7 @@
         "hasConsent":{
             "mode":["Read","Append"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
-            "isProvidedToPerson":"https://id.test/agent",
+            "isConsentForDataSubject":"https://id.test/agent",
             "forPurpose":["https://purpose.test/Purpose1"],
             "forPersonalData":["https://storage.test/data/"]}},
     "proof":{


### PR DESCRIPTION
The AccessRequest data model uses the property `isConsentForDataSubject`, as described in the [documentation](https://docs.inrupt.com/ess/latest/services/service-access-grant-issuer/#access-request).

This changes the generation of an access request to follow that structure.