### PR TITLE
JCL-371: Fix JSON-B config

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -195,6 +195,36 @@
               </classpathDependencyExcludes>
             </configuration>
           </execution>
+          <execution>
+            <id>httpclient-jsonb-caffeine-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <rerunFailingTestsCount>2</rerunFailingTestsCount>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-okhttp</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-jackson</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-guava</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>httpclient-jsonb-guava-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <rerunFailingTestsCount>2</rerunFailingTestsCount>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-okhttp</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-jackson</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-caffeine</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
This re-enables the surefire execution configurations disabled in https://github.com/inrupt/solid-client-java/pull/483/commits/d90f442745c35dfe21870f5281b3accafe45c966 relating to the `access-grants` module. Having the tests run required two changes:
- Making a POJO class used for JSON mapping public
- Preventing the JSONB instance to be shared. In some cases, such as queries, where the mocks would serve the same resource several times in parallel, it resulted in parsing errors that appeared to be related to the JSONB shared instance not being thread-safe.