### PR TITLE
JCL-337: AccessRequest class testing

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -122,28 +122,6 @@ public class AccessGrant implements AccessCredential {
         }
     }
 
-    static Status asRevocationList2020(final Map credentialStatus) {
-        try {
-            int idx = -1;
-            final Object index = credentialStatus.get("revocationListIndex");
-            if (index instanceof String) {
-                idx = Integer.parseInt((String) index);
-            } else if (index instanceof Integer) {
-                idx = (Integer) index;
-            }
-
-            final Object id = credentialStatus.get("id");
-            final Object credential = credentialStatus.get("revocationListCredential");
-            if (id instanceof String && credential instanceof String && idx >= 0) {
-                final URI uri = URI.create((String) credential);
-                return new Status(URI.create((String) id), REVOCATION_LIST_2020_STATUS, uri, idx);
-            }
-            throw new IllegalArgumentException("Unable to process credential status as Revocation List 2020");
-        } catch (final Exception ex) {
-            throw new IllegalArgumentException("Unable to process credential status data", ex);
-        }
-    }
-
     /**
      * Create an AccessGrant object from a VerifiablePresentation.
      *

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -212,7 +212,7 @@ public class AccessGrant implements AccessCredential {
      */
     @Deprecated
     public Set<String> getPurpose() {
-        return purposes;
+        return getPurposes();
     }
 
     @Override

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -131,11 +131,7 @@ public class AccessGrant implements AccessCredential {
      */
     @Deprecated
     public static AccessGrant ofAccessGrant(final String accessGrant) {
-        try {
-            return new AccessGrant(accessGrant);
-        } catch (final IOException ex) {
-            throw new IllegalArgumentException("Unable to read access grant", ex);
-        }
+        return of(accessGrant);
     }
 
     /**
@@ -147,11 +143,7 @@ public class AccessGrant implements AccessCredential {
      */
     @Deprecated
     public static AccessGrant ofAccessGrant(final InputStream accessGrant) {
-        try {
-            return of(IOUtils.toString(accessGrant, UTF_8));
-        } catch (final IOException ex) {
-            throw new IllegalArgumentException("Unable to read access grant", ex);
-        }
+        return of(accessGrant);
     }
 
     /**

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
@@ -116,6 +116,25 @@ class AccessGrantTest {
     }
 
     @Test
+    void testDeprecatedParsingMethod() throws IOException {
+        try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant1.json")) {
+            final String raw = IOUtils.toString(resource, UTF_8);
+            final AccessGrant grant = AccessGrant.ofAccessGrant(raw);
+
+            assertEquals(raw, grant.serialize());
+            assertEquals(grant.serialize(), grant.getRawGrant());
+        }
+    }
+
+    @Test
+    void testDeprecatedParsingMethod2() throws IOException {
+        try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant2.json")) {
+            final AccessGrant grant = AccessGrant.ofAccessGrant(resource);
+            assertEquals(Collections.singleton("Read"), grant.getModes());
+        }
+    }
+
+    @Test
     void testRevocationList2020() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/status_list1.json")) {
             final Map<String, Object> data = jsonService.fromJson(resource,

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
@@ -120,7 +120,7 @@ class AccessGrantTest {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/status_list1.json")) {
             final Map<String, Object> data = jsonService.fromJson(resource,
                 new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-            final Status status = AccessGrant.asRevocationList2020(data);
+            final Status status = Utils.asRevocationList2020(data);
             assertEquals(URI.create("https://accessgrant.example/status/CVAM#2832"), status.getIdentifier());
             assertEquals(URI.create("https://accessgrant.example/status/CVAM"), status.getCredential());
             assertEquals(2832, status.getIndex());
@@ -132,7 +132,7 @@ class AccessGrantTest {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/status_list2.json")) {
             final Map<String, Object> data = jsonService.fromJson(resource,
                 new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-            final Status status = AccessGrant.asRevocationList2020(data);
+            final Status status = Utils.asRevocationList2020(data);
             assertEquals(URI.create("https://accessgrant.example/status/CVAM#2832"), status.getIdentifier());
             assertEquals(URI.create("https://accessgrant.example/status/CVAM"), status.getCredential());
             assertEquals(2832, status.getIndex());
@@ -144,7 +144,7 @@ class AccessGrantTest {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/status_list3.json")) {
             final Map<String, Object> data = jsonService.fromJson(resource,
                 new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.asRevocationList2020(data));
+            assertThrows(IllegalArgumentException.class, () -> Utils.asRevocationList2020(data));
         }
     }
 
@@ -153,7 +153,7 @@ class AccessGrantTest {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/status_list4.json")) {
             final Map<String, Object> data = jsonService.fromJson(resource,
                 new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.asRevocationList2020(data));
+            assertThrows(IllegalArgumentException.class, () -> Utils.asRevocationList2020(data));
         }
     }
 
@@ -162,7 +162,7 @@ class AccessGrantTest {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/status_list5.json")) {
             final Map<String, Object> data = jsonService.fromJson(resource,
                 new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-            assertThrows(IllegalArgumentException.class, () -> AccessGrant.asRevocationList2020(data));
+            assertThrows(IllegalArgumentException.class, () -> Utils.asRevocationList2020(data));
         }
     }
 
@@ -247,6 +247,13 @@ class AccessGrantTest {
     @Test
     void testAccessGrantInvalidStatusBadCredential() throws IOException {
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant13.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
+        }
+    }
+
+    @Test
+    void testAccessGrantInvalidStatusNegativeInteger() throws IOException {
+        try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/invalid_access_grant14.json")) {
             assertThrows(IllegalArgumentException.class, () -> AccessGrant.of(resource));
         }
     }

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.accessgrant;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.spi.JsonService;
+import com.inrupt.client.spi.ServiceProvider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+class AccessRequestTest {
+
+    private static final JsonService jsonService = ServiceProvider.getJsonService();
+
+    @Test
+    void testReadAccessRequest() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class.getResourceAsStream("/access_request1.json")) {
+            final AccessRequest request = AccessRequest.of(resource);
+            assertEquals(Collections.singleton("Read"), request.getModes());
+            assertEquals(URI.create("https://accessgrant.test"), request.getIssuer());
+            final Set<String> expectedTypes = new HashSet<>();
+            expectedTypes.add("VerifiableCredential");
+            expectedTypes.add("SolidAccessRequest");
+            assertEquals(expectedTypes, request.getTypes());
+            assertEquals(Instant.parse("2022-08-27T12:00:00Z"), request.getExpiration());
+            assertEquals(URI.create("https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab"),
+                    request.getIdentifier());
+            assertEquals(Collections.singleton("https://purpose.test/Purpose1"), request.getPurposes());
+            assertEquals(Collections.singleton(
+                        URI.create("https://storage.test/data/")),
+                    request.getResources());
+            assertEquals(URI.create("https://id.test/username"), request.getCreator());
+            assertEquals(Optional.of(URI.create("https://id.test/agent")), request.getRecipient());
+            final Optional<Status> status = request.getStatus();
+            assertTrue(status.isPresent());
+            status.ifPresent(s -> {
+                assertEquals(URI.create("https://accessgrant.test/status/CVAM#2832"), s.getIdentifier());
+                assertEquals(URI.create("https://accessgrant.test/status/CVAM"), s.getCredential());
+                assertEquals(2832, s.getIndex());
+                assertEquals("RevocationList2020Status", s.getType());
+            });
+        }
+    }
+
+    @Test
+    void testReadAccessRequestSingletons() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class.getResourceAsStream("/access_request2.json")) {
+            final AccessRequest request = AccessRequest.of(resource);
+            assertEquals(Collections.singleton("Read"), request.getModes());
+            assertEquals(URI.create("https://accessgrant.test"), request.getIssuer());
+            final Set<String> expectedTypes = new HashSet<>();
+            expectedTypes.add("VerifiableCredential");
+            expectedTypes.add("SolidAccessRequest");
+            assertEquals(expectedTypes, request.getTypes());
+            assertEquals(Instant.parse("2022-08-27T12:00:00Z"), request.getExpiration());
+            assertEquals(URI.create("https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab"),
+                    request.getIdentifier());
+            assertEquals(Collections.singleton("https://purpose.test/Purpose1"), request.getPurposes());
+            assertEquals(Collections.singleton(
+                        URI.create("https://storage.test/e973cc3d-5c28-4a10-98c5-e40079289358/")),
+                    request.getResources());
+            assertEquals(URI.create("https://id.test/username"), request.getCreator());
+            assertEquals(Optional.of(URI.create("https://id.test/agent")), request.getRecipient());
+            final Optional<Status> status = request.getStatus();
+            assertFalse(status.isPresent());
+        }
+    }
+
+    @Test
+    void testRawAccessRequest() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class.getResourceAsStream("/access_request1.json")) {
+            final String raw = IOUtils.toString(resource, UTF_8);
+            final AccessRequest request = AccessRequest.of(raw);
+
+            assertEquals(raw, request.serialize());
+        }
+    }
+
+    @Test
+    void testMissingAccessRequest() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/access_grant1.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testBareAccessRequest() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/invalid_access_request1.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testAccessRequestMissingIssuer() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/invalid_access_request2.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testAccessRequestMissingCredentialSubject() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/invalid_access_request3.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testAccessRequestMissingPresentationType() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/invalid_access_request4.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testAccessRequestMissingId() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/invalid_access_request5.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testAccessRequestMissingCredentialSubjectId() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/invalid_access_request6.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testAccessRequestMissingConsent() throws IOException {
+        try (final InputStream resource = AccessRequestTest.class
+                .getResourceAsStream("/invalid_access_request7.json")) {
+            assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+        }
+    }
+
+    @Test
+    void testInvalidStream() throws IOException {
+        final InputStream resource = AccessRequestTest.class.getResourceAsStream("/access_request2.json");
+        resource.close();
+        assertThrows(IllegalArgumentException.class, () -> AccessRequest.of(resource));
+    }
+
+    @Test
+    void testInvalidString() throws IOException {
+        assertThrows(IllegalArgumentException.class, () -> AccessRequest.of("not json"));
+    }
+}

--- a/access-grant/src/test/resources/access_request1.json
+++ b/access-grant/src/test/resources/access_request1.json
@@ -1,0 +1,36 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab",
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "issuer":"https://accessgrant.test",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialStatus":{
+            "id":"https://accessgrant.test/status/CVAM#2832",
+            "revocationListCredential":"https://accessgrant.test/status/CVAM",
+            "revocationListIndex":"2832",
+            "type":"RevocationList2020Status"},
+        "credentialSubject":{
+            "id":"https://id.test/username",
+            "hasConsent":{
+                "mode":["Read"],
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+                "isConsentForDataSubject":"https://id.test/agent",
+                "forPurpose":["https://purpose.test/Purpose1"],
+                "forPersonalData":["https://storage.test/data/"]}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/access_request2.json
+++ b/access-grant/src/test/resources/access_request2.json
@@ -1,0 +1,31 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab",
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "issuer":"https://accessgrant.test",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialSubject":{
+            "id":"https://id.test/username",
+            "hasConsent":{
+                "mode":"Read",
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+                "isConsentForDataSubject":"https://id.test/agent",
+                "forPurpose":"https://purpose.test/Purpose1",
+                "forPersonalData":"https://storage.test/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/invalid_access_grant14.json
+++ b/access-grant/src/test/resources/invalid_access_grant14.json
@@ -1,0 +1,36 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.example/credential/5c6060ad-2f16-4bc1-b022-dffb46bff626",
+        "type":["VerifiableCredential","SolidAccessGrant"],
+        "issuer":"https://accessgrant.example",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialStatus":{
+            "id":"https://accessgrant.example/status/CVAM#2832",
+            "revocationListCredential":"https://accessgrant.example/status/CVAM",
+            "revocationListIndex":-2,
+            "type":"RevocationList2020Status"},
+        "credentialSubject":{
+            "id":"https://id.example/grantor",
+            "providedConsent":{
+                "mode":["Read"],
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
+                "isProvidedToPerson":"https://id.example/grantee",
+                "forPurpose":["https://purpose.example/Purpose1"],
+                "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.example/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/invalid_access_request1.json
+++ b/access-grant/src/test/resources/invalid_access_request1.json
@@ -1,0 +1,32 @@
+{
+    "@context":[
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1",
+        "https://w3id.org/vc-revocation-list-2020/v1",
+        "https://schema.inrupt.com/credentials/v1.jsonld"],
+    "id":"{{baseUrl}}/access-request-5",
+    "type":["VerifiableCredential","SolidAccessRequest"],
+    "issuer":"{{baseUrl}}",
+    "expirationDate":"2022-08-27T12:00:00Z",
+    "issuanceDate":"2022-08-25T20:34:05.153Z",
+    "credentialStatus":{
+        "id":"https://accessgrant.example/status/CVAM#2832",
+        "revocationListCredential":"https://accessgrant.example/status/CVAM",
+        "revocationListIndex":"2832",
+        "type":"RevocationList2020Status"},
+    "credentialSubject":{
+        "id":"https://id.test/username",
+        "hasConsent":{
+            "mode":["Read","Append"],
+            "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+            "isConsentForDataSubject":"https://id.test/agent",
+            "forPurpose":["https://purpose.test/Purpose1"],
+            "forPersonalData":["https://storage.test/data/"]}},
+    "proof":{
+        "created":"2022-08-25T20:34:05.236Z",
+        "proofPurpose":"assertionMethod",
+        "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+        "type":"Ed25519Signature2020",
+        "verificationMethod":"https://accessgrant.example/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+}
+

--- a/access-grant/src/test/resources/invalid_access_request2.json
+++ b/access-grant/src/test/resources/invalid_access_request2.json
@@ -1,0 +1,30 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab",
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialSubject":{
+            "id":"https://id.test/username",
+            "hasConsent":{
+                "mode":"Read",
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+                "isConsentForDataSubject":"https://id.test/agent",
+                "forPurpose":"https://purpose.test/Purpose1",
+                "forPersonalData":"https://storage.test/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/invalid_access_request3.json
+++ b/access-grant/src/test/resources/invalid_access_request3.json
@@ -1,0 +1,28 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab",
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "issuer":"https://accessgrant.test",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialStatus":{
+            "id":"https://accessgrant.test/status/CVAM#2832",
+            "revocationListCredential":"https://accessgrant.test/status/CVAM",
+            "revocationListIndex":"2832",
+            "type":"RevocationList2020Status"},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/invalid_access_request4.json
+++ b/access-grant/src/test/resources/invalid_access_request4.json
@@ -1,0 +1,35 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab",
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "issuer":"https://accessgrant.test",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialStatus":{
+            "id":"https://accessgrant.test/status/CVAM#2832",
+            "revocationListCredential":"https://accessgrant.test/status/CVAM",
+            "revocationListIndex":"2832",
+            "type":"RevocationList2020Status"},
+        "credentialSubject":{
+            "id":"https://id.test/username",
+            "hasConsent":{
+                "mode":["Read"],
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+                "isConsentForDataSubject":"https://id.test/agent",
+                "forPurpose":["https://purpose.test/Purpose1"],
+                "forPersonalData":["https://storage.test/data/"]}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/invalid_access_request5.json
+++ b/access-grant/src/test/resources/invalid_access_request5.json
@@ -1,0 +1,35 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "issuer":"https://accessgrant.test",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialStatus":{
+            "id":"https://accessgrant.test/status/CVAM#2832",
+            "revocationListCredential":"https://accessgrant.test/status/CVAM",
+            "revocationListIndex":"2832",
+            "type":"RevocationList2020Status"},
+        "credentialSubject":{
+            "id":"https://id.test/username",
+            "hasConsent":{
+                "mode":["Read"],
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+                "isConsentForDataSubject":"https://id.test/agent",
+                "forPurpose":["https://purpose.test/Purpose1"],
+                "forPersonalData":["https://storage.test/data/"]}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/invalid_access_request6.json
+++ b/access-grant/src/test/resources/invalid_access_request6.json
@@ -1,0 +1,35 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab",
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "issuer":"https://accessgrant.test",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialStatus":{
+            "id":"https://accessgrant.test/status/CVAM#2832",
+            "revocationListCredential":"https://accessgrant.test/status/CVAM",
+            "revocationListIndex":"2832",
+            "type":"RevocationList2020Status"},
+        "credentialSubject":{
+            "hasConsent":{
+                "mode":["Read"],
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+                "isConsentForDataSubject":"https://id.test/agent",
+                "forPurpose":["https://purpose.test/Purpose1"],
+                "forPersonalData":["https://storage.test/data/"]}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/access-grant/src/test/resources/invalid_access_request7.json
+++ b/access-grant/src/test/resources/invalid_access_request7.json
@@ -1,0 +1,32 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab",
+        "type":["VerifiableCredential","SolidAccessRequest"],
+        "issuer":"https://accessgrant.test",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialStatus":{
+            "id":"https://accessgrant.test/status/CVAM#2832",
+            "revocationListCredential":"https://accessgrant.test/status/CVAM",
+            "revocationListIndex":"2832",
+            "type":"RevocationList2020Status"},
+        "credentialSubject":{
+            "id":"https://id.test/username",
+            "providedConsent": {
+                "mode": "Read"}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.test/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+


### PR DESCRIPTION
Aside from removing a bit of duplicated code in the AccessGrant class (which had been migrated to Utils), this PR is just about applying the existing testing scenarios that exist for AccessGrant parsing to AccessRequests.