### PR TITLE
JCL-340: Use correct method name in javadocs

### DIFF
--- a/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
+++ b/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
@@ -106,7 +106,7 @@ public class WebIdProfile extends RDFSource {
      * Retrieve the list of related profile resources.
      *
      * @return the {@code rdfs:seeAlso} values
-     * @deprecated use the {@link #relatedResources} method
+     * @deprecated use the {@link #getRelatedResources} method
      */
     @Deprecated
     public Set<URI> getSeeAlso() {


### PR DESCRIPTION
The javadocs refer to an invalid method name.