### PR TITLE
JCL-345: Add antlr dependency to JCL BOM artifact

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -120,6 +120,11 @@
         <artifactId>okhttp</artifactId>
         <version>${okhttp.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr4-runtime</artifactId>
+        <version>${antlr.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
Without this, one has to explicitly include the antlr runtime dependency version in their code or else they see these sorts of warnings:

```
ANTLR Tool version 4.12.0 used for code generation does not match the current runtime version 4.10.1
ANTLR Runtime version 4.12.0 used for parser compilation does not match the current runtime version 4.10.1
```
