### PR TITLE
JCL-375: Clarify javadocs for high level client headers

### DIFF
--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -332,7 +332,10 @@ public class SolidClient {
         }
 
         /**
-         * Set a collection of headers to be used with each request.
+         * Set a collection of headers to be used with each high-level client request.
+         *
+         * <p>Note that any headers set here will not be automatically added to any
+         * requests performed by the {@link SolidClient#send} method.
          *
          * @param headers the headers
          * @return this builder

--- a/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
@@ -162,7 +162,10 @@ public class SolidSyncClient {
         }
 
         /**
-         * Set a collection of headers to be used with each request.
+         * Set a collection of headers to be used with each high-level client request.
+         *
+         * <p>Note that any headers set here will not be automatically added to any
+         * requests performed by the {@link SolidSyncClient#send} method.
          *
          * @param headers the headers
          * @return this builder


### PR DESCRIPTION
The javadocs were misleading in the description of how headers added to the client builder would be used. This clarifies how the library works in this regard.