### PR TITLE
JCL-367: Distinguish between creator and recipient in access credential queries

### DIFF
--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -508,9 +508,8 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final List<AccessGrant> grants = client.query(null,
-                URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/a/b/c"), null, "Read",
-                AccessGrant.class)
+        final URI resource = URI.create("https://storage.example/e973cc3d-5c28-4a10-98c5-e40079289358/a/b/c");
+        final List<AccessGrant> grants = client.query(resource, null, null, null, "Read", AccessGrant.class)
                     .toCompletableFuture().join();
         assertEquals(1, grants.size());
     }
@@ -525,9 +524,8 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final List<AccessGrant> grants = client.query(URI.create("https://id.test/user"),
-                null, null, "Read", AccessGrant.class)
-                    .toCompletableFuture().join();
+        final List<AccessGrant> grants = client.query(null, null, URI.create("https://id.test/user"),
+                null, "Read", AccessGrant.class).toCompletableFuture().join();
         assertEquals(1, grants.size());
     }
 
@@ -541,9 +539,8 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final List<AccessRequest> requests = client.query(URI.create("https://id.test/user"),
-                null, null, "Read", AccessRequest.class)
-                    .toCompletableFuture().join();
+        final List<AccessRequest> requests = client.query(null, null, URI.create("https://id.test/user"),
+                null, "Read", AccessRequest.class).toCompletableFuture().join();
         assertEquals(1, requests.size());
     }
 
@@ -557,10 +554,9 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final List<AccessRequest> requests = client.query(null,
-                URI.create("https://storage.example/f1759e6d-4dda-4401-be61-d90d070a5474/a/b/c"), null, "Read",
-                AccessRequest.class)
-                    .toCompletableFuture().join();
+        final URI resource = URI.create("https://storage.example/f1759e6d-4dda-4401-be61-d90d070a5474/a/b/c");
+        final List<AccessRequest> requests = client.query(resource, null, null, null, "Read", AccessRequest.class)
+            .toCompletableFuture().join();
         assertEquals(1, requests.size());
     }
 
@@ -574,10 +570,9 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final List<AccessDenial> grants = client.query(null,
-                URI.create("https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/e/f/g"), null, "Read",
-                AccessDenial.class)
-                    .toCompletableFuture().join();
+        final URI resource = URI.create("https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/e/f/g");
+        final List<AccessDenial> grants = client.query(resource, null, null, null, "Read", AccessDenial.class)
+            .toCompletableFuture().join();
         assertEquals(1, grants.size());
     }
 
@@ -592,7 +587,8 @@ class AccessGrantClientTest {
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
         final URI uri = URI.create("https://storage.example/f1759e6d-4dda-4401-be61-d90d070a5474/a/b/c");
-        assertThrows(AccessGrantException.class, () -> client.query(null, uri, null, "Read", AccessCredential.class));
+        assertThrows(AccessGrantException.class, () ->
+                client.query(uri, null, null, null, "Read", AccessCredential.class));
     }
 
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -323,8 +323,8 @@ public class AccessGrantScenarios {
         final AccessGrantClient accessGrantClient = new AccessGrantClient(URI.create(VC_PROVIDER)).session(session);
 
         //query for all grants issued by the user
-        final List<AccessRequest> grants = accessGrantClient.query(URI.create(webidUrl),
-                sharedResource, PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
+        final List<AccessRequest> grants = accessGrantClient.query(sharedResource, null, URI.create(webidUrl),
+                PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
             .toCompletableFuture().join();
         // result is 4 because we retrieve the grants for each path
         // sharedTextFileURI =
@@ -332,8 +332,8 @@ public class AccessGrantScenarios {
         assertEquals(1, grants.size());
 
         //query for all grants issued by a random user
-        final List<AccessRequest> randomGrants = accessGrantClient.query(URI.create("https://someuser.test"),
-                sharedResource, PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
+        final List<AccessRequest> randomGrants = accessGrantClient.query(sharedResource, null,
+                URI.create("https://someuser.test"), PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
             .toCompletableFuture().join();
         assertEquals(0, randomGrants.size());
     }
@@ -347,14 +347,14 @@ public class AccessGrantScenarios {
         final AccessGrantClient accessGrantClient = new AccessGrantClient(URI.create(VC_PROVIDER)).session(session);
 
         //query for all grants of a dedicated resource
-        final List<AccessRequest> requests = accessGrantClient.query(URI.create(webidUrl),
-                sharedResource, PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
+        final List<AccessRequest> requests = accessGrantClient.query(sharedResource, null, URI.create(webidUrl),
+                PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
             .toCompletableFuture().join();
         assertEquals(1, requests.size());
 
         //query for all grants of a random resource
-        final List<AccessRequest> randomGrants = accessGrantClient.query(URI.create(webidUrl),
-                URI.create("https://somerandom.test"), PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
+        final List<AccessRequest> randomGrants = accessGrantClient.query(URI.create("https://somerandom.test"),
+                null, URI.create(webidUrl), PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
             .toCompletableFuture().join();
         assertEquals(0, randomGrants.size());
     }
@@ -368,14 +368,14 @@ public class AccessGrantScenarios {
         final AccessGrantClient accessGrantClient = new AccessGrantClient(URI.create(VC_PROVIDER)).session(session);
 
         //query for all grants with a dedicated purpose
-        final List<AccessRequest> requests = accessGrantClient.query(URI.create(webidUrl),
-                sharedResource, PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
+        final List<AccessRequest> requests = accessGrantClient.query(sharedResource, null, URI.create(webidUrl),
+                PURPOSE1, GRANT_MODE_READ, AccessRequest.class)
             .toCompletableFuture().join();
         assertEquals(1, requests.size());
 
         //query for all grants of dedicated purpose combinations
-        final List<AccessGrant> randomGrants = accessGrantClient.query(URI.create(webidUrl),
-                sharedResource, PURPOSE1, GRANT_MODE_WRITE, AccessGrant.class)
+        final List<AccessGrant> randomGrants = accessGrantClient.query(sharedResource, null, URI.create(webidUrl),
+                PURPOSE1, GRANT_MODE_WRITE, AccessGrant.class)
             .toCompletableFuture().join();
         assertEquals(0, randomGrants.size()); //our grant is actually a Read
     }


### PR DESCRIPTION
At present, the `AccessGrantClient.query()` method has an `agent` parameter, which refers to the recipient of an access credential, but there is no way to query based on `creator`. This PR introduces an additional parameter so that one can query for creator and/or recipient.

**Note**: this also moves the `resource` URI to the first position in the new `::query` API (to be introduced in Beta3), as this property is anticipated to be `null` less often.