### PR TITLE
JCL-361: Make it easier to modify Access Control resources

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -25,6 +25,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-vocabulary</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>${commons.io.version}</version>

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -391,13 +391,13 @@ public class AccessGrantClient {
         final URI type;
         final Set<String> supportedTypes;
         if (AccessGrant.class.isAssignableFrom(clazz)) {
-            type = ACCESS_GRANT;
+            type = URI.create("SolidAccessGrant");
             supportedTypes = ACCESS_GRANT_TYPES;
         } else if (AccessRequest.class.isAssignableFrom(clazz)) {
-            type = ACCESS_REQUEST;
+            type = URI.create("SolidAccessRequest");
             supportedTypes = ACCESS_REQUEST_TYPES;
         } else if (AccessDenial.class.isAssignableFrom(clazz)) {
-            type = ACCESS_DENIAL;
+            type = URI.create("SolidAccessDenial");
             supportedTypes = ACCESS_DENIAL_TYPES;
         } else {
             throw new AccessGrantException("Unsupported type " + clazz + " in query request");

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantUtils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantUtils.java
@@ -20,6 +20,8 @@
  */
 package com.inrupt.client.accessgrant;
 
+import static com.inrupt.client.vocabulary.RDF.type;
+
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.vocabulary.ACP;
@@ -47,13 +49,16 @@ public final class AccessGrantUtils {
 
     public static Set<Triple> accessControlPolicyTriples(final URI acl, final URI... modes) {
         final Set<Triple> triples = new HashSet<>();
+        final IRI a = asIRI(type);
 
         // Matcher
         final IRI matcher = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(matcher, a, asIRI(ACP.Matcher)));
         triples.add(rdf.createTriple(matcher, asIRI(ACP.vc), SOLID_ACCESS_GRANT));
 
         // Policy
         final IRI policy = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(policy, a, asIRI(ACP.Policy)));
         triples.add(rdf.createTriple(policy, asIRI(ACP.allOf), matcher));
         for (final URI mode : modes ) {
             triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(mode)));
@@ -61,10 +66,14 @@ public final class AccessGrantUtils {
 
         // Access Control
         final IRI accessControl = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(accessControl, a, asIRI(ACP.AccessControl)));
         triples.add(rdf.createTriple(accessControl, asIRI(ACP.apply), policy));
 
-        triples.add(rdf.createTriple(asIRI(acl), asIRI(ACP.accessControl), accessControl));
-        triples.add(rdf.createTriple(asIRI(acl), asIRI(ACP.memberAccessControl), accessControl));
+        // Access Control Resource
+        final IRI subject = asIRI(acl);
+        triples.add(rdf.createTriple(subject, a, asIRI(ACP.AccessControlResource)));
+        triples.add(rdf.createTriple(subject, asIRI(ACP.accessControl), accessControl));
+        triples.add(rdf.createTriple(subject, asIRI(ACP.memberAccessControl), accessControl));
         return triples;
     }
 

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantUtils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantUtils.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.accessgrant;
+
+import com.inrupt.client.spi.RDFFactory;
+import com.inrupt.client.util.URIBuilder;
+import com.inrupt.client.vocabulary.ACP;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.Triple;
+
+/**
+ * Utility methods for use with the Access Grant module.
+ **/
+public final class AccessGrantUtils {
+
+    private static final RDF rdf = RDFFactory.getInstance();
+    private static final IRI SOLID_ACCESS_GRANT = rdf.createIRI("http://www.w3.org/ns/solid/vc#SolidAccessGrant");
+
+    private static IRI asIRI(final URI uri) {
+        return rdf.createIRI(uri.toString());
+    }
+
+    public static Set<Triple> accessControlPolicyTriples(final URI acl, final URI... modes) {
+        final Set<Triple> triples = new HashSet<>();
+
+        // Matcher
+        final IRI matcher = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(matcher, asIRI(ACP.vc), SOLID_ACCESS_GRANT));
+
+        // Policy
+        final IRI policy = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(policy, asIRI(ACP.allOf), matcher));
+        for (final URI mode : modes ) {
+            triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(mode)));
+        }
+
+        // Access Control
+        final IRI accessControl = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(accessControl, asIRI(ACP.apply), policy));
+
+        triples.add(rdf.createTriple(asIRI(acl), asIRI(ACP.accessControl), accessControl));
+        triples.add(rdf.createTriple(asIRI(acl), asIRI(ACP.memberAccessControl), accessControl));
+        return triples;
+    }
+
+    private AccessGrantUtils() {
+        // Prevent instantiation
+    }
+}

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -203,7 +203,7 @@ public class AuthenticationScenarios {
     @MethodSource("provideSessions")
     @DisplayName(":authenticatedPublicNode Authenticated fetch of public resource succeeds")
     void fetchPublicResourceAuthenticatedTest(final Session session) {
-        LOGGER.info("Integration Test - AuAuthenticatedth fetch of public resource");
+        LOGGER.info("Integration Test - Authenticated fetch of public resource");
         //create public resource
         final SolidSyncClient client = SolidSyncClient.getClient();
         try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURL, null, null)) {


### PR DESCRIPTION
This introduces a utility function to make it easier to modify Access Control resources to support AccessGrants.

Eventually, this will become part of a stand-alone ACP module, but adding full support for ACP is beyond the scope of the 1.0 release. This, however, allows developers to interact more easily with ACRs within the 1.0 release timeframe.

A sample usage of this would be:

```java
try (final SolidRDFSource resource = client.read(uri, SolidRDFSource.class)) {
    resource.getMetadata().getAcl().ifPresent(acl -> {
        try (final SolidRDFSource acr = client.read(acl, SolidRDFSource.class)) {
            AccessGrantUtils.accessControlPolicyTriples(acl, ACL.Read, ACL.Write)
                .forEach(acr.getGraph()::add);
            client.update(acr);
        }
    });
}
```
