### PR TITLE
JCL-350: Adjust deployment settings

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -10,11 +10,21 @@ on:
       - inrupt-client-[0-9]+.[0-9]+.[0-9]+.Beta[0-9]+
 
 jobs:
-  publish:
+  deployment:
     name: Deploy artifacts
     runs-on: ubuntu-latest
     environment:
-      name: "Sonatype"
+      name: ${{ matrix.envName }}
+    strategy:
+      matrix:
+        envName: ["Development", "Production"]
+        release:
+          - ${{ contains(github.ref, 'inrupt-client-') }}
+        exclude:
+          - release: false
+            envName: "Production"
+          - release: true
+            envName: "Development"
 
     steps:
       - uses: actions/checkout@v3
@@ -35,14 +45,15 @@ jobs:
         run: mvn -B -ntp install -Pci
 
       - name: Deploy Artifacts
-        run: mvn deploy -P publish
         if: ${{ github.actor != 'dependabot[bot]' }}
+        run: mvn deploy -P publish
         env:
           MAVEN_REPO_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_REPO_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: Sonar Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: mvn sonar:sonar -Dsonar.login=${{ secrets.SONARQUBE_TOKEN }}
 
   site:
@@ -50,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     environment:
-      name: "Github Pages"
+      name: "Documentation"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This includes some additional refinement of the CD jobs to align the environment names with names that are used in Jira, so that it is easier to map these events to standard reports.

In brief: development deployments are now called "Development" and production deployments are called "Production" (Documentation deployments are called "Documentation").

The matrix configuration makes it possible to control for "Production" deployments being triggered by a matching tag and "Development" deployments being triggered by merges to `main`.