### PR TITLE
JCL-309: Specialized HTTP client exceptions

### DIFF
--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -36,10 +36,7 @@ import com.inrupt.client.auth.Credential;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.openid.OpenIdException;
 import com.inrupt.client.openid.OpenIdSession;
-import com.inrupt.client.solid.SolidClientException;
-import com.inrupt.client.solid.SolidNonRDFSource;
-import com.inrupt.client.solid.SolidRDFSource;
-import com.inrupt.client.solid.SolidSyncClient;
+import com.inrupt.client.solid.*;
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.vocabulary.ACL;
@@ -240,7 +237,7 @@ public class AccessGrantScenarios {
 
         //unauthorized request test
         final SolidSyncClient client = SolidSyncClient.getClientBuilder().build();
-        final SolidClientException err = assertThrows(SolidClientException.class,
+        final var err = assertThrows(UnauthorizedException.class,
                 () -> client.read(sharedTextFileURI, SolidNonRDFSource.class));
         assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
         final Request reqRead =

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -33,6 +33,7 @@ import com.inrupt.client.openid.OpenIdSession;
 import com.inrupt.client.solid.SolidClientException;
 import com.inrupt.client.solid.SolidRDFSource;
 import com.inrupt.client.solid.SolidSyncClient;
+import com.inrupt.client.solid.UnauthorizedException;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.webid.WebIdProfile;
 
@@ -190,7 +191,7 @@ public class AuthenticationScenarios {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             final SolidSyncClient client = SolidSyncClient.getClient();
-            final SolidClientException err = assertThrows(SolidClientException.class,
+            final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURL, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
@@ -242,7 +243,7 @@ public class AuthenticationScenarios {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             final SolidSyncClient client = SolidSyncClient.getClient();
-            final SolidClientException err = assertThrows(SolidClientException.class,
+            final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURL, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
@@ -278,7 +279,7 @@ public class AuthenticationScenarios {
                 assertDoesNotThrow(() -> authClient2.read(privateResourceURL, SolidRDFSource.class));
 
                 final SolidSyncClient client = SolidSyncClient.getClient();
-                final SolidClientException err = assertThrows(SolidClientException.class,
+                final var err = assertThrows(UnauthorizedException.class,
                         () -> client.read(privateResourceURL, SolidRDFSource.class));
                 assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -26,11 +26,7 @@ import com.inrupt.client.Headers;
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.auth.Session;
-import com.inrupt.client.solid.SolidClientException;
-import com.inrupt.client.solid.SolidContainer;
-import com.inrupt.client.solid.SolidRDFSource;
-import com.inrupt.client.solid.SolidResourceHandlers;
-import com.inrupt.client.solid.SolidSyncClient;
+import com.inrupt.client.solid.*;
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.vocabulary.PIM;
@@ -261,7 +257,7 @@ public class DomainModulesResource {
         }
 
         final var missingWebId = URIBuilder.newBuilder(URI.create(webidUrl)).path(UUID.randomUUID().toString()).build();
-        final var err = assertThrows(SolidClientException.class, () -> client.read(missingWebId, WebIdProfile.class));
+        final var err = assertThrows(NotFoundException.class, () -> client.read(missingWebId, WebIdProfile.class));
         assertEquals(404, err.getStatusCode());
         assertEquals(missingWebId, err.getUri());
     }

--- a/solid/src/main/java/com/inrupt/client/solid/BadRequestException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/BadRequestException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP bad request (400) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.400">RFC 9110 (15.5.1.) 400 Bad Request</a>
  */
 public class BadRequestException extends SolidClientException {
     private static final long serialVersionUID = -3379457428921025570L;

--- a/solid/src/main/java/com/inrupt/client/solid/BadRequestException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/BadRequestException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class BadRequestException extends SolidClientException {
+    private static final long serialVersionUID = -3379457428921025570L;
+
+    public static final int STATUS_CODE = 400;
+
+    /**
+     * Create a BadRequestException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public BadRequestException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/ConflictException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/ConflictException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class ConflictException extends SolidClientException {
+    private static final long serialVersionUID = -203198307847520748L;
+
+    public static final int STATUS_CODE = 409;
+
+    /**
+     * Create a ConflictException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public ConflictException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/ConflictException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/ConflictException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP conflict (409) response..
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.409">RFC 9110 (15.5.10.) 409 Conflict</a>
  */
 public class ConflictException extends SolidClientException {
     private static final long serialVersionUID = -203198307847520748L;

--- a/solid/src/main/java/com/inrupt/client/solid/ForbiddenException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/ForbiddenException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class ForbiddenException extends SolidClientException {
+    private static final long serialVersionUID = 3299286274724874244L;
+
+    public static final int STATUS_CODE = 403;
+
+    /**
+     * Create a ForbiddenException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public ForbiddenException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/ForbiddenException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/ForbiddenException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP forbidden (403) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.403">RFC 9110 (15.5.4.) 403 Forbidden</a>
  */
 public class ForbiddenException extends SolidClientException {
     private static final long serialVersionUID = 3299286274724874244L;

--- a/solid/src/main/java/com/inrupt/client/solid/GoneException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/GoneException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP gone (410) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.410">RFC 9110 (15.5.11.) 410 Gone</a>
  */
 public class GoneException extends SolidClientException {
     private static final long serialVersionUID = -6892345582498100242L;

--- a/solid/src/main/java/com/inrupt/client/solid/GoneException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/GoneException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class GoneException extends SolidClientException {
+    private static final long serialVersionUID = -6892345582498100242L;
+
+    public static final int STATUS_CODE = 410;
+
+    /**
+     * Create a GoneException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public GoneException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/InternalServerErrorException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/InternalServerErrorException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP internal server error (500) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.500">RFC 9110 (15.6.1.) 500 Internal Server Error</a>
  */
 public class InternalServerErrorException extends SolidClientException {
     private static final long serialVersionUID = -6672490715281719330L;

--- a/solid/src/main/java/com/inrupt/client/solid/InternalServerErrorException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/InternalServerErrorException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class InternalServerErrorException extends SolidClientException {
+    private static final long serialVersionUID = -6672490715281719330L;
+
+    public static final int STATUS_CODE = 500;
+
+    /**
+     * Create an InternalServerErrorException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public InternalServerErrorException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/MethodNotAllowedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/MethodNotAllowedException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP method not allowed (405) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.405">RFC 9110 (15.5.6.) 405 Method Not Allowed</a>
  */
 public class MethodNotAllowedException extends SolidClientException {
     private static final long serialVersionUID = -9125437562813923030L;

--- a/solid/src/main/java/com/inrupt/client/solid/MethodNotAllowedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/MethodNotAllowedException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class MethodNotAllowedException extends SolidClientException {
+    private static final long serialVersionUID = -9125437562813923030L;
+
+    public static final int STATUS_CODE = 405;
+
+    /**
+     * Create a MethodNotAllowedException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public MethodNotAllowedException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/NotAcceptableException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/NotAcceptableException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class NotAcceptableException extends SolidClientException {
+    private static final long serialVersionUID = 6594993822477388733L;
+
+    public static final int STATUS_CODE = 406;
+
+    /**
+     * Create a NotAcceptableException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public NotAcceptableException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/NotAcceptableException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/NotAcceptableException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP not acceptable (406) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.406">RFC 9110 (15.5.7.) 406 Not Acceptable</a>
  */
 public class NotAcceptableException extends SolidClientException {
     private static final long serialVersionUID = 6594993822477388733L;

--- a/solid/src/main/java/com/inrupt/client/solid/NotFoundException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/NotFoundException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP not found (404) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.404">RFC 9110 (15.5.5.) 404 Not Found</a>
  */
 public class NotFoundException extends SolidClientException {
     private static final long serialVersionUID = -2256628528500739683L;

--- a/solid/src/main/java/com/inrupt/client/solid/NotFoundException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/NotFoundException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class NotFoundException extends SolidClientException {
+    private static final long serialVersionUID = -2256628528500739683L;
+
+    public static final int STATUS_CODE = 404;
+
+    /**
+     * Create a NotFoundException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public NotFoundException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/PreconditionFailedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/PreconditionFailedException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class PreconditionFailedException extends SolidClientException {
+    private static final long serialVersionUID = 4205761003697773528L;
+
+    public static final int STATUS_CODE = 412;
+
+    /**
+     * Create a PreconditionFailedException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public PreconditionFailedException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/PreconditionFailedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/PreconditionFailedException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP precondition failed (412) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.412">RFC 9110 (15.5.13.) 412 Precondition Failed</a>
  */
 public class PreconditionFailedException extends SolidClientException {
     private static final long serialVersionUID = 4205761003697773528L;

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -133,7 +133,7 @@ public class SolidClient {
         return client.send(builder.build(), Response.BodyHandlers.ofByteArray())
             .thenApply(response -> {
                 if (response.statusCode() >= ERROR_STATUS) {
-                    throw new SolidClientException("Unable to read resource at " + identifier, identifier,
+                    throw SolidClientException.handle("Unable to read resource at " + identifier, identifier,
                             response.statusCode(), response.headers(), new String(response.body()));
                 } else {
                     final String contentType = response.headers().firstValue(CONTENT_TYPE)
@@ -285,7 +285,7 @@ public class SolidClient {
             if (isSuccess(res.statusCode())) {
                 return null;
             } else {
-                throw new SolidClientException("Unable to delete resource", resource.getIdentifier(),
+                throw SolidClientException.handle("Unable to delete resource", resource.getIdentifier(),
                         res.statusCode(), res.headers(), new String(res.body(), UTF_8));
             }
         });
@@ -369,7 +369,7 @@ public class SolidClient {
             final Headers headers, final String message) {
         return res -> {
             if (!isSuccess(res.statusCode())) {
-                throw new SolidClientException(message, resource.getIdentifier(),
+                throw SolidClientException.handle(message, resource.getIdentifier(),
                         res.statusCode(), res.headers(), new String(res.body(), UTF_8));
             }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
@@ -90,5 +90,41 @@ public class SolidClientException extends InruptClientException {
     public String getBody() {
         return body;
     }
+
+    public static SolidClientException handle(
+            final String message,
+            final URI uri,
+            final int statusCode,
+            final Headers headers,
+            final String body) {
+        switch (statusCode) {
+            case BadRequestException.STATUS_CODE:
+                return new BadRequestException(message, uri, headers, body);
+            case UnauthorizedException.STATUS_CODE:
+                return new UnauthorizedException(message, uri, headers, body);
+            case ForbiddenException.STATUS_CODE:
+                return new ForbiddenException(message, uri, headers, body);
+            case NotFoundException.STATUS_CODE:
+                return new NotFoundException(message, uri, headers, body);
+            case MethodNotAllowedException.STATUS_CODE:
+                return new MethodNotAllowedException(message, uri, headers, body);
+            case NotAcceptableException.STATUS_CODE:
+                return new NotAcceptableException(message, uri, headers, body);
+            case ConflictException.STATUS_CODE:
+                return new ConflictException(message, uri, headers, body);
+            case GoneException.STATUS_CODE:
+                return new GoneException(message, uri, headers, body);
+            case PreconditionFailedException.STATUS_CODE:
+                return new PreconditionFailedException(message, uri, headers, body);
+            case UnsupportedMediaTypeException.STATUS_CODE:
+                return new UnsupportedMediaTypeException(message, uri, headers, body);
+            case TooManyRequestsException.STATUS_CODE:
+                return new TooManyRequestsException(message, uri, headers, body);
+            case InternalServerErrorException.STATUS_CODE:
+                return new InternalServerErrorException(message, uri, headers, body);
+            default:
+                return new SolidClientException(message, uri, statusCode, headers, body);
+        }
+    }
 }
 

--- a/solid/src/main/java/com/inrupt/client/solid/TooManyRequestsException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/TooManyRequestsException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP too many requests (429) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc6585#section-4">RFC 6585 (4.) 429 Too Many Requests</a>
  */
 public class TooManyRequestsException extends SolidClientException {
     private static final long serialVersionUID = -1798491190232642824L;

--- a/solid/src/main/java/com/inrupt/client/solid/TooManyRequestsException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/TooManyRequestsException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class TooManyRequestsException extends SolidClientException {
+    private static final long serialVersionUID = -1798491190232642824L;
+
+    public static final int STATUS_CODE = 429;
+
+    /**
+     * Create a TooManyRequestsException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public TooManyRequestsException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/UnauthorizedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/UnauthorizedException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class UnauthorizedException extends SolidClientException {
+    private static final long serialVersionUID = -3219668517323678497L;
+
+    public static final int STATUS_CODE = 401;
+
+    /**
+     * Create an UnauthorizedException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public UnauthorizedException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/main/java/com/inrupt/client/solid/UnauthorizedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/UnauthorizedException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP unauthorized (401) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.401">RFC 9110 (15.5.2.) 401 Unauthorized</a>
  */
 public class UnauthorizedException extends SolidClientException {
     private static final long serialVersionUID = -3219668517323678497L;

--- a/solid/src/main/java/com/inrupt/client/solid/UnsupportedMediaTypeException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/UnsupportedMediaTypeException.java
@@ -25,7 +25,9 @@ import com.inrupt.client.Headers;
 import java.net.URI;
 
 /**
- * A runtime exception for use with SolidClient HTTP operations.
+ * A runtime exception that represents an HTTP unsupported media type (415) response.
+ *
+ * @see <a href="https://www.rfc-editor.org/rfc/rfc9110#status.415">RFC 9110 (15.5.16.) 415 Unsupported Media Type</a>
  */
 public class UnsupportedMediaTypeException extends SolidClientException {
     private static final long serialVersionUID = 1312856145838280673L;

--- a/solid/src/main/java/com/inrupt/client/solid/UnsupportedMediaTypeException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/UnsupportedMediaTypeException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.solid;
+
+import com.inrupt.client.Headers;
+
+import java.net.URI;
+
+/**
+ * A runtime exception for use with SolidClient HTTP operations.
+ */
+public class UnsupportedMediaTypeException extends SolidClientException {
+    private static final long serialVersionUID = 1312856145838280673L;
+
+    public static final int STATUS_CODE = 415;
+
+    /**
+     * Create an UnsupportedMediaTypeException exception.
+     *
+     * @param message the message
+     * @param uri the uri
+     * @param headers the response headers
+     * @param body the body
+     */
+    public UnsupportedMediaTypeException(
+            final String message,
+            final URI uri,
+            final Headers headers,
+            final String body) {
+        super(message, uri, STATUS_CODE, headers, body);
+    }
+}

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -243,7 +243,10 @@ class SolidClientTest {
 
     @ParameterizedTest
     @MethodSource
-    void testExceptionalResources(final URI uri, final int expectedStatusCode) {
+    <T extends SolidClientException> void testExceptionalResources(
+            final URI uri,
+            final int expectedStatusCode,
+            final Class<T> clazz) {
 
         final CompletableFuture<Recipe> future =
             client.read(uri, Recipe.class)
@@ -251,6 +254,7 @@ class SolidClientTest {
         final CompletionException err = assertThrows(CompletionException.class, () ->
             future.join());
         assertTrue(err.getCause() instanceof SolidClientException);
+        assertInstanceOf(clazz, err.getCause());
         final SolidClientException ex = (SolidClientException) err.getCause();
         assertEquals(expectedStatusCode, ex.getStatusCode());
         assertEquals(uri, ex.getUri());
@@ -261,10 +265,13 @@ class SolidClientTest {
     private static Stream<Arguments> testExceptionalResources() {
         return Stream.of(
                 Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/unauthorized"), 401),
+                    URI.create(config.get("solid_resource_uri") + "/unauthorized"), 401,
+                        UnauthorizedException.class),
                 Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/forbidden"), 403),
+                    URI.create(config.get("solid_resource_uri") + "/forbidden"), 403,
+                        ForbiddenException.class),
                 Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/missing"), 404));
+                    URI.create(config.get("solid_resource_uri") + "/missing"), 404,
+                        NotFoundException.class));
     }
 }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
@@ -179,8 +179,11 @@ class SolidSyncClientTest {
 
     @ParameterizedTest
     @MethodSource
-    void testExceptionalResources(final URI uri, final int expectedStatusCode) {
-        final SolidClientException err = assertThrows(SolidClientException.class, () -> client.read(uri, Recipe.class));
+    <T extends SolidClientException> void testExceptionalResources(
+            final URI uri,
+            final int expectedStatusCode,
+            final Class<T> clazz) {
+        final SolidClientException err = assertThrows(clazz, () -> client.read(uri, Recipe.class));
 
         assertEquals(expectedStatusCode, err.getStatusCode());
         assertEquals(uri, err.getUri());
@@ -191,10 +194,13 @@ class SolidSyncClientTest {
     private static Stream<Arguments> testExceptionalResources() {
         return Stream.of(
                 Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/unauthorized"), 401),
+                    URI.create(config.get("solid_resource_uri") + "/unauthorized"), 401,
+                        UnauthorizedException.class),
                 Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/forbidden"), 403),
+                    URI.create(config.get("solid_resource_uri") + "/forbidden"), 403,
+                        ForbiddenException.class),
                 Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/missing"), 404));
+                    URI.create(config.get("solid_resource_uri") + "/missing"), 404,
+                        NotFoundException.class));
     }
 }


### PR DESCRIPTION
Changes in PR:
- new specialized exceptions to cover most common HTTP client errors: `400 Bad Request`, `401 Unauthorized`, `403 Forbidden`, `404 Not Found`, `405 Method Not Allowed`, `406 Not Acceptable`, `409 Conflict`, `410 Gone`, `412 Precondition Failed`, `415 Unsupported Media Type`, `429 Too Many Requests`, `500 Internal Server Error`
- `SolidClient` throws specialized exceptions whenever applicable