### PR TITLE
JCL-373: Address minor compiler warnings

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -576,8 +576,7 @@ public class AccessGrantClient {
             });
     }
 
-
-
+    @SuppressWarnings("unchecked")
     <T extends AccessCredential> T processVerifiableCredential(final InputStream input, final Set<String> validTypes,
             final Class<T> clazz) throws IOException {
         final Map<String, Object> data = jsonService.fromJson(input,
@@ -601,6 +600,7 @@ public class AccessGrantClient {
         throw new AccessGrantException("Invalid Access Grant: missing supported type");
     }
 
+    @SuppressWarnings("unchecked")
     <T extends AccessCredential> List<T> processQueryResponse(final InputStream input, final Set<String> validTypes,
             final Class<T> clazz) throws IOException {
         final Map<String, Object> data = jsonService.fromJson(input,
@@ -676,7 +676,9 @@ public class AccessGrantClient {
     static Collection<Object> getCredentials(final Map<String, Object> data) {
         final Object credential = data.get(VERIFIABLE_CREDENTIAL);
         if (credential instanceof Collection) {
-            return (Collection) credential;
+            @SuppressWarnings("unchecked")
+            final Collection<Object> coll = (Collection<Object>) credential;
+            return coll;
         }
         return Collections.emptyList();
     }

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
@@ -90,7 +90,7 @@ class AccessGrantSessionTest {
         final String token = AccessGrantTestUtils.generateIdToken(claims);
 
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant1.json")) {
-            final AccessGrant grant = AccessGrant.ofAccessGrant(resource);
+            final AccessGrant grant = AccessGrant.of(resource);
             final Session session = AccessGrantSession.ofAccessGrant(OpenIdSession.ofIdToken(token), grant);
             assertEquals(Optional.of(URI.create(WEBID)), session.getPrincipal());
             assertFalse(grant.getResources().isEmpty());
@@ -120,7 +120,7 @@ class AccessGrantSessionTest {
         final String token = AccessGrantTestUtils.generateIdToken(claims);
 
         try (final InputStream resource = AccessGrantTest.class.getResourceAsStream("/access_grant3.json")) {
-            final AccessGrant grant = AccessGrant.ofAccessGrant(resource);
+            final AccessGrant grant = AccessGrant.of(resource);
             final Session session = AccessGrantSession.ofAccessGrant(OpenIdSession.ofIdToken(token), grant);
             final Request req = Request.newBuilder(URI.create("https://storage.example/protected-resource")).build();
             final Authenticator auth = new OpenIdAuthenticationProvider().getAuthenticator(Challenge.of("Bearer"));

--- a/examples/cli/src/main/java/com/inrupt/client/examples/cli/SolidApp.java
+++ b/examples/cli/src/main/java/com/inrupt/client/examples/cli/SolidApp.java
@@ -82,7 +82,7 @@ public class SolidApp implements QuarkusApplication {
                 printWriter.format("WebID: %s", webid);
                 printWriter.println();
                 try (final var profile = client.read(webid, WebIdProfile.class)) {
-                    profile.getStorage().stream().findFirst().ifPresent(storage -> {
+                    profile.getStorages().stream().findFirst().ifPresent(storage -> {
                         printWriter.format("Storage %s ", storage);
                         printWriter.println();
                         try (final var container = client.read(storage, SolidContainer.class)) {

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/SecurityConfiguration.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/SecurityConfiguration.java
@@ -23,6 +23,7 @@ package com.inrupt.client.examples.springboot;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
@@ -55,7 +56,7 @@ public class SecurityConfiguration {
                 .deleteCookies("JSESSIONID")
                 .logoutSuccessHandler(oidcLogoutSuccessHandler())
             )
-            .oauth2Login();
+            .oauth2Login(Customizer.withDefaults());
         return http.build();
     }
 

--- a/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/SolidStorage.java
+++ b/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/SolidStorage.java
@@ -75,7 +75,7 @@ public class SolidStorage {
         return jwt.claim("webid").map(String.class::cast).map(URI::create).map(webid -> {
             final var session = client.session(OpenIdSession.ofIdToken(jwt.getRawToken()));
             return session.read(webid, WebIdProfile.class)
-                .thenCompose(profile -> profile.getStorage().stream().findFirst().map(storage ->
+                .thenCompose(profile -> profile.getStorages().stream().findFirst().map(storage ->
                             session.read(storage, SolidContainer.class).thenApply(container -> {
                                 try (container) {
                                     final var resources = container.getResources().stream()

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -144,8 +144,8 @@ public class AccessGrantScenarios {
         State.WEBID = URI.create(webidUrl);
         final SolidSyncClient client = SolidSyncClient.getClientBuilder().build();
         try (final WebIdProfile profile = client.read(URI.create(webidUrl), WebIdProfile.class)) {
-            issuer = profile.getOidcIssuer().iterator().next().toString();
-            podUrl = profile.getStorage().iterator().next().toString();
+            issuer = profile.getOidcIssuers().iterator().next().toString();
+            podUrl = profile.getStorages().iterator().next().toString();
         }
         if (!podUrl.endsWith(Utils.FOLDER_SEPARATOR)) {
             podUrl += Utils.FOLDER_SEPARATOR;

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -117,8 +117,8 @@ public class AuthenticationScenarios {
         State.WEBID = URI.create(webidUrl);
         final SolidSyncClient client = SolidSyncClient.getClient();
         try (final WebIdProfile profile = client.read(URI.create(webidUrl), WebIdProfile.class)) {
-            issuer = profile.getOidcIssuer().iterator().next().toString();
-            podUrl = profile.getStorage().iterator().next().toString();
+            issuer = profile.getOidcIssuers().iterator().next().toString();
+            podUrl = profile.getStorages().iterator().next().toString();
         }
         if (!podUrl.endsWith(Utils.FOLDER_SEPARATOR)) {
             podUrl += Utils.FOLDER_SEPARATOR;

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -109,7 +109,7 @@ public class DomainModulesResource {
         State.WEBID = URI.create(webidUrl);
         //find storage from WebID using domain-specific webID solid concept
         try (final WebIdProfile sameProfile = client.read(URI.create(webidUrl), WebIdProfile.class)) {
-            final var storages = sameProfile.getStorage();
+            final var storages = sameProfile.getStorages();
             if (!storages.isEmpty()) {
                 podUrl = storages.iterator().next().toString();
             }
@@ -253,7 +253,7 @@ public class DomainModulesResource {
         LOGGER.info("Integration Test - find pod storage from webID");
 
         try (final WebIdProfile sameProfile = client.read(URI.create(webidUrl), WebIdProfile.class)) {
-            assertFalse(sameProfile.getStorage().isEmpty());
+            assertFalse(sameProfile.getStorages().isEmpty());
         }
 
         final var missingWebId = URIBuilder.newBuilder(URI.create(webidUrl)).path(UUID.randomUUID().toString()).build();

--- a/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
+++ b/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
@@ -90,8 +90,8 @@ class ServerTest {
         State.WEBID = URI.create(webidUrl);
         final SolidSyncClient client = SolidSyncClient.getClient();
         try (final WebIdProfile profile = client.read(URI.create(webidUrl), WebIdProfile.class)) {
-            issuer = profile.getOidcIssuer().iterator().next().toString();
-            podUrl = profile.getStorage().iterator().next().toString();
+            issuer = profile.getOidcIssuers().iterator().next().toString();
+            podUrl = profile.getStorages().iterator().next().toString();
         }
     }
 

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdAuthenticationProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdAuthenticationProvider.java
@@ -58,6 +58,7 @@ public class OpenIdAuthenticationProvider implements AuthenticationProvider {
         this.priorityLevel = priority;
     }
 
+    /* deprecated */
     @Override
     public String getScheme() {
         return BEARER;

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -345,7 +345,7 @@ public final class OpenIdSession implements Session {
 
             // Required by OpenID Connect
             builder.setRequireExpirationTime();
-            builder.setExpectedIssuers(true, null);
+            builder.setExpectedIssuers(true, (String[]) null);
             builder.setRequireSubject();
             builder.setRequireIssuedAt();
 


### PR DESCRIPTION
There are two categories of changes here:

* For type coersions, we are explicit about cases where those are allowed (`@SuppressWarnings("unchecked")`) -- in each case, the compiler already catches errors, but the type system isn't quite smart enough to know that the casts are legal
* Removal of deprecated methods -- some of our code is intentionally using methods that we have marked as deprecated, but in some cases, we simply haven't updated those code paths to use the latest version