### PR TITLE
JCL-363: Rework verification response object

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialVerification.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialVerification.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.accessgrant;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The response from a verification operation.
+ */
+public class AccessCredentialVerification {
+
+    private final List<String> checks;
+    private final List<String> warnings;
+    private final List<String> errors;
+
+    /**
+     * Create a verification response.
+     *
+     * @param checks the checks that were performed
+     * @param warnings any warnings from the verification operation
+     * @param errors any errors from the verification operation
+     */
+    public AccessCredentialVerification(final List<String> checks, final List<String> warnings,
+            final List<String> errors) {
+        this.checks = makeImmutable(checks);
+        this.warnings = makeImmutable(warnings);
+        this.errors = makeImmutable(errors);
+    }
+
+    /**
+     * The verification checks that were performed.
+     *
+     * @return a list of any verification checks performed, never {@code null}
+     */
+    public List<String> getChecks() {
+        return checks;
+    }
+
+    /**
+     * The verification warnings that were discovered.
+     *
+     * @return a list of any verification warnings, never {@code null}
+     */
+    public List<String> getWarnings() {
+        return warnings;
+    }
+
+    /**
+     * The verification errors that were discovered.
+     *
+     * @return a list of any verification errors, never {@code null}
+     */
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    static List<String> makeImmutable(final List<String> list) {
+        if (list != null) {
+            return Collections.unmodifiableList(list);
+        }
+        return Collections.emptyList();
+    }
+}
+

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialVerification.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialVerification.java
@@ -49,7 +49,7 @@ public class AccessCredentialVerification {
     /**
      * The verification checks that were performed.
      *
-     * @return a list of any verification checks performed, never {@code null}
+     * @return an unmodifiable list of any verification checks performed, never {@code null}
      */
     public List<String> getChecks() {
         return checks;
@@ -58,7 +58,7 @@ public class AccessCredentialVerification {
     /**
      * The verification warnings that were discovered.
      *
-     * @return a list of any verification warnings, never {@code null}
+     * @return an unmodifiable list of any verification warnings, never {@code null}
      */
     public List<String> getWarnings() {
         return warnings;
@@ -67,7 +67,7 @@ public class AccessCredentialVerification {
     /**
      * The verification errors that were discovered.
      *
-     * @return a list of any verification errors, never {@code null}
+     * @return an unmodifiable list of any verification errors, never {@code null}
      */
     public List<String> getErrors() {
         return errors;

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -101,10 +101,10 @@ class AccessGrantClientTest {
         assertEquals(uri, grant.getIdentifier());
         assertEquals(baseUri, grant.getIssuer());
 
-        final AccessGrantClient.VerificationResponse response = client.verify(grant).toCompletableFuture().join();
-        assertTrue(response.checks.contains("expirationDate"));
-        assertTrue(response.warnings.isEmpty());
-        assertTrue(response.errors.isEmpty());
+        final AccessCredentialVerification response = client.verify(grant).toCompletableFuture().join();
+        assertTrue(response.getChecks().contains("expirationDate"));
+        assertTrue(response.getWarnings().isEmpty());
+        assertTrue(response.getErrors().isEmpty());
 
         // Revoke
         assertDoesNotThrow(client.revoke(grant).toCompletableFuture()::join);
@@ -144,10 +144,10 @@ class AccessGrantClientTest {
         assertEquals(uri, grant.getIdentifier());
         assertEquals(baseUri, grant.getIssuer());
 
-        final AccessGrantClient.VerificationResponse response = client.verify(grant).toCompletableFuture().join();
-        assertTrue(response.checks.contains("expirationDate"));
-        assertTrue(response.warnings.isEmpty());
-        assertTrue(response.errors.isEmpty());
+        final AccessCredentialVerification response = client.verify(grant).toCompletableFuture().join();
+        assertTrue(response.getChecks().contains("expirationDate"));
+        assertTrue(response.getWarnings().isEmpty());
+        assertTrue(response.getErrors().isEmpty());
 
         // Revoke
         assertDoesNotThrow(client.revoke(grant).toCompletableFuture()::join);
@@ -197,10 +197,10 @@ class AccessGrantClientTest {
         assertEquals(uri, request.getIdentifier());
         assertEquals(baseUri, request.getIssuer());
 
-        final AccessGrantClient.VerificationResponse response = client.verify(request).toCompletableFuture().join();
-        assertTrue(response.checks.contains("expirationDate"));
-        assertTrue(response.warnings.isEmpty());
-        assertTrue(response.errors.isEmpty());
+        final AccessCredentialVerification response = client.verify(request).toCompletableFuture().join();
+        assertTrue(response.getChecks().contains("expirationDate"));
+        assertTrue(response.getWarnings().isEmpty());
+        assertTrue(response.getErrors().isEmpty());
 
         // Revoke
         final CompletionException err1 = assertThrows(CompletionException.class, () ->


### PR DESCRIPTION
The current `VerificationResponse` object is an internal class (POJO) in `AccessCredentialClient`, but it should be more properly structured. This PR moves the simple POJO into its own immutable class. There is still an internal POJO for JSON marshalling.