### PR TITLE
JCL-366: Additional sonar warnings

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -305,7 +305,7 @@ public class AccessCredential {
         }
     }
 
-    static CredentialMetadata extractMetadata(final Map data) {
+    static CredentialMetadata extractMetadata(final Map<String, Object> data) {
         final URI issuer = asUri(data.get("issuer")).orElseThrow(() ->
                 new IllegalArgumentException("Missing or invalid issuer field"));
         final Set<String> types = asSet(data.get(TYPE)).orElseGet(Collections::emptySet);
@@ -324,7 +324,7 @@ public class AccessCredential {
         return new CredentialMetadata(issuer, creator, types, expiration, status);
     }
 
-    static Map<String, Object> extractConsent(final Map data, final String property) {
+    static Map<String, Object> extractConsent(final Map<String, Object> data, final String property) {
         final Map<String, Object> subject = asMap(data.get("credentialSubject")).orElseThrow(() ->
                 new IllegalArgumentException("Missing or invalid credentialSubject field"));
         return asMap(subject.get(property)).orElseThrow(() ->

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
@@ -105,7 +105,7 @@ final class Utils {
             for (final Object item : (Collection) data.get("verifiableCredential")) {
                 if (item instanceof Map) {
                     @SuppressWarnings("unchecked")
-                    final Map vc = (Map<String, Object>) item;
+                    final Map<String, Object> vc = (Map<String, Object>) item;
                     if (asSet(vc.get(TYPE)).filter(types ->
                                 types.stream().anyMatch(supportedTypes::contains)).isPresent()) {
                         credentials.add(vc);

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantConfigurationTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantConfigurationTest.java
@@ -42,7 +42,8 @@ class AccessGrantConfigurationTest {
     void testInvalid() {
         final URI issuer = URI.create("https://access.test");
         final AccessGrantConfiguration config = new AccessGrantConfiguration(issuer);
-        assertThrows(IllegalArgumentException.class, () -> config.setSchema(URI.create("https://example.com/")));
+        final URI uri = URI.create("https://example.com/");
+        assertThrows(IllegalArgumentException.class, () -> config.setSchema(uri));
         assertThrows(IllegalArgumentException.class, () -> config.setSchema(null));
     }
 


### PR DESCRIPTION
This addresses a few more sonar warnings, particularly:

* Ensuring that tests with lambdas have only a single invocation throwing a runtime exception
* Providing the parameterized type for generics