### PR TITLE
JCL-335: Rework API and type hierarchy in accessgrant module

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.accessgrant;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+
+public interface AccessCredential {
+
+    /**
+     * Get the types of the access credential.
+     *
+     * @return the access credential types
+     */
+    Set<String> getTypes();
+
+    /**
+     * Get the access modes of the access credential.
+     *
+     * @return the access credential types
+     */
+    Set<String> getModes();
+
+    /**
+     * Get the revocation status of the access credential.
+     *
+     * @return the revocation status, if present
+     */
+    Optional<Status> getStatus();
+
+    /**
+     * Get the expiration time of the access credential.
+     *
+     * @return the expiration time
+     */
+    Instant getExpiration();
+
+    /**
+     * Get the issuer of the access credential.
+     *
+     * @return the issuer
+     */
+    URI getIssuer();
+
+    /**
+     * Get the identifier of the access credential.
+     *
+     * @return the identifier
+     */
+    URI getIdentifier();
+
+    /**
+     * Get the collection of purposes associated with the access credential.
+     *
+     * @return the purposes
+     */
+    Set<String> getPurposes();
+
+    /**
+     * Get the resources associated with the access credential.
+     *
+     * @return the associated resource identifiers
+     */
+    Set<URI> getResources();
+
+    /**
+     * Get the creator of this access credential.
+     *
+     * @return the creator
+     */
+    URI getCreator();
+
+    /**
+     * Get the recipient of this access credential.
+     *
+     * @return the recipient, if present
+     */
+    Optional<URI> getRecipient();
+
+    /**
+     * Serialize this access credential as a String.
+     *
+     * @return a serialized form of the credential
+     */
+    String serialize();
+}

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -51,15 +51,15 @@ public class AccessGrant implements AccessCredential {
     private static final Set<String> supportedTypes = getSupportedTypes();
     private static final JsonService jsonService = ServiceProvider.getJsonService();
 
-    private final String rawGrant;
+    private final String credential;
     private final URI issuer;
     private final URI identifier;
     private final Set<String> types;
     private final Set<String> purposes;
     private final Set<String> modes;
     private final Set<URI> resources;
-    private final URI grantee;
-    private final URI grantor;
+    private final URI recipient;
+    private final URI creator;
     private final Instant expiration;
     private final Status status;
 
@@ -78,7 +78,7 @@ public class AccessGrant implements AccessCredential {
                     new IllegalArgumentException("Invalid Access Grant: missing verifiable credential"));
 
             if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
-                this.rawGrant = grant;
+                this.credential = grant;
                 this.issuer = asUri(vc.get("issuer")).orElseThrow(() ->
                         new IllegalArgumentException("Missing or invalid issuer field"));
                 this.identifier = asUri(vc.get("id")).orElseThrow(() ->
@@ -90,7 +90,7 @@ public class AccessGrant implements AccessCredential {
                 final Map subject = asMap(vc.get("credentialSubject")).orElseThrow(() ->
                         new IllegalArgumentException("Missing or invalid credentialSubject field"));
 
-                this.grantor = asUri(subject.get("id")).orElseThrow(() ->
+                this.creator = asUri(subject.get("id")).orElseThrow(() ->
                         new IllegalArgumentException("Missing or invalid credentialSubject.id field"));
 
                 // V1 Access Grant, using gConsent
@@ -102,7 +102,7 @@ public class AccessGrant implements AccessCredential {
                 final Optional<URI> controller = asUri(consent.get("isProvidedToController"));
                 final Optional<URI> other = asUri(consent.get("isProvidedTo"));
 
-                this.grantee = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
+                this.recipient = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
                 this.modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
                 this.resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
@@ -274,17 +274,17 @@ public class AccessGrant implements AccessCredential {
 
     @Override
     public URI getCreator() {
-        return grantor;
+        return creator;
     }
 
     @Override
     public Optional<URI> getRecipient() {
-        return Optional.ofNullable(grantee);
+        return Optional.ofNullable(recipient);
     }
 
     @Override
     public String serialize() {
-        return rawGrant;
+        return credential;
     }
 
     /**

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -74,8 +75,12 @@ public class AccessGrant implements AccessCredential {
             final Map<String, Object> data = jsonService.fromJson(in,
                     new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
 
-            final Map vc = getCredentialFromPresentation(data, supportedTypes).orElseThrow(() ->
-                    new IllegalArgumentException("Invalid Access Grant: missing verifiable credential"));
+            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            if (vcs.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Invalid Access Grant: ambiguous number of verifiable credentials");
+            }
+            final Map vc = vcs.get(0);
 
             if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
                 this.credential = grant;

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -51,15 +51,15 @@ public class AccessRequest implements AccessCredential {
     private static final JsonService jsonService = ServiceProvider.getJsonService();
     private static final Set<String> supportedTypes = getSupportedTypes();
 
-    private final String rawGrant;
+    private final String credential;
     private final URI issuer;
     private final URI identifier;
     private final Set<String> types;
     private final Set<String> purposes;
     private final Set<String> modes;
     private final Set<URI> resources;
-    private final URI grantee;
-    private final URI grantor;
+    private final URI recipient;
+    private final URI creator;
     private final Instant expiration;
     private final Status status;
 
@@ -78,7 +78,7 @@ public class AccessRequest implements AccessCredential {
                     new IllegalArgumentException("Invalid Access Grant: missing verifiable credential"));
 
             if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
-                this.rawGrant = grant;
+                this.credential = grant;
                 this.issuer = asUri(vc.get("issuer")).orElseThrow(() ->
                         new IllegalArgumentException("Missing or invalid issuer field"));
                 this.identifier = asUri(vc.get("id")).orElseThrow(() ->
@@ -90,7 +90,7 @@ public class AccessRequest implements AccessCredential {
                 final Map subject = asMap(vc.get("credentialSubject")).orElseThrow(() ->
                         new IllegalArgumentException("Missing or invalid credentialSubject field"));
 
-                this.grantor = asUri(subject.get("id")).orElseThrow(() ->
+                this.creator = asUri(subject.get("id")).orElseThrow(() ->
                         new IllegalArgumentException("Missing or invalid credentialSubject.id field"));
 
                 // V1 Access Request, using gConsent
@@ -99,7 +99,7 @@ public class AccessRequest implements AccessCredential {
                         new IllegalArgumentException("Invalid Access Request: missing consent clause"));
 
                 final Optional<URI> dataSubject = asUri(consent.get("isConsentForDataSubject"));
-                this.grantee = dataSubject.orElse(null);
+                this.recipient = dataSubject.orElse(null);
                 this.modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
                 this.resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
@@ -185,17 +185,17 @@ public class AccessRequest implements AccessCredential {
 
     @Override
     public URI getCreator() {
-        return grantor;
+        return creator;
     }
 
     @Override
     public Optional<URI> getRecipient() {
-        return Optional.ofNullable(grantee);
+        return Optional.ofNullable(recipient);
     }
 
     @Override
     public String serialize() {
-        return rawGrant;
+        return credential;
     }
 
     static Set<String> getSupportedTypes() {

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -74,8 +75,12 @@ public class AccessRequest implements AccessCredential {
             final Map<String, Object> data = jsonService.fromJson(in,
                     new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
 
-            final Map vc = getCredentialFromPresentation(data, supportedTypes).orElseThrow(() ->
-                    new IllegalArgumentException("Invalid Access Grant: missing verifiable credential"));
+            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            if (vcs.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Invalid Access Request: ambiguous number of verifiable credentials");
+            }
+            final Map vc = vcs.get(0);
 
             if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
                 this.credential = grant;

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -42,14 +42,14 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 /**
- * An Access Grant abstraction, for use with interacting with Solid resources.
+ * An Access Request abstraction, for use with interacting with Solid resources.
  */
-public class AccessGrant implements AccessCredential {
+public class AccessRequest implements AccessCredential {
 
     private static final String TYPE = "type";
     private static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
-    private static final Set<String> supportedTypes = getSupportedTypes();
     private static final JsonService jsonService = ServiceProvider.getJsonService();
+    private static final Set<String> supportedTypes = getSupportedTypes();
 
     private final String rawGrant;
     private final URI issuer;
@@ -64,11 +64,11 @@ public class AccessGrant implements AccessCredential {
     private final Status status;
 
     /**
-     * Read a verifiable presentation as an AccessGrant.
+     * Read a verifiable presentation as an AccessRequest.
      *
-     * @param grant the Access Grant serialized as a verifiable presentation
+     * @param grant the serialized form of an Access Request
      */
-    protected AccessGrant(final String grant) throws IOException {
+    protected AccessRequest(final String grant) throws IOException {
         try (final InputStream in = new ByteArrayInputStream(grant.getBytes())) {
             // TODO process as JSON-LD
             final Map<String, Object> data = jsonService.fromJson(in,
@@ -93,16 +93,13 @@ public class AccessGrant implements AccessCredential {
                 this.grantor = asUri(subject.get("id")).orElseThrow(() ->
                         new IllegalArgumentException("Missing or invalid credentialSubject.id field"));
 
-                // V1 Access Grant, using gConsent
-                final Map consent = asMap(subject.get("providedConsent")).orElseThrow(() ->
+                // V1 Access Request, using gConsent
+                final Map consent = asMap(subject.get("hasConsent")).orElseThrow(() ->
                         // Unsupported structure
-                        new IllegalArgumentException("Invalid Access Grant: missing consent clause"));
+                        new IllegalArgumentException("Invalid Access Request: missing consent clause"));
 
-                final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
-                final Optional<URI> controller = asUri(consent.get("isProvidedToController"));
-                final Optional<URI> other = asUri(consent.get("isProvidedTo"));
-
-                this.grantee = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
+                final Optional<URI> dataSubject = asUri(consent.get("isConsentForDataSubject"));
+                this.grantee = dataSubject.orElse(null);
                 this.modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
                 this.resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
@@ -112,86 +109,33 @@ public class AccessGrant implements AccessCredential {
                             statusTypes.contains(REVOCATION_LIST_2020_STATUS)).map(x ->
                                 asRevocationList2020(credentialStatus))).orElse(null);
             } else {
-                throw new IllegalArgumentException("Invalid Access Grant: missing VerifiablePresentation type");
+                throw new IllegalArgumentException("Invalid Access Request: missing VerifiablePresentation type");
             }
         }
     }
 
-    static Status asRevocationList2020(final Map credentialStatus) {
-        try {
-            int idx = -1;
-            final Object index = credentialStatus.get("revocationListIndex");
-            if (index instanceof String) {
-                idx = Integer.parseInt((String) index);
-            } else if (index instanceof Integer) {
-                idx = (Integer) index;
-            }
-
-            final Object id = credentialStatus.get("id");
-            final Object credential = credentialStatus.get("revocationListCredential");
-            if (id instanceof String && credential instanceof String && idx >= 0) {
-                final URI uri = URI.create((String) credential);
-                return new Status(URI.create((String) id), REVOCATION_LIST_2020_STATUS, uri, idx);
-            }
-            throw new IllegalArgumentException("Unable to process credential status as Revocation List 2020");
-        } catch (final Exception ex) {
-            throw new IllegalArgumentException("Unable to process credential status data", ex);
-        }
-    }
 
     /**
-     * Create an AccessGrant object from a VerifiablePresentation.
-     *
-     * @param accessGrant the access grant
-     * @return a parsed access grant
-     * @deprecated As of Beta3, please use the {@link AccessGrant#of} method
-     */
-    @Deprecated
-    public static AccessGrant ofAccessGrant(final String accessGrant) {
-        try {
-            return new AccessGrant(accessGrant);
-        } catch (final IOException ex) {
-            throw new IllegalArgumentException("Unable to read access grant", ex);
-        }
-    }
-
-    /**
-     * Create an AccessGrant object from a VerifiablePresentation.
-     *
-     * @param accessGrant the access grant
-     * @return a parsed access grant
-     * @deprecated As of Beta3, please use the {@link AccessGrant#of} method
-     */
-    @Deprecated
-    public static AccessGrant ofAccessGrant(final InputStream accessGrant) {
-        try {
-            return of(IOUtils.toString(accessGrant, UTF_8));
-        } catch (final IOException ex) {
-            throw new IllegalArgumentException("Unable to read access grant", ex);
-        }
-    }
-
-    /**
-     * Create an AccessGrant object from a serialized form.
+     * Create an AccessRequest object from a serialized form.
      *
      * @param serialization the serialized access grant
      * @return a parsed access grant
      */
-    public static AccessGrant of(final String serialization) {
+    public static AccessRequest of(final String serialization) {
         try {
-            return new AccessGrant(serialization);
+            return new AccessRequest(serialization);
         } catch (final IOException ex) {
             throw new IllegalArgumentException("Unable to read access grant", ex);
         }
     }
 
     /**
-     * Create an AccessGrant object from a serialized form.
+     * Create an AccessRequest object from a serialized form.
      *
-     * @param serialization the serialized access grant
+     * @param serialization the access request
      * @return a parsed access grant
      */
-    public static AccessGrant of(final InputStream serialization) {
+    public static AccessRequest of(final InputStream serialization) {
         try {
             return of(IOUtils.toString(serialization, UTF_8));
         } catch (final IOException ex) {
@@ -229,17 +173,6 @@ public class AccessGrant implements AccessCredential {
         return identifier;
     }
 
-    /**
-     * Get the purposes of the access grant.
-     *
-     * @return the access grant purposes
-     * @deprecated as of Beta3, please use the {@link #getPurposes()} method
-     */
-    @Deprecated
-    public Set<String> getPurpose() {
-        return purposes;
-    }
-
     @Override
     public Set<String> getPurposes() {
         return purposes;
@@ -248,28 +181,6 @@ public class AccessGrant implements AccessCredential {
     @Override
     public Set<URI> getResources() {
         return resources;
-    }
-
-    /**
-     * Get the agent to whom access is granted.
-     *
-     * @return the agent that was granted access
-     * @deprecated As of Beta3, please use {@link #getRecipient}
-     */
-    @Deprecated
-    public Optional<URI> getGrantee() {
-        return getRecipient();
-    }
-
-    /**
-     * Get the agent who granted access.
-     *
-     * @return the agent granting access
-     * @deprecated As of Beta3, please use {@link #getCreator}
-     */
-    @Deprecated
-    public URI getGrantor() {
-        return getCreator();
     }
 
     @Override
@@ -287,22 +198,10 @@ public class AccessGrant implements AccessCredential {
         return rawGrant;
     }
 
-    /**
-     * Get the raw access grant.
-     *
-     * @return the access grant
-     * @deprecated as of Beta3, please use the {@link #serialize} method
-     */
-    @Deprecated
-    public String getRawGrant() {
-        return serialize();
-    }
-
     static Set<String> getSupportedTypes() {
         final Set<String> types = new HashSet<>();
-        types.add("SolidAccessGrant");
-        types.add("http://www.w3.org/ns/solid/vc#SolidAccessGrant");
+        types.add("SolidAccessRequest");
+        types.add("http://www.w3.org/ns/solid/vc#SolidAccessRequest");
         return Collections.unmodifiableSet(types);
     }
-
 }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
@@ -22,8 +22,10 @@ package com.inrupt.client.accessgrant;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -94,20 +96,21 @@ final class Utils {
         return Optional.empty();
     }
 
-    public static Optional<Map> getCredentialFromPresentation(final Map<String, Object> data,
+    public static List<Map> getCredentialsFromPresentation(final Map<String, Object> data,
             final Set<String> supportedTypes) {
+        final List<Map> credentials = new ArrayList<>();
         if (data.get("verifiableCredential") instanceof Collection) {
             for (final Object item : (Collection) data.get("verifiableCredential")) {
                 if (item instanceof Map) {
                     final Map vc = (Map) item;
                     if (asSet(vc.get(TYPE)).filter(types ->
                                 types.stream().anyMatch(supportedTypes::contains)).isPresent()) {
-                        return Optional.of(vc);
+                        credentials.add(vc);
                     }
                 }
             }
         }
-        return Optional.empty();
+        return credentials;
     }
 
 

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.accessgrant;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/** Utility classes for the Access Grant module. **/
+final class Utils {
+
+    private static final String TYPE = "type";
+    private static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
+
+    public static Status asRevocationList2020(final Map credentialStatus) {
+        try {
+            int idx = -1;
+            final Object index = credentialStatus.get("revocationListIndex");
+            if (index instanceof String) {
+                idx = Integer.parseInt((String) index);
+            } else if (index instanceof Integer) {
+                idx = (Integer) index;
+            }
+
+            final Object id = credentialStatus.get("id");
+            final Object credential = credentialStatus.get("revocationListCredential");
+            if (id instanceof String && credential instanceof String && idx >= 0) {
+                final URI uri = URI.create((String) credential);
+                return new Status(URI.create((String) id), REVOCATION_LIST_2020_STATUS, uri, idx);
+            }
+            throw new IllegalArgumentException("Unable to process credential status as Revocation List 2020");
+        } catch (final Exception ex) {
+            throw new IllegalArgumentException("Unable to process credential status data", ex);
+        }
+    }
+
+    public static Optional<Instant> asInstant(final Object value) {
+        if (value instanceof String) {
+            return Optional.of(Instant.parse((String) value));
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<URI> asUri(final Object value) {
+        if (value instanceof String) {
+            return Optional.of(URI.create((String) value));
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<Map> asMap(final Object value) {
+        if (value instanceof Map) {
+            return Optional.of((Map) value);
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<Set<String>> asSet(final Object value) {
+        if (value != null) {
+            final Set<String> data = new HashSet<>();
+            if (value instanceof String) {
+                data.add((String) value);
+            } else if (value instanceof Collection) {
+                for (final Object item : (Collection) value) {
+                    if (item instanceof String) {
+                        data.add((String) item);
+                    }
+                }
+            }
+            return Optional.of(data);
+        }
+        return Optional.empty();
+    }
+
+    public static Optional<Map> getCredentialFromPresentation(final Map<String, Object> data,
+            final Set<String> supportedTypes) {
+        if (data.get("verifiableCredential") instanceof Collection) {
+            for (final Object item : (Collection) data.get("verifiableCredential")) {
+                if (item instanceof Map) {
+                    final Map vc = (Map) item;
+                    if (asSet(vc.get(TYPE)).filter(types ->
+                                types.stream().anyMatch(supportedTypes::contains)).isPresent()) {
+                        return Optional.of(vc);
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+
+    private Utils() {
+        // prevent instantiation
+    }
+}

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -218,6 +218,7 @@ class AccessGrantClientTest {
 
         assertTrue(grant.getTypes().contains("SolidAccessGrant"));
         assertEquals(Optional.of(agent), grant.getGrantee());
+        assertEquals(Optional.of(agent), grant.getRecipient());
         assertEquals(modes, grant.getModes());
         assertEquals(expiration, grant.getExpiration());
         assertEquals(baseUri, grant.getIssuer());

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
@@ -93,7 +93,7 @@ class AccessGrantSessionTest {
             assertFalse(grant.getResources().isEmpty());
             for (final URI uri : grant.getResources()) {
                 final String encoded = Base64.getUrlEncoder().withoutPadding()
-                    .encodeToString(grant.getRawGrant().getBytes(UTF_8));
+                    .encodeToString(grant.serialize().getBytes(UTF_8));
                 assertEquals(Optional.of(encoded),
                         session.getCredential(AccessGrantSession.VERIFIABLE_CREDENTIAL, uri).map(Credential::getToken));
                 final URI child = URIBuilder.newBuilder(uri).path("a").path("b").build();

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
@@ -63,7 +63,9 @@ class AccessGrantTest {
                         URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/")),
                     grant.getResources());
             assertEquals(URI.create("https://id.example/grantor"), grant.getGrantor());
+            assertEquals(URI.create("https://id.example/grantor"), grant.getCreator());
             assertEquals(Optional.of(URI.create("https://id.example/grantee")), grant.getGrantee());
+            assertEquals(Optional.of(URI.create("https://id.example/grantee")), grant.getRecipient());
             final Optional<Status> status = grant.getStatus();
             assertTrue(status.isPresent());
             status.ifPresent(s -> {
@@ -94,7 +96,9 @@ class AccessGrantTest {
                         URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/")),
                     grant.getResources());
             assertEquals(URI.create("https://id.example/grantor"), grant.getGrantor());
+            assertEquals(URI.create("https://id.example/grantor"), grant.getCreator());
             assertEquals(Optional.of(URI.create("https://id.example/grantee")), grant.getGrantee());
+            assertEquals(Optional.of(URI.create("https://id.example/grantee")), grant.getRecipient());
             final Optional<Status> status = grant.getStatus();
             assertFalse(status.isPresent());
         }

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
@@ -47,7 +47,7 @@ class AccessGrantTest {
     @Test
     void testReadAccessGrant() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant1.json")) {
-            final AccessGrant grant = AccessGrant.ofAccessGrant(resource);
+            final AccessGrant grant = AccessGrant.of(resource);
             assertEquals(Collections.singleton("Read"), grant.getModes());
             assertEquals(URI.create("https://accessgrant.example"), grant.getIssuer());
             final Set<String> expectedTypes = new HashSet<>();
@@ -78,7 +78,7 @@ class AccessGrantTest {
     @Test
     void testReadAccessGrantSingletons() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant2.json")) {
-            final AccessGrant grant = AccessGrant.ofAccessGrant(resource);
+            final AccessGrant grant = AccessGrant.of(resource);
             assertEquals(Collections.singleton("Read"), grant.getModes());
             assertEquals(URI.create("https://accessgrant.example"), grant.getIssuer());
             final Set<String> expectedTypes = new HashSet<>();
@@ -104,9 +104,10 @@ class AccessGrantTest {
     void testRawAccessGrant() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant1.json")) {
             final String raw = IOUtils.toString(resource, UTF_8);
-            final AccessGrant grant = AccessGrant.ofAccessGrant(raw);
+            final AccessGrant grant = AccessGrant.of(raw);
 
-            assertEquals(raw, grant.getRawGrant());
+            assertEquals(raw, grant.serialize());
+            assertEquals(grant.serialize(), grant.getRawGrant());
         }
     }
 
@@ -165,84 +166,84 @@ class AccessGrantTest {
     @Test
     void testBareAccessGrant() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant1.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantMissingIssuer() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant2.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantMissingCredentialSubject() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant3.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantMissingPresentationType() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant4.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testIrrelevantCredential() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant5.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantMissingId() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant6.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantMissingCredentialSubjectId() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant7.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantMissingConsent() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant8.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantTypeComplexListStructure() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant9.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantTypeObjectStructure() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant10.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantInvalidStatusNoId() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant12.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
     @Test
     void testAccessGrantInvalidStatusBadCredential() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant13.json")) {
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }
 
@@ -250,11 +251,11 @@ class AccessGrantTest {
     void testInvalidStream() throws IOException {
         final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant2.json");
         resource.close();
-        assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant(resource));
+        assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
     }
 
     @Test
     void testInvalidString() throws IOException {
-        assertThrows(IllegalArgumentException.class, () -> AccessGrant.ofAccessGrant("not json"));
+        assertThrows(IllegalArgumentException.class, () -> AccessGrant.of("not json"));
     }
 }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
@@ -59,11 +59,27 @@ class MockAccessGrantServer {
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
                             this.webId, this.sharedFile))));
 
+        wireMockServer.stubFor(get(urlPathMatching(".+:(\\d*)/vc-request"))
+                    .willReturn(aResponse()
+                        .withStatus(Utils.SUCCESS)
+                        .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
+                        .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
+                            this.webId, this.sharedFile))));
+
         wireMockServer.stubFor(delete(urlPathMatching("/vc-grant"))
                     .willReturn(aResponse()
                         .withStatus(204)));
 
         wireMockServer.stubFor(post(urlEqualTo("/issue"))
+                    .withRequestBody(containing("hasConsent"))
+                    .willReturn(aResponse()
+                        .withStatus(Utils.SUCCESS)
+                        .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
+                        .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
+                            this.webId, this.sharedFile))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/issue"))
+                    .withRequestBody(containing("providedConsent"))
                     .willReturn(aResponse()
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)

--- a/integration/base/src/main/resources/vc-request.json
+++ b/integration/base/src/main/resources/vc-request.json
@@ -4,8 +4,8 @@
         "https://w3id.org/security/suites/ed25519-2020/v1",
         "https://w3id.org/vc-revocation-list-2020/v1",
         "https://schema.inrupt.com/credentials/v1.jsonld"],
-    "id":"{{baseUrl}}/vc-grant",
-    "type":["VerifiableCredential","SolidAccessGrant"],
+    "id":"{{baseUrl}}/vc-request",
+    "type":["VerifiableCredential","SolidAccessRequest"],
     "issuer":"{{baseUrl}}",
     "expirationDate":"2023-04-03T12:00:00Z",
     "issuanceDate":"2022-08-25T20:34:05.153Z",
@@ -16,11 +16,11 @@
         "type":"RevocationList2020Status"},
     "credentialSubject":{
         "id":"{{webId}}",
-        "providedConsent":{
+        "hasConsent":{
             "mode":["Read"],
-            "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"{{webId}}",
-            "forPurpose":["https://purpose.example/1", "https://purpose.example/2"],
+            "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+            "isConsentForDataSubject":"{{webId}}",
+            "forPurpose":["https://some.purpose/not-a-nefarious-one/i-promise", "https://some.other.purpose/"],
             "forPersonalData":["{{sharedFile}}"]}},
     "proof":{
         "created":"2022-08-25T20:34:05.236Z",


### PR DESCRIPTION
Supersedes #422, integrating the code in that PR into an implementation that does not break backwards compatibility and which does not leak VC implementation details.

This introduces a simple type hierarchy for the access grant module:

```
interface AccessCredential {}
class AccessGrant implements AccessCredential {}
class AccessRequest implements AccessCredential {}
```

And using that hierarchy, we have a clearer API:

```
CompletionStage<AccessGrant> grant = client.requestAccess(...).thenCompose(client::grantAccess);
```

Some of the existing APIs have been deprecated in favor of methods that make use of this hierarchy.
