### PR TITLE
JCL-384: Optimize request caching in session objects

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
@@ -152,7 +152,7 @@ public final class AccessGrantSession implements Session {
         return authenticator.authenticate(this, request, algorithms)
             .thenApply(credential -> {
                 if (credential != null) {
-                    tokenCache.put(request.uri(), credential);
+                    tokenCache.put(cacheKey(request.uri()), credential);
                 }
                 return Optional.ofNullable(credential);
             });
@@ -171,7 +171,7 @@ public final class AccessGrantSession implements Session {
 
     @Override
     public Optional<Credential> fromCache(final Request request) {
-        final Credential cachedToken = tokenCache.get(request.uri());
+        final Credential cachedToken = tokenCache.get(cacheKey(request.uri()));
         if (cachedToken != null && cachedToken.getExpiration().isAfter(Instant.now())) {
             return Optional.of(cachedToken);
         }
@@ -180,5 +180,12 @@ public final class AccessGrantSession implements Session {
 
     static boolean isAncestor(final URI parent, final URI resource) {
         return !parent.relativize(resource).isAbsolute();
+    }
+
+    static URI cacheKey(final URI uri) {
+        if (uri.getQuery() != null || uri.getFragment() != null) {
+            return URI.create(uri.getScheme() + "://" + uri.getHost() + uri.getPath());
+        }
+        return uri;
     }
 }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
@@ -183,8 +183,8 @@ public final class AccessGrantSession implements Session {
     }
 
     static URI cacheKey(final URI uri) {
-        if (uri.getQuery() != null || uri.getFragment() != null) {
-            return URI.create(uri.getScheme() + "://" + uri.getHost() + uri.getPath());
+        if (uri.getFragment() != null) {
+            return URI.create(uri.getScheme() + ":" + uri.getSchemeSpecificPart());
         }
         return uri;
     }

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
@@ -35,9 +35,11 @@ import com.inrupt.client.util.URIBuilder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -130,8 +132,20 @@ class AccessGrantSessionTest {
 
             assertTrue(credential.isPresent());
             assertTrue(session.fromCache(req).isPresent());
+            final List<String> uris = Arrays.asList("https://storage.example/protected-resource?k=v",
+                    "https://storage.example/protected-resource#hash",
+                    "https://storage.example/protected-resource?q=1&k=2#hash");
+            for (final String uri : uris) {
+                final Request r = Request.newBuilder(URI.create(uri)).build();
+                assertTrue(session.fromCache(r).isPresent());
+            }
+
             session.reset();
             assertFalse(session.fromCache(req).isPresent());
+            for (final String uri : uris) {
+                final Request r = Request.newBuilder(URI.create(uri)).build();
+                assertFalse(session.fromCache(r).isPresent());
+            }
         }
     }
 

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
@@ -132,17 +132,29 @@ class AccessGrantSessionTest {
 
             assertTrue(credential.isPresent());
             assertTrue(session.fromCache(req).isPresent());
-            final List<String> uris = Arrays.asList("https://storage.example/protected-resource?k=v",
-                    "https://storage.example/protected-resource#hash",
-                    "https://storage.example/protected-resource?q=1&k=2#hash");
-            for (final String uri : uris) {
+            final List<String> hashUris = Arrays.asList("https://storage.example/protected-resource#hash1",
+                    "https://storage.example/protected-resource#hash2",
+                    "https://storage.example/protected-resource#hash3");
+            for (final String uri : hashUris) {
                 final Request r = Request.newBuilder(URI.create(uri)).build();
                 assertTrue(session.fromCache(r).isPresent());
             }
+            final List<String> queryUris = Arrays.asList("https://storage.example/protected-resource?q=1",
+                    "https://storage.example/protected-resource?a=b",
+                    "https://storage.example/protected-resource?foo=bar&q=1");
+            for (final String uri : queryUris) {
+                final Request r = Request.newBuilder(URI.create(uri)).build();
+                assertFalse(session.fromCache(r).isPresent());
+            }
 
             session.reset();
+
             assertFalse(session.fromCache(req).isPresent());
-            for (final String uri : uris) {
+            for (final String uri : hashUris) {
+                final Request r = Request.newBuilder(URI.create(uri)).build();
+                assertFalse(session.fromCache(r).isPresent());
+            }
+            for (final String uri : queryUris) {
                 final Request r = Request.newBuilder(URI.create(uri)).build();
                 assertFalse(session.fromCache(r).isPresent());
             }

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -223,7 +223,7 @@ public final class OpenIdSession implements Session {
     @Override
     public Optional<Credential> fromCache(final Request request) {
         final Credential c = credential.get();
-        if (!hasExpired(c) && request != null && requestCache.get(request.uri()) != null) {
+        if (!hasExpired(c) && request != null && requestCache.get(cacheKey(request.uri())) != null) {
             LOGGER.debug("Using cached token for request: {}", request.uri());
             return Optional.of(c);
         }
@@ -242,7 +242,7 @@ public final class OpenIdSession implements Session {
         final Optional<Credential> cred = getCredential(ID_TOKEN, null);
         if (cred.isPresent() && request != null) {
             LOGGER.debug("Setting cache entry for request: {}", request.uri());
-            requestCache.put(request.uri(), Boolean.TRUE);
+            requestCache.put(cacheKey(request.uri()), Boolean.TRUE);
         }
         return CompletableFuture.completedFuture(cred);
     }
@@ -337,6 +337,13 @@ public final class OpenIdSession implements Session {
             return Instant.MAX;
         }
         return Instant.now().plusSeconds(expiresIn);
+    }
+
+    static URI cacheKey(final URI uri) {
+        if (uri.getQuery() != null || uri.getFragment() != null) {
+            return URI.create(uri.getScheme() + "://" + uri.getHost() + uri.getPath());
+        }
+        return uri;
     }
 
     static JwtClaims parseIdToken(final String idToken, final OpenIdConfig config) {

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -340,8 +340,8 @@ public final class OpenIdSession implements Session {
     }
 
     static URI cacheKey(final URI uri) {
-        if (uri.getQuery() != null || uri.getFragment() != null) {
-            return URI.create(uri.getScheme() + "://" + uri.getHost() + uri.getPath());
+        if (uri.getFragment() != null) {
+            return URI.create(uri.getScheme() + ":" + uri.getSchemeSpecificPart());
         }
         return uri;
     }

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdSessionTest.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdSessionTest.java
@@ -166,15 +166,30 @@ class OpenIdSessionTest {
             .toCompletableFuture().join();
         assertEquals(Optional.of(URI.create(WEBID)), credential.flatMap(Credential::getPrincipal));
         assertTrue(session.fromCache(req).isPresent());
-        final List<String> uris = Arrays.asList("https://storage.example/?k=v",
-                "https://storage.example/#hash", "https://storage.example/?q=1&k=2#hash");
-        for (final String uri : uris) {
+
+        final List<String> hashUris = Arrays.asList("https://storage.example/#hash1",
+                "https://storage.example/#hash2",
+                "https://storage.example/#hash3");
+        for (final String uri : hashUris) {
             final Request r = Request.newBuilder(URI.create(uri)).build();
             assertTrue(session.fromCache(r).isPresent());
         }
+        final List<String> queryUris = Arrays.asList("https://storage.example/?q=1",
+                "https://storage.example/?a=b",
+                "https://storage.example/?foo=bar&q=1");
+        for (final String uri : queryUris) {
+            final Request r = Request.newBuilder(URI.create(uri)).build();
+            assertFalse(session.fromCache(r).isPresent());
+        }
+
         session.reset();
+
         assertFalse(session.fromCache(req).isPresent());
-        for (final String uri : uris) {
+        for (final String uri : hashUris) {
+            final Request r = Request.newBuilder(URI.create(uri)).build();
+            assertFalse(session.fromCache(r).isPresent());
+        }
+        for (final String uri : queryUris) {
             final Request r = Request.newBuilder(URI.create(uri)).build();
             assertFalse(session.fromCache(r).isPresent());
         }


### PR DESCRIPTION
At present, the caching mechanism compares the full URI in requests, but it should ignore any query parameters or hash fragments.