### PR TITLE
JCL-312: Refactor future handling

### DIFF
--- a/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
@@ -23,6 +23,7 @@ package com.inrupt.client.solid;
 import com.inrupt.client.Client;
 import com.inrupt.client.ClientProvider;
 import com.inrupt.client.Headers;
+import com.inrupt.client.InruptClientException;
 import com.inrupt.client.Request;
 import com.inrupt.client.Resource;
 import com.inrupt.client.Response;
@@ -199,7 +200,10 @@ public class SolidSyncClient {
         try {
             return future.toCompletableFuture().join();
         } catch (final CompletionException ex) {
-            throw (R) ex.getCause();
+            if (ex.getCause() != null) {
+                throw (R) ex.getCause();
+            }
+            throw new InruptClientException("Error performing SolidClient operation", ex);
         }
     }
 }


### PR DESCRIPTION
There are many possible approaches to refactoring the use of futures in the SolidSyncClient, but I opted to keep this as simple as possible. If a user wants full control over this there are many alternatives, such as:

* Use the async client
* Configure an HTTP Client with specific timeouts as part of the client construction process
* Use the low-level client and set timeouts on a per-request basis

The high-level client is intended to be simple to use, and this implementation retains that level of simplicity.