### PR TITLE
JCL-372: Use correct value for revocation status

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -490,7 +490,7 @@ public class AccessGrantClient {
 
             final Map<String, Object> credentialStatus = new HashMap<>();
             credentialStatus.put(TYPE, status.getType());
-            credentialStatus.put("status", Integer.toString(status.getIndex()));
+            credentialStatus.put("status", "1");
 
             final Map<String, Object> data = new HashMap<>();
             data.put("credentialId", credential.getIdentifier());

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
@@ -256,6 +256,7 @@ class MockAccessGrantServer {
         wireMockServer.stubFor(post(urlEqualTo("/status"))
                     .atPriority(1)
                     .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .withRequestBody(containing("\"status\":\"1\""))
                     .withRequestBody(containing("\"" + wireMockServer.baseUrl() + "/access-grant-1\""))
                     .willReturn(aResponse()
                         .withStatus(204)));


### PR DESCRIPTION
The access grant revocation API has been using the credential status index value for the `status` value, when it should be using the value `"1"` for revocation.

See https://w3c-ccg.github.io/vc-api/issuer.html#tag/Credentials/operation/updateCredentialStatus for more details on the API.