### PR TITLE
JCL-350: Better use of GH Environments for CI/CD workflows

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -11,8 +11,10 @@ on:
 
 jobs:
   publish:
-    name: Build and deploy
+    name: Deploy artifacts
     runs-on: ubuntu-latest
+    environment:
+      name: "Sonatype"
 
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +36,7 @@ jobs:
 
       - name: Deploy Artifacts
         run: mvn deploy -P publish
-        if: github.actor != 'dependabot[bot]'
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_REPO_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
@@ -46,6 +48,9 @@ jobs:
   site:
     name: Publish version-specific site
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    environment:
+      name: "Github Pages"
 
     steps:
       - uses: actions/checkout@v3
@@ -70,7 +75,7 @@ jobs:
 
       - name: Publish tagged site to GitHub pages
         uses: peaceiris/actions-gh-pages@v3
-        if: github.actor != 'dependabot[bot]' && startsWith(github.event.ref, 'refs/tags/inrupt-client')
+        if: ${{ startsWith(github.event.ref, 'refs/tags/inrupt-client') }}
         with:
           keep_files: true
           publish_dir: ./target/staging/
@@ -78,7 +83,6 @@ jobs:
 
       - name: Publish versioned site to GitHub pages
         uses: peaceiris/actions-gh-pages@v3
-        if: github.actor != 'dependabot[bot]'
         with:
           keep_files: true
           publish_dir: ./target/staging/

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -8,18 +8,9 @@ jobs:
   build:
     name: Java environment
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ matrix.environment-name }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        environment-name: ["ESS PodSpaces"]
         java: [ 11, 17 ]
-        experimental: [false]
-        include:
-          - environment-name: "ESS DevNext"
-            java: 11
-            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -34,15 +25,24 @@ jobs:
       - name: Build the code with Maven
         run: mvn -B -ntp install -Pci -pl -integration/uma,-integration/openid
 
-      - name: Integration tests (${{ matrix.environment-name }})
-        run: mvn -B -ntp verify -Pci -pl integration/uma,integration/openid
+      - name: Prod Integration tests
         if: ${{ github.actor != 'dependabot[bot]' }}
-        # for integration tests
+        run: mvn -B -ntp verify -Pci -pl integration/uma,integration/openid
         env:
-          inrupt.test-webid: ${{ secrets.INRUPT_TEST_WEBID }}
-          inrupt.test.public-resource-path: ${{ secrets.INRUPT_TEST_PUBLIC_RESOURCE_PATH }}
-          inrupt.test.client-id: ${{ secrets.INRUPT_TEST_CLIENT_ID }}
-          inrupt.test.client-secret: ${{ secrets.INRUPT_TEST_CLIENT_SECRET }}
+          INRUPT_TEST_WEBID: ${{ secrets.INRUPT_PROD_WEBID }}
+          INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_PROD_PUBLIC_RESOURCE_PATH }}
+          INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_PROD_CLIENT_ID }}
+          INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_CLIENT_SECRET }}
+
+      - name: Dev Integration tests
+        if: ${{ github.actor != 'dependabot[bot]' && matrix.java-version == 11 }}
+        continue-on-error: true
+        run: mvn -B -ntp verify -Pci -pl integration/uma,integration/openid
+        env:
+          INRUPT_TEST_WEBID: ${{ secrets.INRUPT_DEV_WEBID }}
+          INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_DEV_PUBLIC_RESOURCE_PATH }}
+          INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_DEV_CLIENT_ID }}
+          INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_DEV_CLIENT_SECRET }}
 
   dependencies:
     name: Dependency Check


### PR DESCRIPTION
GH includes the use of "Environments" for use with CI/CD workflows. These environments are intended to be used as deployment targets, but we are currently using this as a way to partition configuration secrets. This adjusts the CI/CD structure to align our use of environments with the intended use, namely deployment targets.

*Note*: Before merging, this will require adjusting the branch protection rules