### PR TITLE
JCL-355: Add reset method to session interface

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
@@ -105,6 +105,12 @@ public final class AccessGrantSession implements Session {
     }
 
     @Override
+    public void reset() {
+        session.reset();
+        tokenCache.invalidateAll();
+    }
+
+    @Override
     public Optional<URI> getPrincipal() {
         return session.getPrincipal();
     }

--- a/access-grant/src/test/resources/access_grant3.json
+++ b/access-grant/src/test/resources/access_grant3.json
@@ -1,0 +1,31 @@
+{
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [{
+        "@context":[
+            "https://www.w3.org/2018/credentials/v1",
+            "https://w3id.org/security/suites/ed25519-2020/v1",
+            "https://w3id.org/vc-revocation-list-2020/v1",
+            "https://schema.inrupt.com/credentials/v1.jsonld"],
+        "id":"https://accessgrant.example/credential/5c6060ad-2f16-4bc1-b022-dffb46bff626",
+        "type":["VerifiableCredential","SolidAccessGrant"],
+        "issuer":"https://accessgrant.example",
+        "expirationDate":"2022-08-27T12:00:00Z",
+        "issuanceDate":"2022-08-25T20:34:05.153Z",
+        "credentialSubject":{
+            "id":"https://id.example/grantor",
+            "providedConsent":{
+                "mode":["Read"],
+                "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
+                "isProvidedToPerson":"https://id.example/grantee",
+                "forPurpose":["https://purpose.example/Purpose1"],
+                "forPersonalData":["https://storage.example/protected-resource"]}},
+        "proof":{
+            "created":"2022-08-25T20:34:05.236Z",
+            "proofPurpose":"assertionMethod",
+            "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+            "type":"Ed25519Signature2020",
+            "verificationMethod":"https://accessgrant.example/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+    }]
+}
+

--- a/api/src/main/java/com/inrupt/client/auth/Session.java
+++ b/api/src/main/java/com/inrupt/client/auth/Session.java
@@ -94,6 +94,11 @@ public interface Session {
     Optional<String> selectThumbprint(Collection<String> algorithms);
 
     /**
+     * Reset the session state, clearing any internal caches.
+     */
+    void reset();
+
+    /**
      * Fetch an authentication token from session values.
      *
      * @param request the HTTP request
@@ -157,6 +162,11 @@ public interface Session {
             @Override
             public Optional<String> selectThumbprint(final Collection<String> algorithms) {
                 return Optional.empty();
+            }
+
+            @Override
+            public void reset() {
+                // no-op
             }
 
             @Override

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -231,6 +231,12 @@ public final class OpenIdSession implements Session {
     }
 
     @Override
+    public void reset() {
+        credential.set(null);
+        requestCache.invalidateAll();
+    }
+
+    @Override
     public CompletionStage<Optional<Credential>> authenticate(final Authenticator auth,
             final Request request, final Set<String> algorithms) {
         final Optional<Credential> credential = getCredential(ID_TOKEN, null);

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdSessionTest.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdSessionTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.Request;
 import com.inrupt.client.auth.Authenticator;
+import com.inrupt.client.auth.Challenge;
 import com.inrupt.client.auth.Credential;
 import com.inrupt.client.auth.DPoP;
 import com.inrupt.client.auth.Session;
@@ -158,9 +159,14 @@ class OpenIdSessionTest {
         final Optional<URI> principal = session.getPrincipal();
         assertEquals(Optional.of(URI.create(WEBID)), principal);
         assertFalse(session.fromCache(null).isPresent());
-        final Optional<Credential> credential = session.authenticate(null, Collections.emptySet())
+        final Authenticator auth = new OpenIdAuthenticationProvider().getAuthenticator(Challenge.of("Bearer"));
+        final Request req = Request.newBuilder(URI.create("https://storage.example")).build();
+        final Optional<Credential> credential = session.authenticate(auth, req, Collections.emptySet())
             .toCompletableFuture().join();
         assertEquals(Optional.of(URI.create(WEBID)), credential.flatMap(Credential::getPrincipal));
+        assertTrue(session.fromCache(req).isPresent());
+        session.reset();
+        assertFalse(session.fromCache(req).isPresent());
     }
 
     @Test

--- a/uma/src/main/java/com/inrupt/client/uma/UmaSession.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaSession.java
@@ -82,6 +82,14 @@ public final class UmaSession implements Session {
     }
 
     @Override
+    public void reset() {
+        for (final Session session : internalSessions) {
+            session.reset();
+        }
+        tokenCache.invalidateAll();
+    }
+
+    @Override
     public Optional<URI> getPrincipal() {
         for (final Session session : internalSessions) {
             final Optional<URI> principal = session.getPrincipal();


### PR DESCRIPTION
This adds a `reset()` method to the Session interface, allowing a developer to reset any internal state of a Session object.