### PR TITLE
JCL-340: Pluralize getter names in WebIdProfile class

### DIFF
--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -62,6 +62,12 @@
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
+++ b/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
@@ -66,8 +66,19 @@ public class WebIdProfile extends RDFSource {
      * Retrieve the RDF type values.
      *
      * @return the {@code rdf:type} values
+     * @deprecated use the {@link #getTypes} method
      */
+    @Deprecated
     public Set<URI> getType() {
+        return getTypes();
+    }
+
+    /**
+     * Retrieve the RDF type values.
+     *
+     * @return the {@code rdf:type} values
+     */
+    public Set<URI> getTypes() {
         return new Node(rdf.createIRI(getIdentifier().toString()), getGraph()).getType();
     }
 
@@ -75,8 +86,19 @@ public class WebIdProfile extends RDFSource {
      * Retrieve the list of OIDC issuers.
      *
      * @return the {@code solid:oidcIssuer} values
+     * @deprecated use the {@link #getOidcIssuers} method
      */
+    @Deprecated
     public Set<URI> getOidcIssuer() {
+        return getOidcIssuers();
+    }
+
+    /**
+     * Retrieve the list of OIDC issuers.
+     *
+     * @return the {@code solid:oidcIssuer} values
+     */
+    public Set<URI> getOidcIssuers() {
         return new Node(rdf.createIRI(getIdentifier().toString()), getGraph()).getOidcIssuer();
     }
 
@@ -84,8 +106,19 @@ public class WebIdProfile extends RDFSource {
      * Retrieve the list of related profile resources.
      *
      * @return the {@code rdfs:seeAlso} values
+     * @deprecated use the {@link #relatedResources} method
      */
+    @Deprecated
     public Set<URI> getSeeAlso() {
+        return getRelatedResources();
+    }
+
+    /**
+     * Retrieve the list of related profile resources.
+     *
+     * @return the {@code rdfs:seeAlso} values
+     */
+    public Set<URI> getRelatedResources() {
         return new Node(rdf.createIRI(getIdentifier().toString()), getGraph()).getSeeAlso();
     }
 
@@ -93,8 +126,19 @@ public class WebIdProfile extends RDFSource {
      * Retrieve the list of storage locations.
      *
      * @return the {@code pim:storage} values
+     * @deprecated use the {@link #getStorages} method
      */
+    @Deprecated
     public Set<URI> getStorage() {
+        return getStorages();
+    }
+
+    /**
+     * Retrieve the list of storage locations.
+     *
+     * @return the {@code pim:storage} values
+     */
+    public Set<URI> getStorages() {
         return new Node(rdf.createIRI(getIdentifier().toString()), getGraph()).getStorage();
     }
 

--- a/webid/src/test/java/com/inrupt/client/webid/WebIdMockHttpService.java
+++ b/webid/src/test/java/com/inrupt/client/webid/WebIdMockHttpService.java
@@ -25,8 +25,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
-import java.util.Map;
-
 public class WebIdMockHttpService {
 
     private final WireMockServer wireMockServer;
@@ -56,12 +54,12 @@ public class WebIdMockHttpService {
         );
     }
 
-    public Map<String, String> start() {
+    public String start() {
         wireMockServer.start();
 
         setupMocks();
 
-        return Map.of("webid_uri", wireMockServer.baseUrl());
+        return wireMockServer.baseUrl();
     }
 
     public void stop() {

--- a/webid/src/test/java/com/inrupt/client/webid/WebIdProfileTest.java
+++ b/webid/src/test/java/com/inrupt/client/webid/WebIdProfileTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.webid;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.solid.SolidSyncClient;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class WebIdProfileTest {
+
+    private static final URI AGENT = URI.create("http://xmlns.test/foaf/0.1/Agent");
+    private static final URI SEE_ALSO = URI.create("https://storage.example.test/storage-id/extendedProfile");
+    private static final URI ISSUER = URI.create("https://login.example.test");
+    private static final URI STORAGE = URI.create("https://storage.example.test/storage-id/");
+
+    private static final WebIdMockHttpService mockHttpServer = new WebIdMockHttpService();
+    private static final SolidSyncClient client = SolidSyncClient.getClient();
+    private static String baseUrl;
+
+    @BeforeAll
+    static void setup() {
+        baseUrl = mockHttpServer.start();
+    }
+
+    @AfterAll
+    static void teardown() {
+        mockHttpServer.stop();
+    }
+
+    @Test
+    void testGetProfileSlash() {
+        final URI uri = URI.create(baseUrl + "/webId");
+        try (final WebIdProfile profile = client.read(uri, WebIdProfile.class)) {
+            assertEquals(uri, profile.getIdentifier());
+            assertTrue(profile.getTypes().contains(AGENT));
+            assertTrue(profile.getRelatedResources().contains(SEE_ALSO));
+            assertTrue(profile.getOidcIssuers().contains(ISSUER));
+            assertTrue(profile.getStorages().contains(STORAGE));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void testGetProfileSlashDeprecatedMethods() {
+        final URI uri = URI.create(baseUrl + "/webId");
+        try (final WebIdProfile profile = client.read(uri, WebIdProfile.class)) {
+            assertEquals(uri, profile.getIdentifier());
+            assertTrue(profile.getType().contains(AGENT));
+            assertTrue(profile.getSeeAlso().contains(SEE_ALSO));
+            assertTrue(profile.getOidcIssuer().contains(ISSUER));
+            assertTrue(profile.getStorage().contains(STORAGE));
+        }
+    }
+
+    @Test
+    void testGetProfileHash() {
+        final URI uri = URI.create(baseUrl + "/webIdHash#me");
+        try (final WebIdProfile profile = client.read(uri, WebIdProfile.class)) {
+            assertEquals(uri, profile.getIdentifier());
+            assertTrue(profile.getTypes().contains(AGENT));
+            assertTrue(profile.getRelatedResources().contains(SEE_ALSO));
+            assertTrue(profile.getOidcIssuers().contains(ISSUER));
+            assertTrue(profile.getStorages().contains(STORAGE));
+        }
+    }
+}


### PR DESCRIPTION
This deprecates the existing (singular) getter methods on the WebIdProfile class, replacing them with plural equivalents.

The one method that didn't have an obvious plural was `getSeeAlso`, which I replaced with `getRelatedResources`. I am not wedded to that name, if someone comes up with a better one.

Also, it appeared that there was insufficient testing of this class, so I added complete testing of the WebIdProfile class.

