### PR TITLE
JCL-365: Improve efficiency of CI workflow

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'maven'
 
       - name: Build the code with Maven
-        run: mvn -B -ntp install javadoc:javadoc -Pci -pl -integration/uma,-integration/openid
+        run: mvn -B -ntp install -Pci -pl -integration/uma,-integration/openid
 
       - name: Prod Integration tests
         if: ${{ github.actor != 'dependabot[bot]' }}
@@ -43,6 +43,26 @@ jobs:
           INRUPT_TEST_PUBLIC_RESOURCE_PATH: ${{ secrets.INRUPT_DEV_PUBLIC_RESOURCE_PATH }}
           INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_DEV_CLIENT_ID }}
           INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_DEV_CLIENT_SECRET }}
+
+  documentation:
+    name: Documentation Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 11 ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: Build the code with Maven
+        run: mvn -B -ntp verify -Pwebsite javadoc:javadoc
 
   dependencies:
     name: Dependency Check

--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -110,10 +110,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -90,10 +90,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -155,10 +155,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -70,10 +70,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -148,10 +148,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -76,10 +76,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -80,10 +80,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -88,10 +88,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -92,10 +92,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -79,10 +79,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -108,10 +108,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -53,10 +53,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-maven-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,12 @@
     <inrupt.rdf.wrapping.version>0.4.0</inrupt.rdf.wrapping.version>
 
     <!-- plugins -->
-    <buildhelper.plugin.version>3.4.0</buildhelper.plugin.version>
     <checkstyle.plugin.version>3.2.2</checkstyle.plugin.version>
     <clean.plugin.version>3.2.0</clean.plugin.version>
     <compiler.plugin.version>3.11.0</compiler.plugin.version>
     <deploy.plugin.version>3.1.1</deploy.plugin.version>
     <exec.plugin.version>3.1.0</exec.plugin.version>
     <install.plugin.version>3.1.1</install.plugin.version>
-    <git.plugin.version>4.9.10</git.plugin.version>
     <gpg.plugin.version>3.1.0</gpg.plugin.version>
     <jacoco.plugin.version>0.8.10</jacoco.plugin.version>
     <jar.plugin.version>3.3.0</jar.plugin.version>
@@ -282,23 +280,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>pl.project13.maven</groupId>
-          <artifactId>git-commit-id-plugin</artifactId>
-          <version>${git.plugin.version}</version>
-          <executions>
-            <execution>
-              <id>get-the-git-infos</id>
-              <goals>
-                <goal>revision</goal>
-              </goals>
-            </execution>
-          </executions>
-          <configuration>
-            <generateGitPropertiesFile>false</generateGitPropertiesFile>
-            <failOnNoGitDirectory>false</failOnNoGitDirectory>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <version>${release.plugin.version}</version>
@@ -406,44 +387,6 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>${buildhelper.plugin.version}</version>
-          <executions>
-            <execution>
-              <id>parse-version</id>
-              <goals>
-                <goal>parse-version</goal>
-              </goals>
-            </execution>
-            <execution>
-              <id>regex-properties</id>
-              <goals>
-                <goal>regex-properties</goal>
-              </goals>
-              <phase>generate-sources</phase>
-              <configuration>
-                <regexPropertySettings>
-                  <regexPropertySetting>
-                    <name>application.version</name>
-                    <value>${project.version}</value>
-                    <regex>-SNAPSHOT</regex>
-                    <replacement>-dev-\$\{git.commit.id.abbrev\}</replacement>
-                    <failIfNoMatch>false</failIfNoMatch>
-                  </regexPropertySetting>
-                  <regexPropertySetting>
-                    <name>inrupt.image-tag</name>
-                    <value>${project.version}</value>
-                    <regex>.+-SNAPSHOT</regex>
-                    <replacement>\$\{git.commit.id\}</replacement>
-                    <failIfNoMatch>false</failIfNoMatch>
-                  </regexPropertySetting>
-                </regexPropertySettings>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${pmd.plugin.version}</version>
@@ -507,15 +450,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -92,10 +92,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -76,10 +76,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -94,10 +94,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>

--- a/vocabulary/pom.xml
+++ b/vocabulary/pom.xml
@@ -46,10 +46,6 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -87,10 +87,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
The CI workflow has gotten very slow. It appears that there are some active maven plugins that are not used. I also moved the javadoc check into its own CI step, as that tends to be relatively resource-intensive (and doesn't need to become part of the version matrix)

As an interesting point of reference, the last PR included a total duration of just over 51 minutes to complete
This PR took just under 6 minutes to complete

This is, approximately, a 90% improvement with the same level of testing performed.