### PR TITLE
JCL-337: End-to-end test of UMA auth for Access Grants endpoints

### DIFF
--- a/core/src/test/java/com/inrupt/client/core/MockHttpService.java
+++ b/core/src/test/java/com/inrupt/client/core/MockHttpService.java
@@ -133,7 +133,7 @@ class MockHttpService {
                     .withHeader("User-Agent", equalTo(USER_AGENT))
                     .withRequestBody(matching("Test String 1"))
                     .withHeader(CONTENT_TYPE, containing(TEXT_PLAIN))
-                    .withHeader("Authorization", containing("Bearer eyJ"))
+                    .withHeader("Authorization", containing("Bearer"))
                     .withHeader("DPoP", absent())
                     .willReturn(aResponse()
                         .withStatus(201)));

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -69,6 +69,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.inrupt.client</groupId>
+            <artifactId>inrupt-client-caffeine</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -85,7 +85,7 @@ public class AccessGrantScenarios {
 
     private static String podUrl;
     private static String issuer;
-    private static String webidUrl;
+    protected static String webidUrl;
     private static final String MOCK_USERNAME = "someuser";
 
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
@@ -93,27 +93,27 @@ public class AccessGrantScenarios {
     private static final String AUTH_METHOD = config
         .getOptionalValue("inrupt.test.auth-method", String.class)
         .orElse("client_secret_basic");
-    private static String VC_PROVIDER;
+    protected static String VC_PROVIDER;
     private static final String PRIVATE_RESOURCE_PATH = config
         .getOptionalValue("inrupt.test.private-resource-path", String.class)
         .orElse("private");
 
     private static final URI ACCESS_GRANT = URI.create("http://www.w3.org/ns/solid/vc#SolidAccessGrant");
     private static final URI ACCESS_REQUEST = URI.create("http://www.w3.org/ns/solid/vc#SolidAccessRequest");
-    private static final String GRANT_MODE_READ = "Read";
+    protected static final String GRANT_MODE_READ = "Read";
     private static final String GRANT_MODE_APPEND = "Append";
     private static final String GRANT_MODE_WRITE = "Write";
     private static final URI PURPOSE1 = URI.create("https://purpose.example/212efdf4-e1a4-4dcd-9d3b-d6eb92e0205f");
     private static final URI PURPOSE2 = URI.create("https://purpose.example/de605b08-76c7-4f04-9cec-a438810b0c03");
-    private static final Set<URI> PURPOSES = new HashSet<>(Arrays.asList(PURPOSE1, PURPOSE2));
-    private static final String GRANT_EXPIRATION = "2024-04-03T12:00:00Z";
+    protected static final Set<URI> PURPOSES = new HashSet<>(Arrays.asList(PURPOSE1, PURPOSE2));
+    protected static final String GRANT_EXPIRATION = "2024-04-03T12:00:00Z";
 
     private static URI testContainerURI;
     private static String testRDFresourceName = "resource.ttl";
     private static URI testRDFresourceURI;
     private static String sharedTextFileName = "sharedFile.txt";
     private static String sharedResourceName = "sharedResource";
-    private static URI sharedTextFileURI;
+    protected static URI sharedTextFileURI;
     private static URI sharedResource;
     private static Session session;
 
@@ -182,7 +182,12 @@ public class AccessGrantScenarios {
             prepareACPofResource(authClient, sharedTextFileURI);
         }
 
-        accessGrantServer = new MockAccessGrantServer(State.WEBID, sharedTextFileURI, sharedResource);
+        accessGrantServer = new MockAccessGrantServer(
+                State.WEBID,
+                sharedTextFileURI,
+                sharedResource,
+                authServer.getMockServerUrl()
+        );
         accessGrantServer.start();
 
         VC_PROVIDER = config

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -72,7 +72,7 @@ public class AuthenticationScenarios {
 
     private static String testResourceName = "resource.ttl";
     private static URI publicResourceURL;
-    private static URI privateResourceURL;
+    protected static URI privateResourceURL;
     private static final Config config = ConfigProvider.getConfig();
 
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
@@ -57,7 +57,9 @@ class MockUMAAuthorizationServer {
                     .willReturn(aResponse()
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
-                        .withBody("{\"access_token\":\"token-67890\",\"token_type\":\"Bearer\"}")));
+                        .withBody(
+                                "{\"access_token\":\"token-67890\",\"token_type\":\"Bearer\",\"expires_in\":\"3600\"}"
+                        )));
     }
 
     public void start() {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -41,16 +41,16 @@ import org.jose4j.jwk.PublicJsonWebKey;
 import org.jose4j.lang.JoseException;
 import org.jose4j.lang.UncheckedJoseException;
 
-final class Utils {
+public final class Utils {
 
     static final String ACCEPT = "Accept";
-    static final String CONTENT_TYPE = "Content-Type";
+    public static final String CONTENT_TYPE = "Content-Type";
     static final String IF_NONE_MATCH = "If-None-Match";
     static final String TEXT_TURTLE = "text/turtle";
     static final String SPARQL_UPDATE = "application/sparql-update";
     static final String APPLICATION_JSON = "application/json";
     static final String APPLICATION_FORM = "application/x-www-form-urlencoded";
-    static final String PLAIN_TEXT = "text/plain";
+    public static final String PLAIN_TEXT = "text/plain";
     static final String APPLICATION_OCTET = "application/octet-stream";
     static final String PATCH = "PATCH";
     static final String WILDCARD = "*";
@@ -62,7 +62,7 @@ final class Utils {
     static final int SUCCESS = 200;
     static final int CREATED = 201;
     static final int NO_CONTENT = 204;
-    static final int UNAUTHORIZED = 401;
+    public static final int UNAUTHORIZED = 401;
     static final int NOT_FOUND = 404;
     static final int NOT_ALLOWED = 405;
     static final int CONFLICT = 409;

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
@@ -40,7 +40,7 @@ class OpenIdAuthenticationScenariosTest extends AuthenticationScenarios {
 
     @ParameterizedTest
     @MethodSource("provideSessions")
-    void fetchPrivateResourceAuthenticatedTest(final Session session) {
+    void openIdAuthenticationTest(final Session session) {
         LOGGER.info("Integration Test - Authenticated fetch of private resource uses OpenID authenticator");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
@@ -30,7 +30,6 @@ import com.inrupt.client.solid.SolidSyncClient;
 
 import java.net.URI;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
@@ -41,9 +40,8 @@ class OpenIdAuthenticationScenariosTest extends AuthenticationScenarios {
 
     @ParameterizedTest
     @MethodSource("provideSessions")
-    @DisplayName(":authenticatedPrivateNode Authenticated fetch of private resource succeeds")
     void fetchPrivateResourceAuthenticatedTest(final Session session) {
-        LOGGER.info("Integration Test - Authenticated fetch of private resource");
+        LOGGER.info("Integration Test - Authenticated fetch of private resource uses OpenID authenticator");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
         try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null)) {
@@ -58,8 +56,8 @@ class OpenIdAuthenticationScenariosTest extends AuthenticationScenarios {
                     URI.create("http://openid.net/specs/openid-connect-core-1_0.html#IDToken"),
                     null
             );
-            // If UMA authentication was successful, the token issuer will be the UMA server, while the credential (i.e. the
-            // ID Token) is issued by the OpenID provider.
+            // If OpenID authentication was successful, both the token and the credential (i.e. the ID Token) are issued
+            // by the OpenID provider.
             assertEquals(token.get().getIssuer(), credential.get().getIssuer());
 
             assertDoesNotThrow(() -> authClient.delete(testResource));

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
@@ -32,7 +32,6 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
@@ -20,8 +20,55 @@
  */
 package com.inrupt.client.integration.uma;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.Request;
+import com.inrupt.client.accessgrant.AccessGrantClient;
+import com.inrupt.client.auth.Session;
 import com.inrupt.client.integration.base.AccessGrantScenarios;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class UmaAccessGrantScenarioTest extends AccessGrantScenarios {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(UmaAccessGrantScenarioTest.class);
+
+    @ParameterizedTest
+    @MethodSource("provideSessions")
+    void accessGrantIssuanceLifecycleTest(final Session session) {
+        LOGGER.info("Integration Test - UMA Authentication to VC endpoint");
+
+        final AccessGrantClient accessGrantClient = new AccessGrantClient(
+                URI.create(AccessGrantScenarios.VC_PROVIDER)
+        ).session(session);
+
+        // Make an authenticated request to the VC provider /issue endpoint to enforce a token is cached by the session.
+        accessGrantClient.requestAccess(URI.create(webidUrl),
+                        new HashSet<>(Arrays.asList(sharedTextFileURI)),
+                        new HashSet<>(Arrays.asList(GRANT_MODE_READ)),
+                        PURPOSES,
+                        Instant.parse(GRANT_EXPIRATION))
+                .toCompletableFuture().join();
+        // Lookup the session cache.
+        final Request dummyRequest = Request.newBuilder(
+            URI.create(AccessGrantScenarios.VC_PROVIDER).resolve("/issue")
+        ).POST(Request.BodyPublishers.ofString("Not relevant")).build();
+        final var token = session.fromCache(dummyRequest);
+        final var credential = session.getCredential(
+                URI.create("http://openid.net/specs/openid-connect-core-1_0.html#IDToken"),
+                null
+        );
+        // If UMA authentication was successful, the token issuer will be the UMA server, while the credential (i.e. the
+        // ID Token) is issued by the OpenID provider.
+        assertNotEquals(token.get().getIssuer(), credential.get().getIssuer());
+    }
 }

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
@@ -43,7 +43,7 @@ public class UmaAccessGrantScenarioTest extends AccessGrantScenarios {
 
     @ParameterizedTest
     @MethodSource("provideSessions")
-    void accessGrantIssuanceLifecycleTest(final Session session) {
+    void accessGrantUmaAuthentication(final Session session) {
         LOGGER.info("Integration Test - UMA Authentication to VC endpoint");
 
         final AccessGrantClient accessGrantClient = new AccessGrantClient(

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -222,10 +222,12 @@ public final class OpenIdSession implements Session {
 
     @Override
     public Optional<Credential> fromCache(final Request request) {
-        final Credential c = credential.get();
-        if (!hasExpired(c) && request != null && requestCache.get(cacheKey(request.uri())) != null) {
-            LOGGER.debug("Using cached token for request: {}", request.uri());
-            return Optional.of(requestCache.get(cacheKey(request.uri())));
+        if (request != null) {
+            final Credential cachedCredential = requestCache.get(cacheKey(request.uri()));
+            if(!hasExpired(cachedCredential)) {
+                LOGGER.debug("Using cached token for request: {}", request.uri());
+                return Optional.of(cachedCredential);
+            }
         }
         return Optional.empty();
     }

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -223,10 +223,10 @@ public final class OpenIdSession implements Session {
     @Override
     public Optional<Credential> fromCache(final Request request) {
         if (request != null) {
-            final Credential cachedCredential = requestCache.get(cacheKey(request.uri()));
-            if(!hasExpired(cachedCredential)) {
+            final Credential cachedToken = requestCache.get(cacheKey(request.uri()));
+            if(!hasExpired(cachedToken)) {
                 LOGGER.debug("Using cached token for request: {}", request.uri());
-                return Optional.of(cachedCredential);
+                return Optional.of(cachedToken);
             }
         }
         return Optional.empty();
@@ -244,7 +244,8 @@ public final class OpenIdSession implements Session {
         return auth.authenticate(this, request, algorithms)
                 .thenApply(credential -> {
                     if (credential != null) {
-                        requestCache.put(request.uri(), credential);
+                        LOGGER.debug("Setting cache entry for request: {}", request.uri());
+                        requestCache.put(cacheKey(request.uri()), credential);
                     }
                     return Optional.ofNullable(credential);
                 });
@@ -257,7 +258,7 @@ public final class OpenIdSession implements Session {
         final Optional<Credential> cred = getCredential(ID_TOKEN, null);
         if (cred.isPresent() && request != null) {
             LOGGER.debug("Setting cache entry for request: {}", request.uri());
-            requestCache.put(request.uri(), cred.get());
+            requestCache.put(cacheKey(request.uri()), cred.get());
         }
         return CompletableFuture.completedFuture(cred);
     }

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -224,7 +224,7 @@ public final class OpenIdSession implements Session {
     public Optional<Credential> fromCache(final Request request) {
         if (request != null) {
             final Credential cachedToken = requestCache.get(cacheKey(request.uri()));
-            if(!hasExpired(cachedToken)) {
+            if (!hasExpired(cachedToken)) {
                 LOGGER.debug("Using cached token for request: {}", request.uri());
                 return Optional.of(cachedToken);
             }


### PR DESCRIPTION
This adds tests to verify that the expected authentication mechanism (UMA or OpenId) gets used when accessing the Access Grants endpoints (e.g. `/issue`)