### PR TITLE
JCL-337: Use verify endpoint in tests

### DIFF
--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -290,13 +290,6 @@ public class AccessGrantScenarios {
         assertTrue(grantVerification.getChecks().size() > 0);
         assertEquals(revokedGrantVerification.getErrors().size(), 1);
         assertEquals(grantVerification.getWarnings().size(), 0);
-
-        accessSession.reset();
-        // Once revoked, the Access Grant should no longer grant access to the resource.
-        assertThrows(
-                UnauthorizedException.class,
-                () -> authClient.send(reqReadAgain, Response.BodyHandlers.discarding())
-        );
     }
 
     @ParameterizedTest

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -252,6 +252,10 @@ public class AccessGrantScenarios {
             .toCompletableFuture().join();
 
         //2. call verify endpoint to verify grant
+        final var grantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(grantVerification.getErrors().size(), 0);
+        assertEquals(grantVerification.getWarnings().size(), 0);
 
         final AccessGrant grantFromVcProvider = accessGrantClient.fetch(grant.getIdentifier(), AccessGrant.class)
             .toCompletableFuture().join();
@@ -282,6 +286,17 @@ public class AccessGrantScenarios {
         assertDoesNotThrow(accessGrantClient.revoke(grant).toCompletableFuture()::join);
 
         //6. call verify endpoint to check the grant is not valid
+        final var revokedGrantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(revokedGrantVerification.getErrors().size(), 1);
+        assertEquals(grantVerification.getWarnings().size(), 0);
+
+        accessSession.reset();
+        // Once revoked, the Access Grant should no longer grant access to the resource.
+        assertThrows(
+                UnauthorizedException.class,
+                () -> authClient.send(reqReadAgain, Response.BodyHandlers.discarding())
+        );
     }
 
     @ParameterizedTest
@@ -303,6 +318,10 @@ public class AccessGrantScenarios {
             .toCompletableFuture().join();
 
         //2. call verify endpoint to verify grant
+        final var grantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(grantVerification.getErrors().size(), 0);
+        assertEquals(grantVerification.getWarnings().size(), 0);
     }
 
     @ParameterizedTest
@@ -323,7 +342,15 @@ public class AccessGrantScenarios {
         final AccessGrant grant = accessGrantClient.grantAccess(request)
             .toCompletableFuture().join();
         //Steps
+
         //1. call verify endpoint to verify grant
+        final var grantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(grantVerification.getErrors().size(), 0);
+        assertEquals(grantVerification.getWarnings().size(), 0);
+
+        //2. use the grant to access the target container.
+        //3. try using the grant to access a child resource.
     }
 
     // Query access grant related tests

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
@@ -31,7 +31,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.apache.commons.io.IOUtils;
 
@@ -176,9 +177,9 @@ class MockAccessGrantServer {
                 .withHeader(HEADER_AUTHORIZATION, containing(SCHEME_BEARER))
                 .willReturn(jsonResponse(
                         new AccessCredentialVerification(
-                                List.of("issuanceDate", "proof", "expirationDate", "credentialStatus"),
-                                List.of(),
-                                List.of()),
+                                Arrays.asList("issuanceDate", "proof", "expirationDate", "credentialStatus"),
+                                Collections.emptyList(),
+                                Collections.emptyList()),
                         200)
                 ));
 
@@ -190,9 +191,9 @@ class MockAccessGrantServer {
                 .withRequestBody(containing("providedConsent"))
                 .willReturn(jsonResponse(
                         new AccessCredentialVerification(
-                                List.of("issuanceDate", "proof", "expirationDate", "credentialStatus"),
-                                List.of(),
-                                List.of("credentialStatus validation has failed: credential has been revoked")),
+                                Arrays.asList("issuanceDate", "proof", "expirationDate", "credentialStatus"),
+                                Collections.emptyList(),
+                                Arrays.asList("credentialStatus validation has failed: credential has been revoked")),
                         200)
                 )
         );


### PR DESCRIPTION
Call verify to check the validity of the issued grant, and the invalidity of the revoked grant.