### PR TITLE
JCL-350: Fix matrix variable name

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -35,7 +35,7 @@ jobs:
           INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_CLIENT_SECRET }}
 
       - name: Dev Integration tests
-        if: ${{ github.actor != 'dependabot[bot]' && matrix.java-version == 11 }}
+        if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 11 }}
         continue-on-error: true
         run: mvn -B -ntp verify -Pci -pl integration/uma,integration/openid
         env:


### PR DESCRIPTION
The CI workflow checks for `matrix.java-version`, though the configuration is `matrix.java`, which means that the expression will _always_ return false.