### PR TITLE
JCL-369: Use isProvidedTo property for access grants

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -92,7 +92,7 @@ public class AccessGrantClient {
     private static final String APPLICATION_JSON = "application/json";
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String CREDENTIAL_SUBJECT = "credentialSubject";
-    private static final String IS_PROVIDED_TO_PERSON = "isProvidedToPerson";
+    private static final String IS_PROVIDED_TO = "isProvidedTo";
     private static final String IS_CONSENT_FOR_DATA_SUBJECT = "isConsentForDataSubject";
     private static final String FOR_PERSONAL_DATA = "forPersonalData";
     private static final String HAS_STATUS = "hasStatus";
@@ -696,7 +696,7 @@ public class AccessGrantClient {
         final Map<String, Object> consent = new HashMap<>();
         if (agent != null) {
             if (isAccessGrant(type) || isAccessDenial(type)) {
-                consent.put(IS_PROVIDED_TO_PERSON, agent);
+                consent.put(IS_PROVIDED_TO, agent);
             } else if (isAccessRequest(type)) {
                 consent.put(IS_CONSENT_FOR_DATA_SUBJECT, agent);
             }
@@ -761,7 +761,7 @@ public class AccessGrantClient {
         consent.put(MODE, modes);
         consent.put(HAS_STATUS, "https://w3id.org/GConsent#ConsentStatusRefused");
         consent.put(FOR_PERSONAL_DATA, resources);
-        consent.put(IS_PROVIDED_TO_PERSON, agent);
+        consent.put(IS_PROVIDED_TO, agent);
         if (!purposes.isEmpty()) {
             consent.put(FOR_PURPOSE, purposes);
         }
@@ -788,7 +788,7 @@ public class AccessGrantClient {
         consent.put(MODE, modes);
         consent.put(HAS_STATUS, "https://w3id.org/GConsent#ConsentStatusExplicitlyGiven");
         consent.put(FOR_PERSONAL_DATA, resources);
-        consent.put(IS_PROVIDED_TO_PERSON, agent);
+        consent.put(IS_PROVIDED_TO, agent);
         if (!purposes.isEmpty()) {
             consent.put(FOR_PURPOSE, purposes);
         }

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
@@ -309,7 +309,7 @@ class MockAccessGrantServer {
         wireMockServer.stubFor(post(urlEqualTo("/derive"))
                     .atPriority(2)
                     .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
-                    .withRequestBody(containing("\"isProvidedToPerson\":\"https://id.test/user\""))
+                    .withRequestBody(containing("\"isProvidedTo\":\"https://id.test/user\""))
                     .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")

--- a/access-grant/src/test/resources/access_grant1.json
+++ b/access-grant/src/test/resources/access_grant1.json
@@ -22,7 +22,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":["https://purpose.example/Purpose1"],
                 "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
         "proof":{

--- a/access-grant/src/test/resources/access_grant3.json
+++ b/access-grant/src/test/resources/access_grant3.json
@@ -17,7 +17,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":["https://purpose.example/Purpose1"],
                 "forPersonalData":["https://storage.example/protected-resource"]}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant1.json
+++ b/access-grant/src/test/resources/invalid_access_grant1.json
@@ -19,7 +19,7 @@
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"https://id.example/grantee",
+            "isProvidedTo":"https://id.example/grantee",
             "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
     "proof":{
         "created":"2022-08-25T20:34:05.236Z",

--- a/access-grant/src/test/resources/invalid_access_grant10.json
+++ b/access-grant/src/test/resources/invalid_access_grant10.json
@@ -22,7 +22,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":"https://purpose.example/Purpose1",
                 "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant12.json
+++ b/access-grant/src/test/resources/invalid_access_grant12.json
@@ -21,7 +21,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":["https://purpose.example/Purpose1"],
                 "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant13.json
+++ b/access-grant/src/test/resources/invalid_access_grant13.json
@@ -22,7 +22,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":["https://purpose.example/Purpose1"],
                 "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant14.json
+++ b/access-grant/src/test/resources/invalid_access_grant14.json
@@ -22,7 +22,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":["https://purpose.example/Purpose1"],
                 "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant2.json
+++ b/access-grant/src/test/resources/invalid_access_grant2.json
@@ -21,7 +21,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":"https://purpose.example/Purpose1",
                 "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant4.json
+++ b/access-grant/src/test/resources/invalid_access_grant4.json
@@ -21,7 +21,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":"https://purpose.example/Purpose1",
                 "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant5.json
+++ b/access-grant/src/test/resources/invalid_access_grant5.json
@@ -27,7 +27,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":"https://purpose.example/Purpose1",
                 "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant6.json
+++ b/access-grant/src/test/resources/invalid_access_grant6.json
@@ -21,7 +21,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":"https://purpose.example/Purpose1",
                 "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant7.json
+++ b/access-grant/src/test/resources/invalid_access_grant7.json
@@ -21,7 +21,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":"https://purpose.example/Purpose1",
                 "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
         "proof":{

--- a/access-grant/src/test/resources/invalid_access_grant9.json
+++ b/access-grant/src/test/resources/invalid_access_grant9.json
@@ -22,7 +22,7 @@
             "providedConsent":{
                 "mode":["Read"],
                 "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-                "isProvidedToPerson":"https://id.example/grantee",
+                "isProvidedTo":"https://id.example/grantee",
                 "forPurpose":"https://purpose.example/Purpose1",
                 "forPersonalData":"https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"}},
         "proof":{

--- a/access-grant/src/test/resources/query_response1.json
+++ b/access-grant/src/test/resources/query_response1.json
@@ -20,7 +20,7 @@
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"https://id.example/grantee",
+            "isProvidedTo":"https://id.example/grantee",
             "forPurpose":["https://purpose.example/Purpose1"],
             "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
     "proof":{

--- a/access-grant/src/test/resources/query_response4.json
+++ b/access-grant/src/test/resources/query_response4.json
@@ -20,7 +20,7 @@
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"https://id.test/user",
+            "isProvidedTo":"https://id.test/user",
             "forPurpose":["https://purpose.example/Purpose1"],
             "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
     "proof":{

--- a/access-grant/src/test/resources/query_response6.json
+++ b/access-grant/src/test/resources/query_response6.json
@@ -20,7 +20,7 @@
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusRefused",
-            "isProvidedToPerson":"https://id.example/grantee",
+            "isProvidedTo":"https://id.example/grantee",
             "forPurpose":["https://purpose.example/Purpose1"],
             "forPersonalData":["https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/"]}},
     "proof":{

--- a/access-grant/src/test/resources/vc-1.json
+++ b/access-grant/src/test/resources/vc-1.json
@@ -19,7 +19,7 @@
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"https://id.example/grantee",
+            "isProvidedTo":"https://id.example/grantee",
             "forPurpose":["https://purpose.example/Purpose1"],
             "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
     "proof":{

--- a/access-grant/src/test/resources/vc-2.json
+++ b/access-grant/src/test/resources/vc-2.json
@@ -19,7 +19,7 @@
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"https://id.example/grantee",
+            "isProvidedTo":"https://id.example/grantee",
             "forPurpose":["https://purpose.example/Purpose1"],
             "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
     "proof":{

--- a/access-grant/src/test/resources/vc-4.json
+++ b/access-grant/src/test/resources/vc-4.json
@@ -19,7 +19,7 @@
         "providedConsent":{
             "mode":["Read","Append"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"https://id.test/agent",
+            "isProvidedTo":"https://id.test/agent",
             "forPurpose":["https://purpose.test/Purpose1"],
             "forPersonalData":["https://storage.test/data/"]}},
     "proof":{

--- a/access-grant/src/test/resources/vc-6.json
+++ b/access-grant/src/test/resources/vc-6.json
@@ -14,7 +14,7 @@
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"https://id.example/grantee",
+            "isProvidedTo":"https://id.example/grantee",
             "forPurpose":["https://purpose.example/Purpose1"],
             "forPersonalData":["https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/"]}},
     "proof":{

--- a/access-grant/src/test/resources/vc-7.json
+++ b/access-grant/src/test/resources/vc-7.json
@@ -19,7 +19,7 @@
         "providedConsent":{
             "mode":["Read","Append"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusRefused",
-            "isProvidedToPerson":"https://id.test/agent",
+            "isProvidedTo":"https://id.test/agent",
             "forPurpose":["https://purpose.test/Purpose1"],
             "forPersonalData":["https://storage.test/data/"]}},
     "proof":{


### PR DESCRIPTION
The Java client libraries currently make use of the `isProvidedToPerson` property when issuing and querying access grants. The JS SDK and the documentation prefer the use of `isProvidedTo`, which is a better property to use anyway. This PR replaces the use of `isProvidedToPerson` with `isProvidedTo`.