### PR TITLE
JCL-366: Remove use of deprecated authenticate

### DIFF
--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdAuthenticationProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdAuthenticationProvider.java
@@ -27,7 +27,6 @@ import com.inrupt.client.auth.Credential;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.spi.AuthenticationProvider;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
@@ -111,13 +110,8 @@ public class OpenIdAuthenticationProvider implements AuthenticationProvider {
         @Override
         public CompletionStage<Credential> authenticate(final Session session, final Request request,
                 final Set<String> algorithms) {
-            final Optional<CompletionStage<Credential>> token = session
-                .getCredential(OpenIdSession.ID_TOKEN, request.uri())
-                .map(CompletableFuture::completedFuture);
-            return token
-                .orElseGet(() -> session.authenticate(request, algorithms)
-                    .thenApply(credential -> credential
-                        .orElseThrow(() -> new OpenIdException("Unable to perform OpenID authentication"))));
+            return CompletableFuture.completedFuture(session
+                    .getCredential(OpenIdSession.ID_TOKEN, request.uri()).orElse(null));
         }
     }
 }


### PR DESCRIPTION
The `Session.authenticate(Request, Set<String>)` method was deprecated as part of #459.

In that change, the `ReactiveAuthorization` class calls `session.authenticate(Authenticator, Request, Set<String>)` so that the session is able to manage a token cache internally.

As such, the session may call the `Authenticator` object to retrieve the relevant credential. If that authenticator _also_ calls `session.authenticate(...)` -- as it does here -- there is a possibility that this call will enter a recursive loop.

This PR removes the use of the deprecated `Session.authenticate(Request, Set<String>)` method as it is no longer needed for reactive authorization. Instead, the authenticator only extracts an OpenID Credential from the existing session.