### PR TITLE
JCL-376: Capture deployment metrics for releases

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -13,8 +13,8 @@ jobs:
   deployment:
     name: Deploy artifacts
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ matrix.envName }}
+    permissions:
+      deployments: write
     strategy:
       matrix:
         envName: ["Development", "Production"]
@@ -41,6 +41,13 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        id: deployment
+        with:
+          token: ${{ github.token }}
+          environment: ${{ matrix.envName }}
+
       - name: Build the code with Maven
         run: mvn -B -ntp install -Pci
 
@@ -51,6 +58,22 @@ jobs:
           MAVEN_REPO_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_REPO_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          state: 'success'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ github.token }}
+          state: 'failure'
+          deployment-id: ${{ steps.deployment.outputs.deployment_id }}
 
       - name: Sonar Analysis
         if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
This improves our use of the Jira integration for capturing deployment metrics for release workflows.

As it was, production deployments (releases) would not be captured by the Jira integration. By explicitly creating deployments and updating the status, we can more effectively capture this data.