### PR TITLE
JCL-359: Reduce duplication in AccessCredential types

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -20,87 +20,321 @@
  */
 package com.inrupt.client.accessgrant;
 
+import static com.inrupt.client.accessgrant.Utils.*;
+
 import java.net.URI;
 import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-public interface AccessCredential {
+public class AccessCredential {
+
+    protected static final String TYPE = "type";
+    protected static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
+
+    private final String credential;
+    private final URI issuer;
+    private final URI identifier;
+    private final Set<String> types;
+    private final Set<String> purposes;
+    private final Set<String> modes;
+    private final Set<URI> resources;
+    private final URI recipient;
+    private final URI creator;
+    private final Instant expiration;
+    private final Status status;
+
+    /**
+     * Create a base class for credential types.
+     * @param identifier the credential identifier
+     * @param credential the full credential
+     * @param data items pertaining to user-defined credential data
+     * @param metadata items pertaining to server-managed credential data
+     */
+    protected AccessCredential(final URI identifier, final String credential,
+            final CredentialData data, final CredentialMetadata metadata) {
+        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null");
+        this.credential = Objects.requireNonNull(credential, "credential may not be null!");
+        Objects.requireNonNull(data, "credential data may not be null!");
+        Objects.requireNonNull(metadata, "credential metadata may not be null!");
+
+        this.purposes = data.getPurposes();
+        this.resources = data.getResources();
+        this.modes = data.getModes();
+        this.recipient = data.getRecipient();
+
+        this.issuer = metadata.getIssuer();
+        this.creator = metadata.getCreator();
+        this.types = metadata.getTypes();
+        this.status = metadata.getStatus();
+        this.expiration = metadata.getExpiration();
+    }
 
     /**
      * Get the types of the access credential.
      *
      * @return the access credential types
      */
-    Set<String> getTypes();
+    public Set<String> getTypes() {
+        return types;
+    }
 
     /**
      * Get the access modes of the access credential.
      *
      * @return the access credential types
      */
-    Set<String> getModes();
+    public Set<String> getModes() {
+        return modes;
+    }
 
     /**
      * Get the revocation status of the access credential.
      *
      * @return the revocation status, if present
      */
-    Optional<Status> getStatus();
+    public Optional<Status> getStatus() {
+        return Optional.ofNullable(status);
+    }
 
     /**
      * Get the expiration time of the access credential.
      *
      * @return the expiration time
      */
-    Instant getExpiration();
+    public Instant getExpiration() {
+        if (expiration != null) {
+            return expiration;
+        }
+        return Instant.MAX;
+    }
 
     /**
      * Get the issuer of the access credential.
      *
      * @return the issuer
      */
-    URI getIssuer();
+    public URI getIssuer() {
+        return issuer;
+    }
 
     /**
      * Get the identifier of the access credential.
      *
      * @return the identifier
      */
-    URI getIdentifier();
+    public URI getIdentifier() {
+        return identifier;
+    }
 
     /**
      * Get the collection of purposes associated with the access credential.
      *
      * @return the purposes
      */
-    Set<String> getPurposes();
+    public Set<String> getPurposes() {
+        return purposes;
+    }
 
     /**
      * Get the resources associated with the access credential.
      *
      * @return the associated resource identifiers
      */
-    Set<URI> getResources();
+    public Set<URI> getResources() {
+        return resources;
+    }
 
     /**
      * Get the creator of this access credential.
      *
      * @return the creator
      */
-    URI getCreator();
+    public URI getCreator() {
+        return creator;
+    }
 
     /**
      * Get the recipient of this access credential.
      *
      * @return the recipient, if present
      */
-    Optional<URI> getRecipient();
+    public Optional<URI> getRecipient() {
+        return Optional.ofNullable(recipient);
+    }
 
     /**
      * Serialize this access credential as a String.
      *
      * @return a serialized form of the credential
      */
-    String serialize();
+    public String serialize() {
+        return credential;
+    }
+
+    /**
+     * Server-managed credential data.
+     */
+    public static class CredentialMetadata {
+        private final URI issuer;
+        private final URI creator;
+        private final Set<String> types;
+        private final Status status;
+        private final Instant expiration;
+
+        /**
+         * A collection of server-managed credential metadata.
+         *
+         * @param issuer the issuer
+         * @param creator the agent who created the credential
+         * @param types the credential types
+         * @param expiration the credential expiration
+         * @param status the credential status
+         */
+        public CredentialMetadata(final URI issuer, final URI creator, final Set<String> types,
+                final Instant expiration, final Status status) {
+            this.issuer = Objects.requireNonNull(issuer, "issuer may not be null!");
+            this.creator = Objects.requireNonNull(creator, "creator may not be null!");
+            this.types = Objects.requireNonNull(types, "types may not be null!");
+            this.expiration = expiration;
+            this.status = status;
+        }
+
+        /**
+         * Get the issuer of the credential.
+         *
+         * @return the issuer
+         */
+        public URI getIssuer() {
+            return issuer;
+        }
+
+        /**
+         * Get the creator of the credential.
+         *
+         * @return the creator
+         */
+        public URI getCreator() {
+            return creator;
+        }
+
+        /**
+         * Get the types of the credential.
+         *
+         * @return the credential types
+         */
+        public Set<String> getTypes() {
+            return types;
+        }
+
+        /**
+         * Get the expiration time of the credential.
+         *
+         * @return the expiration time
+         */
+        public Instant getExpiration() {
+            return expiration;
+        }
+
+        /**
+         * Get the status of the credential.
+         *
+         * @return the credential status
+         */
+        public Status getStatus() {
+            return status;
+        }
+    }
+
+    /**
+     *  User-managed credential data.
+     */
+    public static class CredentialData {
+        private final Set<String> purposes;
+        private final Set<String> modes;
+        private final Set<URI> resources;
+        private final URI recipient;
+
+        /**
+         * Create a collection of user-managed credential data.
+         *
+         * @param resources the resources referenced by the credential
+         * @param modes the access modes defined by this credential
+         * @param purposes the purposes associated with this credential
+         * @param recipient the recipient for this credential, may be {@code null}
+         */
+        public CredentialData(final Set<URI> resources, final Set<String> modes,
+                final Set<String> purposes, final URI recipient) {
+            this.modes = Objects.requireNonNull(modes, "modes may not be null!");
+            this.purposes = Objects.requireNonNull(purposes, "purposes may not be null!");
+            this.resources = Objects.requireNonNull(resources, "resources may not be null!");
+            this.recipient = recipient;
+        }
+
+        /**
+         * Get the purposes associated with the credential.
+         *
+         * @return the purpose definitions
+         */
+        public Set<String> getPurposes() {
+            return purposes;
+        }
+
+        /**
+         * Get the access modes associated with the credential.
+         *
+         * @return the access modes
+         */
+        public Set<String> getModes() {
+            return modes;
+        }
+
+        /**
+         * Get the resource URIs associated with this credential.
+         *
+         * @return the resource URIs
+         */
+        public Set<URI> getResources() {
+            return resources;
+        }
+
+        /**
+         * Get the recipient associated with this credential.
+         *
+         * @return the credential, may be {@code null}
+         */
+        public URI getRecipient() {
+            return recipient;
+        }
+    }
+
+    static CredentialMetadata extractMetadata(final Map data) {
+        final URI issuer = asUri(data.get("issuer")).orElseThrow(() ->
+                new IllegalArgumentException("Missing or invalid issuer field"));
+        final Set<String> types = asSet(data.get(TYPE)).orElseGet(Collections::emptySet);
+        final Instant expiration = asInstant(data.get("expirationDate")).orElse(Instant.MAX);
+        final Status status = asMap(data.get("credentialStatus")).flatMap(credentialStatus ->
+                asSet(credentialStatus.get(TYPE)).filter(statusTypes ->
+                    statusTypes.contains(REVOCATION_LIST_2020_STATUS)).map(x ->
+                        asRevocationList2020(credentialStatus))).orElse(null);
+
+        final Map subject = asMap(data.get("credentialSubject")).orElseThrow(() ->
+                new IllegalArgumentException("Missing or invalid credentialSubject field"));
+
+        final URI creator = asUri(subject.get("id")).orElseThrow(() ->
+                new IllegalArgumentException("Missing or invalid credentialSubject.id field"));
+
+        return new CredentialMetadata(issuer, creator, types, expiration, status);
+    }
+
+    static Map extractConsent(final Map data, final String property) {
+        final Map subject = asMap(data.get("credentialSubject")).orElseThrow(() ->
+                new IllegalArgumentException("Missing or invalid credentialSubject field"));
+        return asMap(subject.get(property)).orElseThrow(() ->
+                // Unsupported structure
+                new IllegalArgumentException("Invalid Access Request: missing consent clause"));
+    }
 }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+/** A base class for access credentials. **/
 public class AccessCredential {
 
     protected static final String TYPE = "type";
@@ -106,10 +107,7 @@ public class AccessCredential {
      * @return the expiration time
      */
     public Instant getExpiration() {
-        if (expiration != null) {
-            return expiration;
-        }
-        return Instant.MAX;
+        return expiration != null ? expiration : Instant.MAX;
     }
 
     /**
@@ -175,9 +173,7 @@ public class AccessCredential {
         return credential;
     }
 
-    /**
-     * Server-managed credential data.
-     */
+    /** Server-managed credential data. */
     public static class CredentialMetadata {
         private final URI issuer;
         private final URI creator;
@@ -249,9 +245,7 @@ public class AccessCredential {
         }
     }
 
-    /**
-     *  User-managed credential data.
-     */
+    /**  User-managed credential data. */
     public static class CredentialData {
         private final Set<String> purposes;
         private final Set<String> modes;

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,81 +44,19 @@ import org.apache.commons.io.IOUtils;
 /**
  * An Access Denial abstraction, for use when interacting with Solid resources.
  */
-public class AccessDenial implements AccessCredential {
+public class AccessDenial extends AccessCredential {
 
-    private static final String TYPE = "type";
-    private static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
     private static final Set<String> supportedTypes = getSupportedTypes();
     private static final JsonService jsonService = ServiceProvider.getJsonService();
-
-    private final String credential;
-    private final URI issuer;
-    private final URI identifier;
-    private final Set<String> types;
-    private final Set<String> purposes;
-    private final Set<String> modes;
-    private final Set<URI> resources;
-    private final URI recipient;
-    private final URI creator;
-    private final Instant expiration;
-    private final Status status;
 
     /**
      * Read a verifiable presentation as an AccessDenial.
      *
      * @param serialization the Access Denial serialized as a verifiable presentation
      */
-    protected AccessDenial(final String serialization) throws IOException {
-        try (final InputStream in = new ByteArrayInputStream(serialization.getBytes())) {
-            // TODO process as JSON-LD
-            final Map<String, Object> data = jsonService.fromJson(in,
-                    new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-
-            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
-            if (vcs.size() != 1) {
-                throw new IllegalArgumentException(
-                        "Invalid Access Denial: ambiguous number of verifiable credentials");
-            }
-            final Map vc = vcs.get(0);
-
-            if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
-                this.credential = serialization;
-                this.issuer = asUri(vc.get("issuer")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid issuer field"));
-                this.identifier = asUri(vc.get("id")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid id field"));
-
-                this.types = asSet(vc.get(TYPE)).orElseGet(Collections::emptySet);
-                this.expiration = asInstant(vc.get("expirationDate")).orElse(Instant.MAX);
-
-                final Map subject = asMap(vc.get("credentialSubject")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid credentialSubject field"));
-
-                this.creator = asUri(subject.get("id")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid credentialSubject.id field"));
-
-                // V1 Access Denial, using gConsent
-                final Map consent = asMap(subject.get("providedConsent")).orElseThrow(() ->
-                        // Unsupported structure
-                        new IllegalArgumentException("Invalid Access Denial: missing consent clause"));
-
-                final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
-                final Optional<URI> controller = asUri(consent.get("isProvidedToController"));
-                final Optional<URI> other = asUri(consent.get("isProvidedTo"));
-
-                this.recipient = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
-                this.modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
-                this.resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
-                    .stream().map(URI::create).collect(Collectors.toSet());
-                this.purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
-                this.status = asMap(vc.get("credentialStatus")).flatMap(credentialStatus ->
-                        asSet(credentialStatus.get(TYPE)).filter(statusTypes ->
-                            statusTypes.contains(REVOCATION_LIST_2020_STATUS)).map(x ->
-                                asRevocationList2020(credentialStatus))).orElse(null);
-            } else {
-                throw new IllegalArgumentException("Invalid Access Denial: missing VerifiablePresentation type");
-            }
-        }
+    protected AccessDenial(final URI identifier, final String credential, final CredentialData data,
+            final CredentialMetadata metadata) {
+        super(identifier, credential, data, metadata);
     }
 
     /**
@@ -130,7 +67,7 @@ public class AccessDenial implements AccessCredential {
      */
     public static AccessDenial of(final String serialization) {
         try {
-            return new AccessDenial(serialization);
+            return parse(serialization);
         } catch (final IOException ex) {
             throw new IllegalArgumentException("Unable to read access denial", ex);
         }
@@ -150,65 +87,52 @@ public class AccessDenial implements AccessCredential {
         }
     }
 
-    @Override
-    public Set<String> getTypes() {
-        return types;
-    }
-
-    @Override
-    public Set<String> getModes() {
-        return modes;
-    }
-
-    @Override
-    public Optional<Status> getStatus() {
-        return Optional.ofNullable(status);
-    }
-
-    @Override
-    public Instant getExpiration() {
-        return expiration;
-    }
-
-    @Override
-    public URI getIssuer() {
-        return issuer;
-    }
-
-    @Override
-    public URI getIdentifier() {
-        return identifier;
-    }
-
-    @Override
-    public Set<String> getPurposes() {
-        return purposes;
-    }
-
-    @Override
-    public Set<URI> getResources() {
-        return resources;
-    }
-
-    @Override
-    public URI getCreator() {
-        return creator;
-    }
-
-    @Override
-    public Optional<URI> getRecipient() {
-        return Optional.ofNullable(recipient);
-    }
-
-    @Override
-    public String serialize() {
-        return credential;
-    }
-
     static Set<String> getSupportedTypes() {
         final Set<String> types = new HashSet<>();
         types.add("SolidAccessDenial");
         types.add("http://www.w3.org/ns/solid/vc#SolidAccessDenial");
         return Collections.unmodifiableSet(types);
+    }
+
+    static AccessDenial parse(final String serialization) throws IOException {
+        try (final InputStream in = new ByteArrayInputStream(serialization.getBytes())) {
+            // TODO process as JSON-LD
+            final Map<String, Object> data = jsonService.fromJson(in,
+                    new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
+
+            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            if (vcs.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Invalid Access Denial: ambiguous number of verifiable credentials");
+            }
+            final Map vc = vcs.get(0);
+
+            if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
+                final URI identifier = asUri(vc.get("id")).orElseThrow(() ->
+                        new IllegalArgumentException("Missing or invalid id field"));
+
+                // Extract metadata
+                final CredentialMetadata credentialMetadata = extractMetadata(vc);
+
+
+                // Extract V1 Access Denial data, using gConsent
+                final Map consent = extractConsent(vc, "providedConsent");
+
+                final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
+                final Optional<URI> controller = asUri(consent.get("isProvidedToController"));
+                final Optional<URI> other = asUri(consent.get("isProvidedTo"));
+
+                final URI recipient = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
+                final Set<String> modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
+                final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
+                    .stream().map(URI::create).collect(Collectors.toSet());
+                final Set<String> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
+                final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
+
+                return new AccessDenial(identifier, serialization, credentialData, credentialMetadata);
+            } else {
+                throw new IllegalArgumentException("Invalid Access Denial: missing VerifiablePresentation type");
+            }
+        }
     }
 }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -30,7 +30,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,81 +44,19 @@ import org.apache.commons.io.IOUtils;
 /**
  * An Access Grant abstraction, for use when interacting with Solid resources.
  */
-public class AccessGrant implements AccessCredential {
+public class AccessGrant extends AccessCredential {
 
-    private static final String TYPE = "type";
-    private static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
     private static final Set<String> supportedTypes = getSupportedTypes();
     private static final JsonService jsonService = ServiceProvider.getJsonService();
-
-    private final String credential;
-    private final URI issuer;
-    private final URI identifier;
-    private final Set<String> types;
-    private final Set<String> purposes;
-    private final Set<String> modes;
-    private final Set<URI> resources;
-    private final URI recipient;
-    private final URI creator;
-    private final Instant expiration;
-    private final Status status;
 
     /**
      * Read a verifiable presentation as an AccessGrant.
      *
      * @param grant the Access Grant serialized as a verifiable presentation
      */
-    protected AccessGrant(final String grant) throws IOException {
-        try (final InputStream in = new ByteArrayInputStream(grant.getBytes())) {
-            // TODO process as JSON-LD
-            final Map<String, Object> data = jsonService.fromJson(in,
-                    new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-
-            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
-            if (vcs.size() != 1) {
-                throw new IllegalArgumentException(
-                        "Invalid Access Grant: ambiguous number of verifiable credentials");
-            }
-            final Map vc = vcs.get(0);
-
-            if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
-                this.credential = grant;
-                this.issuer = asUri(vc.get("issuer")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid issuer field"));
-                this.identifier = asUri(vc.get("id")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid id field"));
-
-                this.types = asSet(vc.get(TYPE)).orElseGet(Collections::emptySet);
-                this.expiration = asInstant(vc.get("expirationDate")).orElse(Instant.MAX);
-
-                final Map subject = asMap(vc.get("credentialSubject")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid credentialSubject field"));
-
-                this.creator = asUri(subject.get("id")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid credentialSubject.id field"));
-
-                // V1 Access Grant, using gConsent
-                final Map consent = asMap(subject.get("providedConsent")).orElseThrow(() ->
-                        // Unsupported structure
-                        new IllegalArgumentException("Invalid Access Grant: missing consent clause"));
-
-                final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
-                final Optional<URI> controller = asUri(consent.get("isProvidedToController"));
-                final Optional<URI> other = asUri(consent.get("isProvidedTo"));
-
-                this.recipient = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
-                this.modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
-                this.resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
-                    .stream().map(URI::create).collect(Collectors.toSet());
-                this.purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
-                this.status = asMap(vc.get("credentialStatus")).flatMap(credentialStatus ->
-                        asSet(credentialStatus.get(TYPE)).filter(statusTypes ->
-                            statusTypes.contains(REVOCATION_LIST_2020_STATUS)).map(x ->
-                                asRevocationList2020(credentialStatus))).orElse(null);
-            } else {
-                throw new IllegalArgumentException("Invalid Access Grant: missing VerifiablePresentation type");
-            }
-        }
+    protected AccessGrant(final URI identifier, final String credential, final CredentialData data,
+            final CredentialMetadata metadata) {
+        super(identifier, credential, data, metadata);
     }
 
     /**
@@ -154,7 +91,7 @@ public class AccessGrant implements AccessCredential {
      */
     public static AccessGrant of(final String serialization) {
         try {
-            return new AccessGrant(serialization);
+            return parse(serialization);
         } catch (final IOException ex) {
             throw new IllegalArgumentException("Unable to read access grant", ex);
         }
@@ -174,36 +111,6 @@ public class AccessGrant implements AccessCredential {
         }
     }
 
-    @Override
-    public Set<String> getTypes() {
-        return types;
-    }
-
-    @Override
-    public Set<String> getModes() {
-        return modes;
-    }
-
-    @Override
-    public Optional<Status> getStatus() {
-        return Optional.ofNullable(status);
-    }
-
-    @Override
-    public Instant getExpiration() {
-        return expiration;
-    }
-
-    @Override
-    public URI getIssuer() {
-        return issuer;
-    }
-
-    @Override
-    public URI getIdentifier() {
-        return identifier;
-    }
-
     /**
      * Get the purposes of the access grant.
      *
@@ -213,16 +120,6 @@ public class AccessGrant implements AccessCredential {
     @Deprecated
     public Set<String> getPurpose() {
         return getPurposes();
-    }
-
-    @Override
-    public Set<String> getPurposes() {
-        return purposes;
-    }
-
-    @Override
-    public Set<URI> getResources() {
-        return resources;
     }
 
     /**
@@ -247,21 +144,6 @@ public class AccessGrant implements AccessCredential {
         return getCreator();
     }
 
-    @Override
-    public URI getCreator() {
-        return creator;
-    }
-
-    @Override
-    public Optional<URI> getRecipient() {
-        return Optional.ofNullable(recipient);
-    }
-
-    @Override
-    public String serialize() {
-        return credential;
-    }
-
     /**
      * Get the raw access grant.
      *
@@ -280,4 +162,44 @@ public class AccessGrant implements AccessCredential {
         return Collections.unmodifiableSet(types);
     }
 
+    static AccessGrant parse(final String serialization) throws IOException {
+        try (final InputStream in = new ByteArrayInputStream(serialization.getBytes())) {
+            // TODO process as JSON-LD
+            final Map<String, Object> data = jsonService.fromJson(in,
+                    new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
+
+            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            if (vcs.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Invalid Access Grant: ambiguous number of verifiable credentials");
+            }
+            final Map vc = vcs.get(0);
+
+            if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
+                final URI identifier = asUri(vc.get("id")).orElseThrow(() ->
+                        new IllegalArgumentException("Missing or invalid id field"));
+
+                // Extract metadata
+                final CredentialMetadata credentialMetadata = extractMetadata(vc);
+
+                // Extract V1 Access Grant data, using gConsent
+                final Map consent = extractConsent(vc, "providedConsent");
+
+                final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
+                final Optional<URI> controller = asUri(consent.get("isProvidedToController"));
+                final Optional<URI> other = asUri(consent.get("isProvidedTo"));
+
+                final URI recipient = person.orElseGet(() -> controller.orElseGet(() -> other.orElse(null)));
+                final Set<String> modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
+                final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
+                    .stream().map(URI::create).collect(Collectors.toSet());
+                final Set<String> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
+                final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
+
+                return new AccessGrant(identifier, serialization, credentialData, credentialMetadata);
+            } else {
+                throw new IllegalArgumentException("Invalid Access Grant: missing VerifiablePresentation type");
+            }
+        }
+    }
 }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -30,13 +30,11 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -45,80 +43,20 @@ import org.apache.commons.io.IOUtils;
 /**
  * An Access Request abstraction, for use when interacting with Solid resources.
  */
-public class AccessRequest implements AccessCredential {
+public class AccessRequest extends AccessCredential {
 
-    private static final String TYPE = "type";
-    private static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
     private static final JsonService jsonService = ServiceProvider.getJsonService();
     private static final Set<String> supportedTypes = getSupportedTypes();
-
-    private final String credential;
-    private final URI issuer;
-    private final URI identifier;
-    private final Set<String> types;
-    private final Set<String> purposes;
-    private final Set<String> modes;
-    private final Set<URI> resources;
-    private final URI recipient;
-    private final URI creator;
-    private final Instant expiration;
-    private final Status status;
 
     /**
      * Read a verifiable presentation as an AccessRequest.
      *
      * @param serialization the serialized form of an Access Request
      */
-    protected AccessRequest(final String serialization) throws IOException {
-        try (final InputStream in = new ByteArrayInputStream(serialization.getBytes())) {
-            // TODO process as JSON-LD
-            final Map<String, Object> data = jsonService.fromJson(in,
-                    new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
-
-            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
-            if (vcs.size() != 1) {
-                throw new IllegalArgumentException(
-                        "Invalid Access Request: ambiguous number of verifiable credentials");
-            }
-            final Map vc = vcs.get(0);
-
-            if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
-                this.credential = serialization;
-                this.issuer = asUri(vc.get("issuer")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid issuer field"));
-                this.identifier = asUri(vc.get("id")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid id field"));
-
-                this.types = asSet(vc.get(TYPE)).orElseGet(Collections::emptySet);
-                this.expiration = asInstant(vc.get("expirationDate")).orElse(Instant.MAX);
-
-                final Map subject = asMap(vc.get("credentialSubject")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid credentialSubject field"));
-
-                this.creator = asUri(subject.get("id")).orElseThrow(() ->
-                        new IllegalArgumentException("Missing or invalid credentialSubject.id field"));
-
-                // V1 Access Request, using gConsent
-                final Map consent = asMap(subject.get("hasConsent")).orElseThrow(() ->
-                        // Unsupported structure
-                        new IllegalArgumentException("Invalid Access Request: missing consent clause"));
-
-                final Optional<URI> dataSubject = asUri(consent.get("isConsentForDataSubject"));
-                this.recipient = dataSubject.orElse(null);
-                this.modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
-                this.resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
-                    .stream().map(URI::create).collect(Collectors.toSet());
-                this.purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
-                this.status = asMap(vc.get("credentialStatus")).flatMap(credentialStatus ->
-                        asSet(credentialStatus.get(TYPE)).filter(statusTypes ->
-                            statusTypes.contains(REVOCATION_LIST_2020_STATUS)).map(x ->
-                                asRevocationList2020(credentialStatus))).orElse(null);
-            } else {
-                throw new IllegalArgumentException("Invalid Access Request: missing VerifiablePresentation type");
-            }
-        }
+    protected AccessRequest(final URI identifier, final String credential, final CredentialData data,
+            final CredentialMetadata metadata) {
+        super(identifier, credential, data, metadata);
     }
-
 
     /**
      * Create an AccessRequest object from a serialized form.
@@ -128,7 +66,7 @@ public class AccessRequest implements AccessCredential {
      */
     public static AccessRequest of(final String serialization) {
         try {
-            return new AccessRequest(serialization);
+            return parse(serialization);
         } catch (final IOException ex) {
             throw new IllegalArgumentException("Unable to read access request", ex);
         }
@@ -148,65 +86,47 @@ public class AccessRequest implements AccessCredential {
         }
     }
 
-    @Override
-    public Set<String> getTypes() {
-        return types;
-    }
-
-    @Override
-    public Set<String> getModes() {
-        return modes;
-    }
-
-    @Override
-    public Optional<Status> getStatus() {
-        return Optional.ofNullable(status);
-    }
-
-    @Override
-    public Instant getExpiration() {
-        return expiration;
-    }
-
-    @Override
-    public URI getIssuer() {
-        return issuer;
-    }
-
-    @Override
-    public URI getIdentifier() {
-        return identifier;
-    }
-
-    @Override
-    public Set<String> getPurposes() {
-        return purposes;
-    }
-
-    @Override
-    public Set<URI> getResources() {
-        return resources;
-    }
-
-    @Override
-    public URI getCreator() {
-        return creator;
-    }
-
-    @Override
-    public Optional<URI> getRecipient() {
-        return Optional.ofNullable(recipient);
-    }
-
-    @Override
-    public String serialize() {
-        return credential;
-    }
-
     static Set<String> getSupportedTypes() {
         final Set<String> types = new HashSet<>();
         types.add("SolidAccessRequest");
         types.add("http://www.w3.org/ns/solid/vc#SolidAccessRequest");
         return Collections.unmodifiableSet(types);
+    }
+
+    static AccessRequest parse(final String serialization) throws IOException {
+        try (final InputStream in = new ByteArrayInputStream(serialization.getBytes())) {
+            // TODO process as JSON-LD
+            final Map<String, Object> data = jsonService.fromJson(in,
+                    new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
+
+            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            if (vcs.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Invalid Access Request: ambiguous number of verifiable credentials");
+            }
+            final Map vc = vcs.get(0);
+
+            if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
+                final URI identifier = asUri(vc.get("id")).orElseThrow(() ->
+                        new IllegalArgumentException("Missing or invalid id field"));
+
+                // Extract metadata
+                final CredentialMetadata credentialMetadata = extractMetadata(vc);
+
+                // V1 Access Request, using gConsent
+                final Map consent = extractConsent(vc, "hasConsent");
+
+                final URI recipient = asUri(consent.get("isConsentForDataSubject")).orElse(null);
+                final Set<String> modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
+                final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
+                    .stream().map(URI::create).collect(Collectors.toSet());
+                final Set<String> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
+                final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
+
+                return new AccessRequest(identifier, serialization, credentialData, credentialMetadata);
+            } else {
+                throw new IllegalArgumentException("Invalid Access Request: missing VerifiablePresentation type");
+            }
+        }
     }
 }


### PR DESCRIPTION
At present there is a high degree of duplication among `AccessGrant`, `AccessRequest` and `AccessDenial`. This PR reworks the base interface (`AccessCredential`) into a class -- not an interface -- where most of this shared implementation lives.

This also adds two helper classes: `CredentialData` and `CredentialMetadata`, whose sole purpose is to keep the number of ctor parameters in these classes down to a reasonable number.

The upshot is that the implementation classes become considerably shorter and easier to reason about.