### PR TITLE
JCL-337: Improved tests for AccessGrantClient class

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -93,6 +93,7 @@ public class AccessGrantClient {
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String CREDENTIAL_SUBJECT = "credentialSubject";
     private static final String IS_PROVIDED_TO_PERSON = "isProvidedToPerson";
+    private static final String IS_CONSENT_FOR_DATA_SUBJECT = "isConsentForDataSubject";
     private static final String FOR_PERSONAL_DATA = "forPersonalData";
     private static final String HAS_STATUS = "hasStatus";
     private static final String MODE = "mode";
@@ -122,8 +123,7 @@ public class AccessGrantClient {
      * @param issuer the issuer
      */
     public AccessGrantClient(final Client client, final URI issuer) {
-        this(client, ServiceProvider.getCacheBuilder().build(100, Duration.ofMinutes(60)),
-                new AccessGrantConfiguration(issuer));
+        this(client, issuer, ServiceProvider.getCacheBuilder().build(100, Duration.ofMinutes(60)));
     }
 
     /**
@@ -636,7 +636,11 @@ public class AccessGrantClient {
 
         final Map<String, Object> consent = new HashMap<>();
         if (agent != null) {
-            consent.put(IS_PROVIDED_TO_PERSON, agent);
+            if (isAccessGrant(type)) {
+                consent.put(IS_PROVIDED_TO_PERSON, agent);
+            } else if (isAccessRequest(type)) {
+                consent.put(IS_CONSENT_FOR_DATA_SUBJECT, agent);
+            }
         }
         if (resource != null) {
             consent.put(FOR_PERSONAL_DATA, resource);
@@ -725,7 +729,7 @@ public class AccessGrantClient {
         consent.put(MODE, modes);
         consent.put(FOR_PERSONAL_DATA, resources);
         if (agent != null) {
-            consent.put("isConsentForDataSubject", agent);
+            consent.put(IS_CONSENT_FOR_DATA_SUBJECT, agent);
         }
         if (!purposes.isEmpty()) {
             consent.put("forPurpose", purposes);

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
@@ -107,6 +107,32 @@ class MockAccessGrantServer {
                         .withStatus(401)
                         .withHeader("WWW-Authenticate", "Bearer,DPoP algs=\"ES256\"")));
 
+        wireMockServer.stubFor(get(urlEqualTo("/access-request-5"))
+                    .atPriority(1)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody(getResource("/vc-5.json", wireMockServer.baseUrl()))));
+
+        wireMockServer.stubFor(get(urlEqualTo("/access-request-5"))
+                    .atPriority(2)
+                    .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader("WWW-Authenticate", "Bearer,DPoP algs=\"ES256\"")));
+
+        wireMockServer.stubFor(delete(urlEqualTo("/access-request-5"))
+                    .atPriority(1)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .willReturn(aResponse()
+                        .withStatus(204)));
+
+        wireMockServer.stubFor(delete(urlEqualTo("/access-request-5"))
+                    .atPriority(2)
+                    .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader("WWW-Authenticate", "Bearer,DPoP algs=\"ES256\"")));
+
         wireMockServer.stubFor(get(urlEqualTo("/access-grant-6"))
                     .atPriority(1)
                     .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
@@ -177,6 +203,30 @@ class MockAccessGrantServer {
                         .withStatus(401)
                         .withHeader("WWW-Authenticate", "Bearer,DPoP algs=\"ES256\"")));
 
+        wireMockServer.stubFor(post(urlEqualTo("/verify"))
+                    .atPriority(1)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .withRequestBody(containing("\"" + wireMockServer.baseUrl() + "/access-grant-1\""))
+                    .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResource("/verify-results.json"))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/verify"))
+                    .atPriority(1)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .withRequestBody(containing("\"" + wireMockServer.baseUrl() + "/access-request-5\""))
+                    .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResource("/verify-results.json"))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/verify"))
+                    .atPriority(2)
+                    .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader("WWW-Authenticate", "Bearer,DPoP algs=\"ES256\"")));
+
         wireMockServer.stubFor(post(urlEqualTo("/status"))
                     .atPriority(1)
                     .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
@@ -218,6 +268,24 @@ class MockAccessGrantServer {
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
                         .withBody(getResource("/query_response1.json", wireMockServer.baseUrl()))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/derive"))
+                    .atPriority(2)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .withRequestBody(containing("\"isProvidedToPerson\":\"https://id.test/user\""))
+                    .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResource("/query_response4.json", wireMockServer.baseUrl()))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/derive"))
+                    .atPriority(2)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .withRequestBody(containing("\"isConsentForDataSubject\":\"https://id.test/user\""))
+                    .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResource("/query_response5.json", wireMockServer.baseUrl()))));
 
         wireMockServer.stubFor(post(urlEqualTo("/derive"))
                     .atPriority(2)

--- a/access-grant/src/test/resources/query_response4.json
+++ b/access-grant/src/test/resources/query_response4.json
@@ -1,0 +1,34 @@
+{
+  "verifiableCredential": [{
+    "@context":[
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1",
+        "https://w3id.org/vc-revocation-list-2020/v1",
+        "https://schema.inrupt.com/credentials/v1.jsonld"],
+    "id":"{{baseUrl}}/access-grant-1",
+    "type":["VerifiableCredential","SolidAccessGrant"],
+    "issuer":"{{baseUrl}}",
+    "expirationDate":"2022-08-27T12:00:00Z",
+    "issuanceDate":"2022-08-25T20:34:05.153Z",
+    "credentialStatus":{
+        "id":"https://accessgrant.example/status/CVAM#2832",
+        "revocationListCredential":"https://accessgrant.example/status/CVAM",
+        "revocationListIndex":"2832",
+        "type":"RevocationList2020Status"},
+    "credentialSubject":{
+        "id":"https://id.example/grantor",
+        "providedConsent":{
+            "mode":["Read"],
+            "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
+            "isProvidedToPerson":"https://id.test/user",
+            "forPurpose":["https://purpose.example/Purpose1"],
+            "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
+    "proof":{
+        "created":"2022-08-25T20:34:05.236Z",
+        "proofPurpose":"assertionMethod",
+        "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+        "type":"Ed25519Signature2020",
+        "verificationMethod":"https://accessgrant.example/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+  }]
+}
+

--- a/access-grant/src/test/resources/query_response5.json
+++ b/access-grant/src/test/resources/query_response5.json
@@ -1,0 +1,34 @@
+{
+  "verifiableCredential": [{
+    "@context":[
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1",
+        "https://w3id.org/vc-revocation-list-2020/v1",
+        "https://schema.inrupt.com/credentials/v1.jsonld"],
+    "id":"{{baseUrl}}/access-request-3",
+    "type":["VerifiableCredential","SolidAccessRequest"],
+    "issuer":"{{baseUrl}}",
+    "expirationDate":"2022-08-27T12:00:00Z",
+    "issuanceDate":"2022-08-25T20:34:05.153Z",
+    "credentialStatus":{
+        "id":"https://accessgrant.example/status/CVAM#2833",
+        "revocationListCredential":"https://accessgrant.example/status/CVAM",
+        "revocationListIndex":"2833",
+        "type":"RevocationList2020Status"},
+    "credentialSubject":{
+        "id":"https://id.example/grantor",
+        "hasConsent":{
+            "mode":["Read"],
+            "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
+            "isConsentForDataSubject":"https://id.test/user",
+            "forPurpose":["https://purpose.example/Purpose1"],
+            "forPersonalData":["https://storage.example/f1759e6d-4dda-4401-be61-d90d070a5474/"]}},
+    "proof":{
+        "created":"2022-08-25T20:34:05.236Z",
+        "proofPurpose":"assertionMethod",
+        "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+        "type":"Ed25519Signature2020",
+        "verificationMethod":"https://accessgrant.example/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+  }]
+}
+

--- a/access-grant/src/test/resources/verify-results.json
+++ b/access-grant/src/test/resources/verify-results.json
@@ -1,0 +1,6 @@
+{
+    "checks": ["expirationDate", "issuanceDate"],
+    "warnings": [],
+    "errors": []
+}
+


### PR DESCRIPTION
This improves the test coverage for the `AccessGrantClient` class, including adding tests for `verify` and `grantAccess`.

In the process, an error was fixed related to agent-based query structures only working for AccessGrants. Now, for AccessRequest queries, the correct property is used: `isConsentForDataSubject`.