### PR TITLE
JCL-379: Use a retry handler for integration tests

### DIFF
--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -65,6 +65,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
           <systemPropertyVariables />
         </configuration>
       </plugin>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -69,6 +69,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
           <systemPropertyVariables />
         </configuration>
       </plugin>


### PR DESCRIPTION
When performing integration tests against live servers, there are occasional failures that are outside the control of the test code. This adds a small amount of resiliency so that transient errors are retried, but only in the integration tests.