### PR TITLE
JCL-340: Pluralize getter methods in the accessgrant module

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -231,8 +231,19 @@ public class AccessGrant {
      * Get the purposes of the access grant.
      *
      * @return the access grant purposes
+     * @deprecated as of Beta3, please use the {@link #getPurposes()} method
      */
+    @Deprecated
     public Set<String> getPurpose() {
+        return purposes;
+    }
+
+    /**
+     * Get the purposes of the access grant.
+     *
+     * @return the access grant purposes
+     */
+    public Set<String> getPurposes() {
         return purposes;
     }
 

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -222,6 +222,7 @@ class AccessGrantClientTest {
         assertEquals(expiration, grant.getExpiration());
         assertEquals(baseUri, grant.getIssuer());
         assertEquals(purposes, grant.getPurpose());
+        assertEquals(purposes, grant.getPurposes());
         assertEquals(resources, grant.getResources());
     }
 
@@ -250,6 +251,7 @@ class AccessGrantClientTest {
         assertEquals(expiration, request.getExpiration());
         assertEquals(baseUri, request.getIssuer());
         assertEquals(purposes, request.getPurpose());
+        assertEquals(purposes, request.getPurposes());
         assertEquals(resources, request.getResources());
     }
 

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
@@ -58,6 +58,7 @@ class AccessGrantTest {
             assertEquals(URI.create("https://accessgrant.example/credential/5c6060ad-2f16-4bc1-b022-dffb46bff626"),
                     grant.getIdentifier());
             assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurpose());
+            assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurposes());
             assertEquals(Collections.singleton(
                         URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/")),
                     grant.getResources());
@@ -88,6 +89,7 @@ class AccessGrantTest {
             assertEquals(URI.create("https://accessgrant.example/credential/5c6060ad-2f16-4bc1-b022-dffb46bff626"),
                     grant.getIdentifier());
             assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurpose());
+            assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurposes());
             assertEquals(Collections.singleton(
                         URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/")),
                     grant.getResources());


### PR DESCRIPTION
This makes the `getPurpose` method name plural, in line with all the other methods that return collections.