### PR TITLE
JCL-377: distinguish between creator and recipient

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -177,19 +177,20 @@ public class AccessGrantClient {
     /**
      * Issue an access request.
      *
-     * @param agent the agent to whom the access request is made; i.e., the agent controlling access to the resources
+     * @param recipient the agent to whom the access request is made;
+     *                  i.e., the agent controlling access to the resources
      * @param resources the resources to which this credential applies
      * @param modes the access modes for this credential
      * @param purposes the purposes of this credential
      * @param expiration the expiration time of this credential
      * @return the next stage of completion containing the resulting access request
      */
-    public CompletionStage<AccessRequest> requestAccess(final URI agent, final Set<URI> resources,
+    public CompletionStage<AccessRequest> requestAccess(final URI recipient, final Set<URI> resources,
             final Set<String> modes, final Set<URI> purposes, final Instant expiration) {
         Objects.requireNonNull(resources, "Resources may not be null!");
         Objects.requireNonNull(modes, "Access modes may not be null!");
         return v1Metadata().thenCompose(metadata -> {
-            final Map<String, Object> data = buildAccessRequestv1(agent, resources, modes, expiration, purposes);
+            final Map<String, Object> data = buildAccessRequestv1(recipient, resources, modes, expiration, purposes);
 
             final Request req = Request.newBuilder(metadata.issueEndpoint)
                 .header(CONTENT_TYPE, APPLICATION_JSON)
@@ -280,7 +281,7 @@ public class AccessGrantClient {
      * Issue an access grant or request.
      *
      * @param type the credential type
-     * @param agent the receiving agent for this credential
+     * @param recipient the receiving agent for this credential
      * @param resources the resources to which this credential applies
      * @param modes the access modes for this credential
      * @param purposes the purposes of this credential
@@ -289,7 +290,7 @@ public class AccessGrantClient {
      * @deprecated as of Beta3, please use the {@link #requestAccess} or {@link #grantAccess} methods
      */
     @Deprecated
-    public CompletionStage<AccessGrant> issue(final URI type, final URI agent, final Set<URI> resources,
+    public CompletionStage<AccessGrant> issue(final URI type, final URI recipient, final Set<URI> resources,
             final Set<String> modes, final Set<String> purposes, final Instant expiration) {
         Objects.requireNonNull(type, "Access Grant type may not be null!");
         Objects.requireNonNull(resources, "Resources may not be null!");
@@ -305,9 +306,9 @@ public class AccessGrantClient {
         return v1Metadata().thenCompose(metadata -> {
             final Map<String, Object> data;
             if (FQ_ACCESS_GRANT.equals(type)) {
-                data = buildAccessGrantv1(agent, resources, modes, expiration, uriPurposes);
+                data = buildAccessGrantv1(recipient, resources, modes, expiration, uriPurposes);
             } else if (FQ_ACCESS_REQUEST.equals(type)) {
-                data = buildAccessRequestv1(agent, resources, modes, expiration, uriPurposes);
+                data = buildAccessRequestv1(recipient, resources, modes, expiration, uriPurposes);
             } else {
                 throw new AccessGrantException("Unsupported grant type: " + type);
             }

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -274,10 +274,10 @@ class AccessGrantClientTest {
 
         assertInstanceOf(AccessGrantException.class, err1.getCause());
 
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
 
         final CompletionException err2 = assertThrows(CompletionException.class,
-                agClient.issue(ACCESS_GRANT, agent, Collections.emptySet(), Collections.emptySet(),
+                agClient.issue(ACCESS_GRANT, recipient, Collections.emptySet(), Collections.emptySet(),
                     Collections.emptySet(), Instant.now()).toCompletableFuture()::join);
         assertInstanceOf(AccessGrantException.class, err2.getCause());
     }
@@ -292,18 +292,18 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
-        final AccessGrant grant = client.issue(ACCESS_GRANT, agent, resources, modes, purposes, expiration)
+        final AccessGrant grant = client.issue(ACCESS_GRANT, recipient, resources, modes, purposes, expiration)
             .toCompletableFuture().join();
 
         assertTrue(grant.getTypes().contains("SolidAccessGrant"));
-        assertEquals(Optional.of(agent), grant.getGrantee());
-        assertEquals(Optional.of(agent), grant.getRecipient());
+        assertEquals(Optional.of(recipient), grant.getGrantee());
+        assertEquals(Optional.of(recipient), grant.getRecipient());
         assertEquals(modes, grant.getModes());
         assertEquals(expiration, grant.getExpiration());
         assertEquals(baseUri, grant.getIssuer());
@@ -322,17 +322,17 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
-        final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)
+        final AccessRequest request = client.requestAccess(recipient, resources, modes, purposes, expiration)
             .toCompletableFuture().join();
 
         assertTrue(request.getTypes().contains("SolidAccessRequest"));
-        assertEquals(Optional.of(agent), request.getRecipient());
+        assertEquals(Optional.of(recipient), request.getRecipient());
         assertEquals(modes, request.getModes());
         assertEquals(expiration, request.getExpiration());
         assertEquals(baseUri, request.getIssuer());
@@ -342,14 +342,14 @@ class AccessGrantClientTest {
 
     @Test
     void testRequestAccessNoAuth() {
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
 
-        final CompletableFuture<AccessRequest> future = agClient.requestAccess(agent, resources, modes, purposes,
+        final CompletableFuture<AccessRequest> future = agClient.requestAccess(recipient, resources, modes, purposes,
                 expiration).toCompletableFuture();
         final CompletionException err = assertThrows(CompletionException.class, future::join);
         assertInstanceOf(AccessGrantException.class, err.getCause());
@@ -365,19 +365,19 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
-        final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)
+        final AccessRequest request = client.requestAccess(recipient, resources, modes, purposes, expiration)
             .toCompletableFuture().join();
 
         final AccessGrant grant = client.grantAccess(request).toCompletableFuture().join();
 
         assertTrue(grant.getTypes().contains("SolidAccessGrant"));
-        assertEquals(Optional.of(agent), grant.getRecipient());
+        assertEquals(Optional.of(recipient), grant.getRecipient());
         assertEquals(modes, grant.getModes());
         assertEquals(expiration, grant.getExpiration());
         assertEquals(baseUri, grant.getIssuer());
@@ -395,19 +395,19 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-09-12T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
-        final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)
+        final AccessRequest request = client.requestAccess(recipient, resources, modes, purposes, expiration)
             .toCompletableFuture().join();
 
         final AccessDenial denial = client.denyAccess(request).toCompletableFuture().join();
 
         assertTrue(denial.getTypes().contains("SolidAccessDenial"));
-        assertEquals(Optional.of(agent), denial.getRecipient());
+        assertEquals(Optional.of(recipient), denial.getRecipient());
         assertEquals(modes, denial.getModes());
         assertEquals(expiration, denial.getExpiration());
         assertEquals(baseUri, denial.getIssuer());
@@ -430,13 +430,13 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<URI> purposes = Collections.singleton(URI.create("https://purpose.test/Purpose1"));
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
-        final AccessRequest request = client.requestAccess(agent, resources, modes, purposes, expiration)
+        final AccessRequest request = client.requestAccess(recipient, resources, modes, purposes, expiration)
             .toCompletableFuture().join();
 
         final CompletableFuture<AccessGrant> future = agClient.grantAccess(request).toCompletableFuture();
@@ -446,14 +446,14 @@ class AccessGrantClientTest {
 
     @Test
     void testIssueNoAuth() {
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
 
-        final CompletableFuture<AccessGrant> future = agClient.issue(ACCESS_GRANT, agent, resources, modes,
+        final CompletableFuture<AccessGrant> future = agClient.issue(ACCESS_GRANT, recipient, resources, modes,
                 purposes, expiration).toCompletableFuture();
         final CompletionException err = assertThrows(CompletionException.class, future::join);
         assertInstanceOf(AccessGrantException.class, err.getCause());
@@ -469,14 +469,14 @@ class AccessGrantClientTest {
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
 
-        final URI agent = URI.create("https://id.test/agent");
+        final URI recipient = URI.create("https://id.test/agent");
         final Instant expiration = Instant.parse("2022-08-27T12:00:00Z");
         final Set<String> modes = new HashSet<>(Arrays.asList("Read", "Append"));
         final Set<String> purposes = Collections.singleton("https://purpose.test/Purpose1");
 
         final Set<URI> resources = Collections.singleton(URI.create("https://storage.test/data/"));
         final URI type = URI.create("https://vc.test/Type");
-        final CompletableFuture<AccessGrant> future = client.issue(type, agent, resources,
+        final CompletableFuture<AccessGrant> future = client.issue(type, recipient, resources,
                 modes, purposes, expiration).toCompletableFuture();
         final CompletionException err = assertThrows(CompletionException.class, future::join);
         assertInstanceOf(AccessGrantException.class, err.getCause());
@@ -605,7 +605,7 @@ class AccessGrantClientTest {
     }
 
     @Test
-    void testQueryRequestAgent() {
+    void testQueryRequestRecipient() {
         final Map<String, Object> claims = new HashMap<>();
         claims.put("webid", WEBID);
         claims.put("sub", SUB);
@@ -620,7 +620,7 @@ class AccessGrantClientTest {
     }
 
     @Test
-    void testQueryRequestAgentBuilder() {
+    void testQueryRequestRecipientBuilder() {
         final Map<String, Object> claims = new HashMap<>();
         claims.put("webid", WEBID);
         claims.put("sub", SUB);
@@ -715,6 +715,7 @@ class AccessGrantClientTest {
         assertThrows(AccessGrantException.class, () ->
                 client.query(uri, null, null, null, "Read", AccessCredential.class));
     }
+
 
     @Test
     void testQueryInvalidAuth() {

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -532,7 +532,7 @@ class AccessGrantClientTest {
     }
 
     @Test
-    void testQueryGrantAgent() {
+    void testQueryGrantRecipient() {
         final Map<String, Object> claims = new HashMap<>();
         claims.put("webid", WEBID);
         claims.put("sub", SUB);
@@ -547,7 +547,7 @@ class AccessGrantClientTest {
     }
 
     @Test
-    void testQueryGrantAgentBuilder() {
+    void testQueryGrantCreator() {
         final Map<String, Object> claims = new HashMap<>();
         claims.put("webid", WEBID);
         claims.put("sub", SUB);
@@ -555,10 +555,10 @@ class AccessGrantClientTest {
         claims.put("azp", AZP);
         final String token = generateIdToken(claims);
         final AccessGrantClient client = agClient.session(OpenIdSession.ofIdToken(token));
-
-        final AccessCredentialQuery<AccessGrant> query = AccessCredentialQuery.newBuilder()
-            .recipient(URI.create("https://id.test/user")).mode("Read").build(AccessGrant.class);
-        final List<AccessGrant> grants = client.query(query).toCompletableFuture().join();
+        // A query is always done with the agent making the query as the creator.
+        final List<AccessGrant> grants = client.query(
+                null, URI.create("https://id.test/user"), null, null, "Read", AccessGrant.class
+        ).toCompletableFuture().join();
         assertEquals(1, grants.size());
     }
 

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
@@ -339,6 +339,15 @@ class MockAccessGrantServer {
                         .withBody(getResource("/query_response5.json", wireMockServer.baseUrl()))));
 
         wireMockServer.stubFor(post(urlEqualTo("/derive"))
+                .atPriority(2)
+                .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
+                .withRequestBody(containing("\"id\":\"https://id.test/user\""))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResource("/query_response4.json", wireMockServer.baseUrl()))));
+
+        wireMockServer.stubFor(post(urlEqualTo("/derive"))
                     .atPriority(2)
                     .withHeader("Authorization", containing("Bearer eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9."))
                     .withRequestBody(containing("\"https://storage.example/"))


### PR DESCRIPTION
We recently introduced a clarification separating a credential's creator to its recipient. This is a follow-up from this change, ensuring that occurences of the more generic term "agent" are specialized in either "creator" or "recipient", either in API docs, method signatures, or variable names.