### PR TITLE
JCL-366: Address sonar warnings for access grant module

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -315,7 +315,7 @@ public class AccessCredential {
                     statusTypes.contains(REVOCATION_LIST_2020_STATUS)).map(x ->
                         asRevocationList2020(credentialStatus))).orElse(null);
 
-        final Map subject = asMap(data.get("credentialSubject")).orElseThrow(() ->
+        final Map<String, Object> subject = asMap(data.get("credentialSubject")).orElseThrow(() ->
                 new IllegalArgumentException("Missing or invalid credentialSubject field"));
 
         final URI creator = asUri(subject.get("id")).orElseThrow(() ->
@@ -324,8 +324,8 @@ public class AccessCredential {
         return new CredentialMetadata(issuer, creator, types, expiration, status);
     }
 
-    static Map extractConsent(final Map data, final String property) {
-        final Map subject = asMap(data.get("credentialSubject")).orElseThrow(() ->
+    static Map<String, Object> extractConsent(final Map data, final String property) {
+        final Map<String, Object> subject = asMap(data.get("credentialSubject")).orElseThrow(() ->
                 new IllegalArgumentException("Missing or invalid credentialSubject field"));
         return asMap(subject.get(property)).orElseThrow(() ->
                 // Unsupported structure

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
@@ -103,12 +103,12 @@ public class AccessDenial extends AccessCredential {
             final Map<String, Object> data = jsonService.fromJson(in,
                     new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
 
-            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            final List<Map<String, Object>> vcs = getCredentialsFromPresentation(data, supportedTypes);
             if (vcs.size() != 1) {
                 throw new IllegalArgumentException(
                         "Invalid Access Denial: ambiguous number of verifiable credentials");
             }
-            final Map vc = vcs.get(0);
+            final Map<String, Object> vc = vcs.get(0);
 
             if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
                 final URI identifier = asUri(vc.get("id")).orElseThrow(() ->
@@ -119,7 +119,7 @@ public class AccessDenial extends AccessCredential {
 
 
                 // Extract V1 Access Denial data, using gConsent
-                final Map consent = extractConsent(vc, "providedConsent");
+                final Map<String, Object> consent = extractConsent(vc, "providedConsent");
 
                 final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
                 final Optional<URI> controller = asUri(consent.get("isProvidedToController"));

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -171,12 +171,12 @@ public class AccessGrant extends AccessCredential {
             final Map<String, Object> data = jsonService.fromJson(in,
                     new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
 
-            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            final List<Map<String, Object>> vcs = getCredentialsFromPresentation(data, supportedTypes);
             if (vcs.size() != 1) {
                 throw new IllegalArgumentException(
                         "Invalid Access Grant: ambiguous number of verifiable credentials");
             }
-            final Map vc = vcs.get(0);
+            final Map<String, Object> vc = vcs.get(0);
 
             if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
                 final URI identifier = asUri(vc.get("id")).orElseThrow(() ->
@@ -186,7 +186,7 @@ public class AccessGrant extends AccessCredential {
                 final CredentialMetadata credentialMetadata = extractMetadata(vc);
 
                 // Extract V1 Access Grant data, using gConsent
-                final Map consent = extractConsent(vc, "providedConsent");
+                final Map<String, Object> consent = extractConsent(vc, "providedConsent");
 
                 final Optional<URI> person = asUri(consent.get("isProvidedToPerson"));
                 final Optional<URI> controller = asUri(consent.get("isProvidedToController"));

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
@@ -128,7 +128,7 @@ public final class AccessGrantSession implements Session {
                 if (isAncestor(entry.getKey(), uri)) {
                     final AccessGrant grant = entry.getValue();
                     return Optional.of(new Credential("", grant.getIssuer(), Base64.getUrlEncoder().withoutPadding()
-                                    .encodeToString(grant.getRawGrant().getBytes(UTF_8)),
+                                    .encodeToString(grant.serialize().getBytes(UTF_8)),
                                 grant.getExpiration(), session.getPrincipal().orElse(null), null));
                 }
             }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -102,12 +102,12 @@ public class AccessRequest extends AccessCredential {
             final Map<String, Object> data = jsonService.fromJson(in,
                     new HashMap<String, Object>(){}.getClass().getGenericSuperclass());
 
-            final List<Map> vcs = getCredentialsFromPresentation(data, supportedTypes);
+            final List<Map<String, Object>> vcs = getCredentialsFromPresentation(data, supportedTypes);
             if (vcs.size() != 1) {
                 throw new IllegalArgumentException(
                         "Invalid Access Request: ambiguous number of verifiable credentials");
             }
-            final Map vc = vcs.get(0);
+            final Map<String, Object> vc = vcs.get(0);
 
             if (asSet(data.get(TYPE)).orElseGet(Collections::emptySet).contains("VerifiablePresentation")) {
                 final URI identifier = asUri(vc.get("id")).orElseThrow(() ->
@@ -117,7 +117,7 @@ public class AccessRequest extends AccessCredential {
                 final CredentialMetadata credentialMetadata = extractMetadata(vc);
 
                 // V1 Access Request, using gConsent
-                final Map consent = extractConsent(vc, "hasConsent");
+                final Map<String, Object> consent = extractConsent(vc, "hasConsent");
 
                 final URI recipient = asUri(consent.get("isConsentForDataSubject")).orElse(null);
                 final Set<String> modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
@@ -36,7 +36,7 @@ final class Utils {
     private static final String TYPE = "type";
     private static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
 
-    public static Status asRevocationList2020(final Map credentialStatus) {
+    public static Status asRevocationList2020(final Map<String, Object> credentialStatus) {
         try {
             int idx = -1;
             final Object index = credentialStatus.get("revocationListIndex");
@@ -72,9 +72,11 @@ final class Utils {
         return Optional.empty();
     }
 
-    public static Optional<Map> asMap(final Object value) {
+    public static Optional<Map<String, Object>> asMap(final Object value) {
         if (value instanceof Map) {
-            return Optional.of((Map) value);
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> v = (Map<String, Object>) value;
+            return Optional.of(v);
         }
         return Optional.empty();
     }
@@ -96,13 +98,14 @@ final class Utils {
         return Optional.empty();
     }
 
-    public static List<Map> getCredentialsFromPresentation(final Map<String, Object> data,
+    public static List<Map<String, Object>> getCredentialsFromPresentation(final Map<String, Object> data,
             final Set<String> supportedTypes) {
-        final List<Map> credentials = new ArrayList<>();
+        final List<Map<String, Object>> credentials = new ArrayList<>();
         if (data.get("verifiableCredential") instanceof Collection) {
             for (final Object item : (Collection) data.get("verifiableCredential")) {
                 if (item instanceof Map) {
-                    final Map vc = (Map) item;
+                    @SuppressWarnings("unchecked")
+                    final Map vc = (Map<String, Object>) item;
                     if (asSet(vc.get(TYPE)).filter(types ->
                                 types.stream().anyMatch(supportedTypes::contains)).isPresent()) {
                         credentials.add(vc);
@@ -112,7 +115,6 @@ final class Utils {
         }
         return credentials;
     }
-
 
     private Utils() {
         // prevent instantiation


### PR DESCRIPTION
This addresses a few different sonar warnings about the access grant module:

* providing parameterized types for generics
* defining constants for literals
* reducing cognitive complexity of a certain method

The `Map` objects are derived from JSON structures, so they will always have the `Map<String, Object>` type.