### PR TITLE
JCL-359: Add support for AccessDenial credentials via the Query API

### DIFF
--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -561,6 +561,23 @@ class AccessGrantClientTest {
     }
 
     @Test
+    void testQueryDenial() {
+        final Map<String, Object> claims = new HashMap<>();
+        claims.put("webid", WEBID);
+        claims.put("sub", SUB);
+        claims.put("iss", ISS);
+        claims.put("azp", AZP);
+        final String token = generateIdToken(claims);
+        final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
+
+        final List<AccessDenial> grants = client.query(null,
+                URI.create("https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/e/f/g"), "Read",
+                AccessDenial.class)
+                    .toCompletableFuture().join();
+        assertEquals(1, grants.size());
+    }
+
+    @Test
     void testQueryInvalidType() {
         final Map<String, Object> claims = new HashMap<>();
         claims.put("webid", WEBID);

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
@@ -276,6 +276,17 @@ class MockAccessGrantServer {
         wireMockServer.stubFor(post(urlEqualTo("/derive"))
                     .atPriority(1)
                     .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .withRequestBody(containing("SolidAccessDenial"))
+                    .withRequestBody(containing(
+                            "\"https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/\""))
+                    .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResource("/query_response6.json", wireMockServer.baseUrl()))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/derive"))
+                    .atPriority(1)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
                     .withRequestBody(containing("SolidAccessRequest"))
                     .withRequestBody(containing(
                             "\"https://storage.example/f1759e6d-4dda-4401-be61-d90d070a5474/\""))

--- a/access-grant/src/test/resources/query_response6.json
+++ b/access-grant/src/test/resources/query_response6.json
@@ -1,0 +1,33 @@
+{
+  "verifiableCredential": [{
+    "@context":[
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1",
+        "https://w3id.org/vc-revocation-list-2020/v1",
+        "https://schema.inrupt.com/credentials/v1.jsonld"],
+    "id":"{{baseUrl}}/access-grant-1",
+    "type":["VerifiableCredential","SolidAccessDenial"],
+    "issuer":"{{baseUrl}}",
+    "expirationDate":"2022-08-27T12:00:00Z",
+    "issuanceDate":"2022-08-25T20:34:05.153Z",
+    "credentialStatus":{
+        "id":"https://accessgrant.example/status/CVAM#2832",
+        "revocationListCredential":"https://accessgrant.example/status/CVAM",
+        "revocationListIndex":"2832",
+        "type":"RevocationList2020Status"},
+    "credentialSubject":{
+        "id":"https://id.example/grantor",
+        "providedConsent":{
+            "mode":["Read"],
+            "hasStatus":"https://w3id.org/GConsent#ConsentStatusRefused",
+            "isProvidedToPerson":"https://id.example/grantee",
+            "forPurpose":["https://purpose.example/Purpose1"],
+            "forPersonalData":["https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/"]}},
+    "proof":{
+        "created":"2022-08-25T20:34:05.236Z",
+        "proofPurpose":"assertionMethod",
+        "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+        "type":"Ed25519Signature2020",
+        "verificationMethod":"https://accessgrant.example/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+  }]
+}


### PR DESCRIPTION
This adds support for the AccessDenial credential type at the Query API. I don't entirely like the growing if/else statement for marshaling this data into objects, so I would like to come back to that. For now, this adds support for these queries, which is currently lacking.