### PR TITLE
JCL-368: Use URIs for purpose arguments

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -40,8 +40,8 @@ public class AccessCredential {
     private final URI issuer;
     private final URI identifier;
     private final Set<String> types;
-    private final Set<String> purposes;
     private final Set<String> modes;
+    private final Set<URI> purposes;
     private final Set<URI> resources;
     private final URI recipient;
     private final URI creator;
@@ -133,7 +133,7 @@ public class AccessCredential {
      *
      * @return the purposes
      */
-    public Set<String> getPurposes() {
+    public Set<URI> getPurposes() {
         return purposes;
     }
 
@@ -247,8 +247,8 @@ public class AccessCredential {
 
     /**  User-managed credential data. */
     public static class CredentialData {
-        private final Set<String> purposes;
         private final Set<String> modes;
+        private final Set<URI> purposes;
         private final Set<URI> resources;
         private final URI recipient;
 
@@ -261,7 +261,7 @@ public class AccessCredential {
          * @param recipient the recipient for this credential, may be {@code null}
          */
         public CredentialData(final Set<URI> resources, final Set<String> modes,
-                final Set<String> purposes, final URI recipient) {
+                final Set<URI> purposes, final URI recipient) {
             this.modes = Objects.requireNonNull(modes, "modes may not be null!");
             this.purposes = Objects.requireNonNull(purposes, "purposes may not be null!");
             this.resources = Objects.requireNonNull(resources, "resources may not be null!");
@@ -273,7 +273,7 @@ public class AccessCredential {
          *
          * @return the purpose definitions
          */
-        public Set<String> getPurposes() {
+        public Set<URI> getPurposes() {
             return purposes;
         }
 

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -29,9 +29,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A base class for access credentials. **/
 public class AccessCredential {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(AccessCredential.class);
 
     protected static final String TYPE = "type";
     protected static final String REVOCATION_LIST_2020_STATUS = "RevocationList2020Status";
@@ -131,6 +137,8 @@ public class AccessCredential {
     /**
      * Get the collection of purposes associated with the access credential.
      *
+     * @implNote as of Beta3, this method returns a set of URIs. Any non-URI purpose values encountered
+     *           during access credential parsing will be discarded.
      * @return the purposes
      */
     public Set<URI> getPurposes() {
@@ -330,5 +338,14 @@ public class AccessCredential {
         return asMap(subject.get(property)).orElseThrow(() ->
                 // Unsupported structure
                 new IllegalArgumentException("Invalid Access Request: missing consent clause"));
+    }
+
+    static Stream<URI> filterUris(final String uri) {
+        try {
+            return Stream.of(URI.create(uri));
+        } catch (final IllegalArgumentException ex) {
+            LOGGER.debug("Ignoring non-URI purpose: {}", ex.getMessage());
+        }
+        return Stream.empty();
     }
 }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
@@ -130,7 +130,7 @@ public class AccessDenial extends AccessCredential {
                 final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
                 final Set<URI> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet)
-                    .stream().map(URI::create).collect(Collectors.toSet());
+                    .stream().flatMap(AccessCredential::filterUris).collect(Collectors.toSet());
                 final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
 
                 return new AccessDenial(identifier, serialization, credentialData, credentialMetadata);

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
@@ -129,7 +129,8 @@ public class AccessDenial extends AccessCredential {
                 final Set<String> modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
                 final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
-                final Set<String> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
+                final Set<URI> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet)
+                    .stream().map(URI::create).collect(Collectors.toSet());
                 final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
 
                 return new AccessDenial(identifier, serialization, credentialData, credentialMetadata);

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -122,7 +122,7 @@ public class AccessGrant extends AccessCredential {
      */
     @Deprecated
     public Set<String> getPurpose() {
-        return getPurposes();
+        return getPurposes().stream().map(URI::toString).collect(Collectors.toSet());
     }
 
     /**
@@ -196,7 +196,8 @@ public class AccessGrant extends AccessCredential {
                 final Set<String> modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
                 final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
-                final Set<String> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
+                final Set<URI> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet)
+                    .stream().map(URI::create).collect(Collectors.toSet());
                 final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
 
                 return new AccessGrant(identifier, serialization, credentialData, credentialMetadata);

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -197,7 +197,7 @@ public class AccessGrant extends AccessCredential {
                 final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
                 final Set<URI> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet)
-                    .stream().map(URI::create).collect(Collectors.toSet());
+                    .stream().flatMap(AccessCredential::filterUris).collect(Collectors.toSet());
                 final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
 
                 return new AccessGrant(identifier, serialization, credentialData, credentialMetadata);

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -124,7 +124,7 @@ public class AccessRequest extends AccessCredential {
                 final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
                 final Set<URI> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet)
-                    .stream().map(URI::create).collect(Collectors.toSet());
+                    .stream().flatMap(AccessCredential::filterUris).collect(Collectors.toSet());
                 final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
 
                 return new AccessRequest(identifier, serialization, credentialData, credentialMetadata);

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -123,7 +123,8 @@ public class AccessRequest extends AccessCredential {
                 final Set<String> modes = asSet(consent.get("mode")).orElseGet(Collections::emptySet);
                 final Set<URI> resources = asSet(consent.get("forPersonalData")).orElseGet(Collections::emptySet)
                     .stream().map(URI::create).collect(Collectors.toSet());
-                final Set<String> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet);
+                final Set<URI> purposes = asSet(consent.get("forPurpose")).orElseGet(Collections::emptySet)
+                    .stream().map(URI::create).collect(Collectors.toSet());
                 final CredentialData credentialData = new CredentialData(resources, modes, purposes, recipient);
 
                 return new AccessRequest(identifier, serialization, credentialData, credentialMetadata);

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
 import org.jose4j.jwk.PublicJsonWebKey;
@@ -307,7 +308,7 @@ class AccessGrantClientTest {
         assertEquals(expiration, grant.getExpiration());
         assertEquals(baseUri, grant.getIssuer());
         assertEquals(purposes, grant.getPurpose());
-        assertEquals(purposes, grant.getPurposes());
+        assertEquals(purposes, grant.getPurposes().stream().map(URI::toString).collect(Collectors.toSet()));
         assertEquals(resources, grant.getResources());
     }
 
@@ -324,7 +325,7 @@ class AccessGrantClientTest {
         final URI agent = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
-        final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
+        final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
         final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)
@@ -344,7 +345,7 @@ class AccessGrantClientTest {
         final URI agent = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
-        final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
+        final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
 
@@ -367,7 +368,7 @@ class AccessGrantClientTest {
         final URI agent = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
-        final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
+        final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
         final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)
@@ -397,7 +398,7 @@ class AccessGrantClientTest {
         final URI agent = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-09-12T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
-        final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
+        final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
         final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)
@@ -432,7 +433,7 @@ class AccessGrantClientTest {
         final URI agent = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
-        final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
+        final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
         final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
@@ -58,7 +58,7 @@ class AccessGrantTest {
             assertEquals(URI.create("https://accessgrant.example/credential/5c6060ad-2f16-4bc1-b022-dffb46bff626"),
                     grant.getIdentifier());
             assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurpose());
-            assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurposes());
+            assertEquals(Collections.singleton(URI.create("https://purpose.example/Purpose1")), grant.getPurposes());
             assertEquals(Collections.singleton(
                         URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/")),
                     grant.getResources());
@@ -91,7 +91,7 @@ class AccessGrantTest {
             assertEquals(URI.create("https://accessgrant.example/credential/5c6060ad-2f16-4bc1-b022-dffb46bff626"),
                     grant.getIdentifier());
             assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurpose());
-            assertEquals(Collections.singleton("https://purpose.example/Purpose1"), grant.getPurposes());
+            assertEquals(Collections.singleton(URI.create("https://purpose.example/Purpose1")), grant.getPurposes());
             assertEquals(Collections.singleton(
                         URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/")),
                     grant.getResources());

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
@@ -55,7 +55,7 @@ class AccessRequestTest {
             assertEquals(Instant.parse("2022-08-27T12:00:00Z"), request.getExpiration());
             assertEquals(URI.create("https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab"),
                     request.getIdentifier());
-            assertEquals(Collections.singleton("https://purpose.test/Purpose1"), request.getPurposes());
+            assertEquals(Collections.singleton(URI.create("https://purpose.test/Purpose1")), request.getPurposes());
             assertEquals(Collections.singleton(
                         URI.create("https://storage.test/data/")),
                     request.getResources());
@@ -85,7 +85,7 @@ class AccessRequestTest {
             assertEquals(Instant.parse("2022-08-27T12:00:00Z"), request.getExpiration());
             assertEquals(URI.create("https://accessgrant.test/credential/d604c858-209a-4bb6-a7f8-2f52c9617cab"),
                     request.getIdentifier());
-            assertEquals(Collections.singleton("https://purpose.test/Purpose1"), request.getPurposes());
+            assertEquals(Collections.singleton(URI.create("https://purpose.test/Purpose1")), request.getPurposes());
             assertEquals(Collections.singleton(
                         URI.create("https://storage.test/e973cc3d-5c28-4a10-98c5-e40079289358/")),
                     request.getResources());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -104,9 +104,9 @@ public class AccessGrantScenarios {
     private static final String GRANT_MODE_READ = "Read";
     private static final String GRANT_MODE_APPEND = "Append";
     private static final String GRANT_MODE_WRITE = "Write";
-    private static final Set<String> PURPOSES = new HashSet<>(Arrays.asList(
-            "https://some.purpose/not-a-nefarious-one/i-promise",
-            "https://some.other.purpose/"));
+    private static final Set<URI> PURPOSES = new HashSet<>(Arrays.asList(
+            URI.create("https://some.purpose/not-a-nefarious-one/i-promise"),
+            URI.create("https://some.other.purpose/")));
     private static final String GRANT_EXPIRATION = "2024-04-03T12:00:00Z";
 
     private static URI testContainerURI;
@@ -233,7 +233,7 @@ public class AccessGrantScenarios {
         final URI uri = URIBuilder.newBuilder(URI.create(VC_PROVIDER)).path(grant.getIdentifier().toString()).build();
         final AccessGrant grantFromVcProvider = accessGrantClient.fetch(uri, AccessGrant.class)
             .toCompletableFuture().join();
-        assertEquals(grant.getPurpose(), grantFromVcProvider.getPurpose());
+        assertEquals(grant.getPurposes(), grantFromVcProvider.getPurposes());
 
         //unauthorized request test
         final SolidSyncClient client = SolidSyncClient.getClientBuilder().build();


### PR DESCRIPTION
The current JCL API identifies purposes as Strings, but the ESS documentation indicates that purposes are URIs. This aligns the JCL API with the expectation that purposes are always URIs.

For methods that were present and deprecated in earlier releases, those still use String values. All other methods now use `Set<URI>`.