### PR TITLE
Use correct groupId in documentation

### DIFF
--- a/src/site/apt/getting-started.apt.vm
+++ b/src/site/apt/getting-started.apt.vm
@@ -18,7 +18,7 @@ Getting Started With Inrupt's Java Client Libraries
 
 -----------------
 $ mvn archetype:generate \
-    -DarchetypeGroupId=com.inrupt \
+    -DarchetypeGroupId=com.inrupt.client \
     -DarchetypeArtifactId=inrupt-client-archetype-java \
     -DarchetypeVersion=<VERSION>
 -----------------


### PR DESCRIPTION
The page at https://inrupt.github.io/solid-client-java/1.0.0.Beta3/getting-started.html lists the incorrect groupId for the Java Client libraries.