### PR TITLE
JCL-390: deprecated AccessGrantClient delete method

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -544,7 +544,10 @@ public class AccessGrantClient {
      *
      * @param credential the access credential
      * @return the next stage of completion
+     * @deprecated as of Beta4
      */
+
+    @Deprecated
     public CompletionStage<Void> delete(final AccessCredential credential) {
         final Request req = Request.newBuilder(credential.getIdentifier()).DELETE().build();
         return client.send(req, Response.BodyHandlers.discarding())


### PR DESCRIPTION
In the current VC service, one cannot delete a grant or a request.