### PR TITLE
JCL-385: Improve PKCE verifier to always produce spec conforming values

### DIFF
--- a/openid/src/main/java/com/inrupt/client/openid/PKCE.java
+++ b/openid/src/main/java/com/inrupt/client/openid/PKCE.java
@@ -36,6 +36,8 @@ import java.util.Objects;
  */
 public final class PKCE {
 
+    private static final BigInteger PADDING = BigInteger.valueOf(2).pow(256);
+
     /**
      * Create a PKCE challenge value using the S256 algorithm.
      *
@@ -73,7 +75,7 @@ public final class PKCE {
      * @return the Base64URL-encoded verifier
      */
     static String createVerifier() {
-        final byte[] rand = new BigInteger(32 * 8, new SecureRandom()).toByteArray();
+        final byte[] rand = PADDING.add(new BigInteger(32 * 8, new SecureRandom())).toByteArray();
         return Base64.getUrlEncoder().withoutPadding().encodeToString(rand);
     }
 

--- a/openid/src/test/java/com/inrupt/client/openid/PKCETest.java
+++ b/openid/src/test/java/com/inrupt/client/openid/PKCETest.java
@@ -20,7 +20,6 @@
  */
 package com.inrupt.client.openid;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,16 +29,16 @@ class PKCETest {
 
     @Test
     void createChallengeTest() {
-        assertTrue(PKCE.createChallenge("🐶🐶🐶", "SHA-256").getBytes(UTF_8).length >= 43);
-        assertTrue(PKCE.createChallenge("🐶🐶🐶", "SHA-256").getBytes(UTF_8).length <= 128);
-        assertTrue(PKCE.createChallenge("", "SHA-256").getBytes(UTF_8).length >= 43);
-        assertTrue(PKCE.createChallenge("", "SHA-256").getBytes(UTF_8).length <= 128);
+        assertTrue(PKCE.createChallenge("🐶🐶🐶", "SHA-256").length() >= 43);
+        assertTrue(PKCE.createChallenge("🐶🐶🐶", "SHA-256").length() <= 128);
+        assertTrue(PKCE.createChallenge("", "SHA-256").length() >= 43);
+        assertTrue(PKCE.createChallenge("", "SHA-256").length() <= 128);
         assertThrows(NullPointerException.class, () -> PKCE.createChallenge(null, "SHA-256"));
     }
 
     @Test
     void createVerifierTest() {
-        assertTrue(PKCE.createVerifier().getBytes(UTF_8).length >= 43);
-        assertTrue(PKCE.createVerifier().getBytes(UTF_8).length <= 128);
+        assertTrue(PKCE.createVerifier().length() >= 43);
+        assertTrue(PKCE.createVerifier().length() <= 128);
     }
 }


### PR DESCRIPTION
Occasionally the CI/CD workflows will fail because the PKCE verifier is less than 43 characters (required by the spec). This can happen if the random number selected is too low, resulting in an encoded byte array that has too few characters.

This is fixed here by ensuring a minimum value for the BigInteger.

Effectively it changes the range from [0 - 2^256) to [2^256 - 2^257) so the generated byte array is always sufficiently long.

Imagine that the random number generator selects the number 250 -- this will be packed into a single octet and the entropy of the validator will be too low. This way, there will always be at least 32 octets.

