### PR TITLE
Test authentication fails with revoked grant

### DIFF
--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -248,6 +248,10 @@ public class AccessGrantScenarios {
             .toCompletableFuture().join();
 
         //2. call verify endpoint to verify grant
+        final var grantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(grantVerification.getErrors().size(), 0);
+        assertEquals(grantVerification.getWarnings().size(), 0);
 
         final AccessGrant grantFromVcProvider = accessGrantClient.fetch(grant.getIdentifier(), AccessGrant.class)
             .toCompletableFuture().join();
@@ -278,6 +282,17 @@ public class AccessGrantScenarios {
         assertDoesNotThrow(accessGrantClient.revoke(grant).toCompletableFuture()::join);
 
         //6. call verify endpoint to check the grant is not valid
+        final var revokedGrantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(revokedGrantVerification.getErrors().size(), 1);
+        assertEquals(grantVerification.getWarnings().size(), 0);
+
+        accessSession.reset();
+        // Once revoked, the Access Grant should no longer grant access to the resource.
+        assertThrows(
+                UnauthorizedException.class,
+                () -> authClient.send(reqReadAgain, Response.BodyHandlers.discarding())
+        );
     }
 
     @ParameterizedTest
@@ -297,6 +312,10 @@ public class AccessGrantScenarios {
             .toCompletableFuture().join();
 
         //2. call verify endpoint to verify grant
+        final var grantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(grantVerification.getErrors().size(), 0);
+        assertEquals(grantVerification.getWarnings().size(), 0);
     }
 
     @ParameterizedTest
@@ -315,7 +334,15 @@ public class AccessGrantScenarios {
         final AccessGrant grant = accessGrantClient.grantAccess(request)
             .toCompletableFuture().join();
         //Steps
+
         //1. call verify endpoint to verify grant
+        final var grantVerification = accessGrantClient.verify(grant).toCompletableFuture().join();
+        assertTrue(grantVerification.getChecks().size() > 0);
+        assertEquals(grantVerification.getErrors().size(), 0);
+        assertEquals(grantVerification.getWarnings().size(), 0);
+
+        //2. use the grant to access the target container.
+        //3. try using the grant to access a child resource.
     }
 
     // Query access grant related tests

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -286,6 +286,14 @@ public class AccessGrantScenarios {
         assertTrue(grantVerification.getChecks().size() > 0);
         assertEquals(revokedGrantVerification.getErrors().size(), 1);
         assertEquals(grantVerification.getWarnings().size(), 0);
+
+        // Once revoked, the Access Grant should no longer grant access to the resource. The previously issued access
+        // token may still be valid, so cache is cleared for the test.
+        accessSession.reset();
+        assertThrows(
+                UnauthorizedException.class,
+                () -> authClient.send(reqReadAgain, Response.BodyHandlers.discarding())
+        );
     }
 
     @ParameterizedTest

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -286,13 +286,6 @@ public class AccessGrantScenarios {
         assertTrue(grantVerification.getChecks().size() > 0);
         assertEquals(revokedGrantVerification.getErrors().size(), 1);
         assertEquals(grantVerification.getWarnings().size(), 0);
-
-        accessSession.reset();
-        // Once revoked, the Access Grant should no longer grant access to the resource.
-        assertThrows(
-                UnauthorizedException.class,
-                () -> authClient.send(reqReadAgain, Response.BodyHandlers.discarding())
-        );
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This test that fetching with a revoked grant fails.

This currently fails, because the agent running the test has access without requiring the access grant.