### PR TITLE
JCL-382: Additional tests for the query builder feature

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
@@ -36,7 +36,6 @@ public class AccessCredentialQuery<T extends AccessCredential> {
     private static final URI SOLID_ACCESS_REQUEST = URI.create("SolidAccessRequest");
     private static final URI SOLID_ACCESS_DENIAL = URI.create("SolidAccessDenial");
 
-    private final URI type;
     private final Set<URI> purposes;
     private final Set<String> modes;
     private final URI resource;
@@ -57,31 +56,11 @@ public class AccessCredentialQuery<T extends AccessCredential> {
     AccessCredentialQuery(final URI resource, final URI creator, final URI recipient,
             final Set<URI> purposes, final Set<String> modes, final Class<T> clazz) {
         this.clazz = Objects.requireNonNull(clazz, "The clazz parameter must not be null!");
-
-        if (AccessGrant.class.isAssignableFrom(clazz)) {
-            this.type = SOLID_ACCESS_GRANT;
-        } else if (AccessRequest.class.isAssignableFrom(clazz)) {
-            this.type = SOLID_ACCESS_REQUEST;
-        } else if (AccessDenial.class.isAssignableFrom(clazz)) {
-            this.type = SOLID_ACCESS_DENIAL;
-        } else {
-            throw new AccessGrantException("Unsupported type " + clazz + " in query request");
-        }
-
         this.resource = resource;
         this.creator = creator;
         this.recipient = recipient;
         this.purposes = purposes;
         this.modes = modes;
-    }
-
-    /**
-     * Get the access credential type value.
-     *
-     * @return the type, never {@code null}
-     */
-    public URI getType() {
-        return type;
     }
 
     /**

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
@@ -277,6 +277,19 @@ class MockAccessGrantServer {
         wireMockServer.stubFor(post(urlEqualTo("/derive"))
                     .atPriority(1)
                     .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                    .withRequestBody(containing("SolidAccessGrant"))
+                    .withRequestBody(containing("\"https://id.example/Purpose8\""))
+                    .withRequestBody(containing("\"https://id.example/Purpose9\""))
+                    .withRequestBody(containing("\"Read\""))
+                    .withRequestBody(containing("\"Write\""))
+                    .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResource("/query_response7.json", wireMockServer.baseUrl()))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/derive"))
+                    .atPriority(1)
+                    .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
                     .withRequestBody(containing("SolidAccessDenial"))
                     .withRequestBody(containing(
                             "\"https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/\""))

--- a/access-grant/src/test/resources/query_response7.json
+++ b/access-grant/src/test/resources/query_response7.json
@@ -1,0 +1,33 @@
+{
+  "verifiableCredential": [{
+    "@context":[
+        "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/suites/ed25519-2020/v1",
+        "https://w3id.org/vc-revocation-list-2020/v1",
+        "https://schema.inrupt.com/credentials/v1.jsonld"],
+    "id":"{{baseUrl}}/access-grant-1",
+    "type":["VerifiableCredential","SolidAccessGrant"],
+    "issuer":"{{baseUrl}}",
+    "expirationDate":"2022-08-27T12:00:00Z",
+    "issuanceDate":"2022-08-25T20:34:05.153Z",
+    "credentialStatus":{
+        "id":"https://accessgrant.example/status/CVAM#2832",
+        "revocationListCredential":"https://accessgrant.example/status/CVAM",
+        "revocationListIndex":"2832",
+        "type":"RevocationList2020Status"},
+    "credentialSubject":{
+        "id":"https://id.example/grantor",
+        "providedConsent":{
+            "mode":["Read","Write"],
+            "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
+            "isProvidedTo":"https://id.example/grantee",
+            "forPurpose":["https://purpose.example/Purpose8","https://purpose.example/Purpose9"],
+            "forPersonalData":["https://storage.example/ef9c4b90-0459-408d-bfa9-1c61d46e1eaf/"]}},
+    "proof":{
+        "created":"2022-08-25T20:34:05.236Z",
+        "proofPurpose":"assertionMethod",
+        "proofValue":"nIeQF44XVik7onnAbdkbp8xxJ2C8JoTw6-VtCkAzxuWYRFsSfYpft5MuAJaivyeKDmaK82Lj_YsME2xgL2WIBQ",
+        "type":"Ed25519Signature2020",
+        "verificationMethod":"https://accessgrant.example/key/1e332728-4af5-46e4-a5db-4f7b89e3f378"}
+  }]
+}


### PR DESCRIPTION
This adds an additional set of tests for the query builder (with multiple `mode` and `purpose` values).

When evaluating the coverage, it turns out that the `AccessCredentialQuery::getType` method was completely unused, so that has been removed from the API along with the corresponding test