### PR TITLE
JCL-389: removed copyright year from all headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2023 Inrupt, Inc.
+Copyright Inrupt, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialVerification.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialVerification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessDenial.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantConfiguration.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantException.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantUtils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/Metadata.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/Status.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/Status.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/package-info.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantConfigurationTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantExceptionTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTestUtils.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessGrantTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/MockAccessGrantServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/ByteBufferPublisher.java
+++ b/api/src/main/java/com/inrupt/client/ByteBufferPublisher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/Client.java
+++ b/api/src/main/java/com/inrupt/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/ClientCache.java
+++ b/api/src/main/java/com/inrupt/client/ClientCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/ClientProvider.java
+++ b/api/src/main/java/com/inrupt/client/ClientProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/Headers.java
+++ b/api/src/main/java/com/inrupt/client/Headers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/InruptClientException.java
+++ b/api/src/main/java/com/inrupt/client/InruptClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/NonRDFSource.java
+++ b/api/src/main/java/com/inrupt/client/NonRDFSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/RDFSource.java
+++ b/api/src/main/java/com/inrupt/client/RDFSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/Request.java
+++ b/api/src/main/java/com/inrupt/client/Request.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/Resource.java
+++ b/api/src/main/java/com/inrupt/client/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/Response.java
+++ b/api/src/main/java/com/inrupt/client/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/ValidationResult.java
+++ b/api/src/main/java/com/inrupt/client/ValidationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/auth/Authenticator.java
+++ b/api/src/main/java/com/inrupt/client/auth/Authenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/auth/Challenge.java
+++ b/api/src/main/java/com/inrupt/client/auth/Challenge.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/auth/Credential.java
+++ b/api/src/main/java/com/inrupt/client/auth/Credential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/auth/DPoP.java
+++ b/api/src/main/java/com/inrupt/client/auth/DPoP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/auth/ReactiveAuthorization.java
+++ b/api/src/main/java/com/inrupt/client/auth/ReactiveAuthorization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/auth/Session.java
+++ b/api/src/main/java/com/inrupt/client/auth/Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/auth/package-info.java
+++ b/api/src/main/java/com/inrupt/client/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/package-info.java
+++ b/api/src/main/java/com/inrupt/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/AuthenticationProvider.java
+++ b/api/src/main/java/com/inrupt/client/spi/AuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/CacheBuilderService.java
+++ b/api/src/main/java/com/inrupt/client/spi/CacheBuilderService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/ClientProviderResolver.java
+++ b/api/src/main/java/com/inrupt/client/spi/ClientProviderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/DpopService.java
+++ b/api/src/main/java/com/inrupt/client/spi/DpopService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/HeaderParser.java
+++ b/api/src/main/java/com/inrupt/client/spi/HeaderParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/HttpService.java
+++ b/api/src/main/java/com/inrupt/client/spi/HttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/JsonService.java
+++ b/api/src/main/java/com/inrupt/client/spi/JsonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/NoopCache.java
+++ b/api/src/main/java/com/inrupt/client/spi/NoopCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/RDFFactory.java
+++ b/api/src/main/java/com/inrupt/client/spi/RDFFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/RdfService.java
+++ b/api/src/main/java/com/inrupt/client/spi/RdfService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/ServiceProvider.java
+++ b/api/src/main/java/com/inrupt/client/spi/ServiceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/spi/package-info.java
+++ b/api/src/main/java/com/inrupt/client/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/util/IOUtils.java
+++ b/api/src/main/java/com/inrupt/client/util/IOUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/util/URIBuilder.java
+++ b/api/src/main/java/com/inrupt/client/util/URIBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/main/java/com/inrupt/client/util/package-info.java
+++ b/api/src/main/java/com/inrupt/client/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/test/java/com/inrupt/client/RDFSourceTest.java
+++ b/api/src/test/java/com/inrupt/client/RDFSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/test/java/com/inrupt/client/auth/BasicAuthProvider.java
+++ b/api/src/test/java/com/inrupt/client/auth/BasicAuthProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/test/java/com/inrupt/client/auth/ReactiveAuthorizationTest.java
+++ b/api/src/test/java/com/inrupt/client/auth/ReactiveAuthorizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/test/java/com/inrupt/client/spi/NoopCacheTest.java
+++ b/api/src/test/java/com/inrupt/client/spi/NoopCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/test/java/com/inrupt/client/util/IOUtilsTest.java
+++ b/api/src/test/java/com/inrupt/client/util/IOUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/api/src/test/java/com/inrupt/client/util/URIBuilderTest.java
+++ b/api/src/test/java/com/inrupt/client/util/URIBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/build-tools/license/HEADER.txt
+++ b/build-tools/license/HEADER.txt
@@ -1,4 +1,4 @@
-Copyright 2023 Inrupt Inc.
+Copyright Inrupt Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal in

--- a/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCache.java
+++ b/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCacheBuilder.java
+++ b/caffeine/src/main/java/com/inrupt/client/caffeine/CaffeineCacheBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/caffeine/src/test/java/com/inrupt/client/caffeine/CaffeineCacheTest.java
+++ b/caffeine/src/test/java/com/inrupt/client/caffeine/CaffeineCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/main/java/com/inrupt/client/core/AuthenticationException.java
+++ b/core/src/main/java/com/inrupt/client/core/AuthenticationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/main/java/com/inrupt/client/core/DefaultClient.java
+++ b/core/src/main/java/com/inrupt/client/core/DefaultClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/main/java/com/inrupt/client/core/DefaultClientProviderResolver.java
+++ b/core/src/main/java/com/inrupt/client/core/DefaultClientProviderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/main/java/com/inrupt/client/core/DefaultDpopService.java
+++ b/core/src/main/java/com/inrupt/client/core/DefaultDpopService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/main/java/com/inrupt/client/core/DefaultHeaderParser.java
+++ b/core/src/main/java/com/inrupt/client/core/DefaultHeaderParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/main/java/com/inrupt/client/core/package-info.java
+++ b/core/src/main/java/com/inrupt/client/core/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/test/java/com/inrupt/client/core/DPoPManagerTest.java
+++ b/core/src/test/java/com/inrupt/client/core/DPoPManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/test/java/com/inrupt/client/core/DefaultClientTest.java
+++ b/core/src/test/java/com/inrupt/client/core/DefaultClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/test/java/com/inrupt/client/core/LinkTest.java
+++ b/core/src/test/java/com/inrupt/client/core/LinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/test/java/com/inrupt/client/core/MockHttpService.java
+++ b/core/src/test/java/com/inrupt/client/core/MockHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/test/java/com/inrupt/client/core/WacAllowTest.java
+++ b/core/src/test/java/com/inrupt/client/core/WacAllowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/core/src/test/java/com/inrupt/client/core/WwwAuthenticateTest.java
+++ b/core/src/test/java/com/inrupt/client/core/WwwAuthenticateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/cli/src/main/java/com/inrupt/client/examples/cli/AppConfig.java
+++ b/examples/cli/src/main/java/com/inrupt/client/examples/cli/AppConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/cli/src/main/java/com/inrupt/client/examples/cli/SolidApp.java
+++ b/examples/cli/src/main/java/com/inrupt/client/examples/cli/SolidApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/cli/src/main/java/com/inrupt/client/examples/cli/package-info.java
+++ b/examples/cli/src/main/java/com/inrupt/client/examples/cli/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/Application.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/ApplicationStartController.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/ApplicationStartController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/AuthenticationException.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/AuthenticationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/AuthorizationException.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/AuthorizationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/SecurityConfiguration.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/SecurityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Book.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Book.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/BookLibrary.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/BookLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Vocabulary.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/Vocabulary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/WebIdOwner.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/model/WebIdOwner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/service/BookLibraryService.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/service/BookLibraryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/service/IBookLibraryService.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/service/IBookLibraryService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/service/UserService.java
+++ b/examples/springboot/src/main/java/com/inrupt/client/examples/springboot/service/UserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/SolidStorage.java
+++ b/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/SolidStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/package-info.java
+++ b/examples/webapp/src/main/java/com/inrupt/client/examples/webapp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/guava/src/main/java/com/inrupt/client/guava/GuavaCache.java
+++ b/guava/src/main/java/com/inrupt/client/guava/GuavaCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/guava/src/main/java/com/inrupt/client/guava/GuavaCacheBuilder.java
+++ b/guava/src/main/java/com/inrupt/client/guava/GuavaCacheBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/guava/src/test/java/com/inrupt/client/guava/GuavaCacheTest.java
+++ b/guava/src/test/java/com/inrupt/client/guava/GuavaCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientResponse.java
+++ b/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientResponseInfo.java
+++ b/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientResponseInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientService.java
+++ b/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/httpclient/src/main/java/com/inrupt/client/httpclient/package-info.java
+++ b/httpclient/src/main/java/com/inrupt/client/httpclient/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/httpclient/src/test/java/com/inrupt/client/httpclient/HttpclientServiceTest.java
+++ b/httpclient/src/test/java/com/inrupt/client/httpclient/HttpclientServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-import com.inrupt.client.Headers;
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.accessgrant.*;
@@ -36,7 +35,6 @@ import com.inrupt.client.solid.*;
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.vocabulary.ACL;
-import com.inrupt.client.vocabulary.LDP;
 import com.inrupt.client.webid.WebIdProfile;
 
 import java.io.ByteArrayInputStream;
@@ -116,11 +114,9 @@ public class AccessGrantScenarios {
     private static URI testRDFresourceURI;
     private static String sharedTextFileName = "sharedFile.txt";
     protected static URI sharedTextFileURI;
-    private static URI privateContainerURI;
+    private static URI sharedResource;
     private static Session requesterSession;
     private static Session resourceOwnerSession;
-
-    private static SolidSyncClient authResourceOwnerClient;
 
     @BeforeAll
     static void setup() throws IOException {
@@ -157,32 +153,34 @@ public class AccessGrantScenarios {
             podUrl += Utils.FOLDER_SEPARATOR;
         }
 
-
-        privateContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path(State.PRIVATE_RESOURCE_PATH + "/").build();
-
         testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path(State.PRIVATE_RESOURCE_PATH)
-                .path("accessgrant-test-" + UUID.randomUUID() + "/")
-                .build();
+            .path(State.PRIVATE_RESOURCE_PATH)
+            .path("accessgrant-test-" + UUID.randomUUID())
+            .build();
 
-        createAuthenticatedClient();
-        createContainer(testContainerURI);
-        prepareAcpOfResource(authResourceOwnerClient, testContainerURI, SolidRDFSource.class);
-
-        sharedTextFileURI = URIBuilder.newBuilder(testContainerURI)
-                .path(sharedTextFileName)
-                .build();
+        sharedTextFileURI = URIBuilder.newBuilder(URI.create(testContainerURI.toString()))
+            .path(sharedTextFileName)
+            .build();
+        sharedResource = URIBuilder.newBuilder(URI.create(testContainerURI.toString()))
+            .path(sharedTextFileName).build();
 
         testRDFresourceURI = URIBuilder.newBuilder(testContainerURI)
-                .path(testRDFresourceName)
-                .build();
+            .path(testRDFresourceName)
+            .build();
+
+        resourceOwnerSession = OpenIdSession.ofClientCredentials(
+            URI.create(issuer), //Client credentials
+            RESOURCE_OWNER_CLIENT_ID,
+            RESOURCE_OWNER_CLIENT_SECRET,
+            AUTH_METHOD);
 
         //create test file in test container
         try (final InputStream is = new ByteArrayInputStream(StandardCharsets.UTF_8.encode("Test text").array())) {
             final SolidNonRDFSource testResource = new SolidNonRDFSource(sharedTextFileURI, Utils.PLAIN_TEXT, is, null);
-            assertDoesNotThrow(() -> authResourceOwnerClient.create(testResource));
-            prepareAcpOfResource(authResourceOwnerClient, sharedTextFileURI, SolidNonRDFSource.class);
+            final SolidSyncClient authClient = client.session(resourceOwnerSession);
+            assertDoesNotThrow(() -> authClient.create(testResource));
+
+            prepareAcpOfResource(authClient, sharedTextFileURI, SolidNonRDFSource.class);
         }
 
         requesterWebidUrl = config
@@ -195,6 +193,7 @@ public class AccessGrantScenarios {
         accessGrantServer = new MockAccessGrantServer(
                 URI.create(requesterWebidUrl),
                 sharedTextFileURI,
+                sharedResource,
                 authServer.getMockServerUrl()
         );
         accessGrantServer.start();
@@ -211,16 +210,17 @@ public class AccessGrantScenarios {
     @AfterAll
     static void teardown() {
          //cleanup pod
-        authResourceOwnerClient.send(Request.newBuilder(sharedTextFileURI).DELETE().build(),
-                Response.BodyHandlers.discarding());
-        authResourceOwnerClient.send(Request.newBuilder(testRDFresourceURI).DELETE().build(),
-                Response.BodyHandlers.discarding());
-        authResourceOwnerClient.send(Request.newBuilder(sharedTextFileURI.resolve(".")).DELETE().build(),
+        resourceOwnerSession = OpenIdSession.ofClientCredentials(
+            URI.create(issuer), //Client credentials
+            RESOURCE_OWNER_CLIENT_ID,
+            RESOURCE_OWNER_CLIENT_SECRET,
+            AUTH_METHOD);
+        final SolidSyncClient client = SolidSyncClient.getClientBuilder()
+            .build().session(requesterSession);
+        client.send(Request.newBuilder(sharedTextFileURI).DELETE().build(), Response.BodyHandlers.discarding());
+        client.send(Request.newBuilder(testRDFresourceURI).DELETE().build(), Response.BodyHandlers.discarding());
+        client.send(Request.newBuilder(sharedTextFileURI.resolve(".")).DELETE().build(),
             Response.BodyHandlers.discarding());
-        authResourceOwnerClient.send(Request.newBuilder(testContainerURI).DELETE().build(),
-                Response.BodyHandlers.discarding());
-        authResourceOwnerClient.send(Request.newBuilder(privateContainerURI).DELETE().build(),
-                Response.BodyHandlers.discarding());
 
         mockHttpServer.stop();
         identityProviderServer.stop();
@@ -393,13 +393,13 @@ public class AccessGrantScenarios {
 
         //query for all grants with a dedicated purpose
         final AccessCredentialQuery<AccessGrant> query = AccessCredentialQuery.newBuilder()
-                .resource(sharedTextFileURI).purpose(PURPOSE1).mode(GRANT_MODE_APPEND).build(AccessGrant.class);
+                .resource(sharedResource).purpose(PURPOSE1).mode(GRANT_MODE_APPEND).build(AccessGrant.class);
         final List<AccessGrant> grants = resourceOwnerAccessGrantClient.query(query).toCompletableFuture().join();
         assertEquals(1, grants.size());
 
         //query for all grants of dedicated purpose combinations
         final AccessCredentialQuery<AccessGrant> query2 = AccessCredentialQuery.newBuilder()
-                .resource(sharedTextFileURI).purpose(PURPOSE1).mode(GRANT_MODE_WRITE).build(AccessGrant.class);
+                .resource(sharedResource).purpose(PURPOSE1).mode(GRANT_MODE_WRITE).build(AccessGrant.class);
         final List<AccessGrant> randomGrants =
             resourceOwnerAccessGrantClient.query(query2).toCompletableFuture().join();
         assertEquals(0, randomGrants.size()); //our grant is actually a APPEND
@@ -521,7 +521,7 @@ public class AccessGrantScenarios {
         final SolidSyncClient resourceOwnerClient = SolidSyncClient.getClientBuilder()
                 .build().session(resourceOwnerSession);
 
-        prepareAcpOfResource(resourceOwnerClient, testContainerURI, SolidRDFSource.class);
+        prepareAcpOfResource(resourceOwnerClient, URI.create(testContainerURI.toString() + "/"), SolidRDFSource.class);
 
         final AccessGrantClient requesterAccessGrantClient = new AccessGrantClient(
             URI.create(ACCESS_GRANT_PROVIDER)
@@ -682,6 +682,8 @@ public class AccessGrantScenarios {
         final SolidSyncClient resourceOwnerClient = SolidSyncClient.getClientBuilder()
                 .build().session(resourceOwnerSession);
 
+        prepareAcpOfResource(resourceOwnerClient, URI.create(testContainerURI.toString() + "/"), SolidRDFSource.class);
+
         final AccessGrantClient requesterAccessGrantClient = new AccessGrantClient(
                 URI.create(ACCESS_GRANT_PROVIDER)
         ).session(requesterSession);
@@ -754,26 +756,5 @@ public class AccessGrantScenarios {
         return Stream.of(
             Arguments.of(resourceOwnerSession, requesterSession)
             );
-    }
-
-    private static void createAuthenticatedClient() {
-        final Session session = OpenIdSession.ofClientCredentials(
-                URI.create(issuer), //Client credentials
-                RESOURCE_OWNER_CLIENT_ID,
-                RESOURCE_OWNER_CLIENT_SECRET,
-                AUTH_METHOD);
-
-        authResourceOwnerClient = SolidSyncClient.getClient().session(session);
-    }
-
-    private static void createContainer(final URI publicContainerURI) {
-        final var requestCreate = Request.newBuilder(publicContainerURI)
-                .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
-                .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
-                .PUT(Request.BodyPublishers.noBody())
-                .build();
-        final var resCreate =
-                authResourceOwnerClient.send(requestCreate, Response.BodyHandlers.discarding());
-        assertTrue(Utils.isSuccessful(resCreate.statusCode()));
     }
 }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -20,18 +20,21 @@
  */
 package com.inrupt.client.integration.base;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.inrupt.client.Headers;
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.auth.Credential;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.openid.OpenIdException;
 import com.inrupt.client.openid.OpenIdSession;
-import com.inrupt.client.solid.*;
+import com.inrupt.client.solid.SolidClientException;
+import com.inrupt.client.solid.SolidRDFSource;
+import com.inrupt.client.solid.SolidSyncClient;
+import com.inrupt.client.solid.UnauthorizedException;
 import com.inrupt.client.util.URIBuilder;
-import com.inrupt.client.vocabulary.LDP;
 import com.inrupt.client.webid.WebIdProfile;
 
 import java.net.URI;
@@ -68,12 +71,8 @@ public class AuthenticationScenarios {
     private static final String MOCK_USERNAME = "someuser";
 
     private static String testResourceName = "resource.ttl";
-    private static URI publicTestContainerURI;
-    private static URI publicResourceURI;
-    private static URI publicContainerURI;
-    private static URI privateTestContainerURI;
-    protected static URI privateResourceURI;
-    private static URI privateContainerURI;
+    private static URI publicResourceURL;
+    protected static URI privateResourceURL;
     private static final Config config = ConfigProvider.getConfig();
 
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
@@ -87,7 +86,7 @@ public class AuthenticationScenarios {
     private static final String PUBLIC_RESOURCE_PATH = config
         .getOptionalValue("inrupt.test.public-resource-path", String.class)
         .orElse("");
-    private static SolidSyncClient authClient;
+    private static Session session;
 
     @BeforeAll
     static void setup() {
@@ -124,41 +123,23 @@ public class AuthenticationScenarios {
         if (!podUrl.endsWith(Utils.FOLDER_SEPARATOR)) {
             podUrl += Utils.FOLDER_SEPARATOR;
         }
-
-        createAuthenticatedClient();
         if (PUBLIC_RESOURCE_PATH.isEmpty()) {
-            publicTestContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                    .path("test-" + UUID.randomUUID())
-                    .build();
-
-        } else {
-            publicTestContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path(PUBLIC_RESOURCE_PATH)
+            publicResourceURL = URIBuilder.newBuilder(URI.create(podUrl))
                 .path("test-" + UUID.randomUUID())
-                .build();
-
-            publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                    .path(PUBLIC_RESOURCE_PATH + "/").build();
-
-            createContainer(publicContainerURI);
-            prepareACR(publicContainerURI);
-        }
-
-        publicResourceURI = URIBuilder.newBuilder(publicTestContainerURI)
                 .path(testResourceName)
                 .build();
-
-        privateTestContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path(State.PRIVATE_RESOURCE_PATH)
+        } else {
+            publicResourceURL = URIBuilder.newBuilder(URI.create(podUrl))
+                .path(PUBLIC_RESOURCE_PATH)
                 .path("test-" + UUID.randomUUID())
+                .path(testResourceName)
                 .build();
-
-        privateResourceURI = URIBuilder.newBuilder(privateTestContainerURI)
+        }
+        privateResourceURL = URIBuilder.newBuilder(URI.create(podUrl))
+            .path(State.PRIVATE_RESOURCE_PATH)
+            .path("test-" + UUID.randomUUID())
             .path(testResourceName)
             .build();
-
-        privateContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path(PRIVATE_RESOURCE_PATH + "/").build();
 
         LOGGER.info("Integration Test Issuer: [{}]", issuer);
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());
@@ -166,25 +147,18 @@ public class AuthenticationScenarios {
     @AfterAll
     static void teardown() {
         //cleanup pod
-        final var reqDeletePrivateResource = Request.newBuilder(privateTestContainerURI).DELETE().build();
-        authClient.send(reqDeletePrivateResource, Response.BodyHandlers.discarding());
+        final SolidSyncClient client = SolidSyncClient.getClient().session(session);
+        final var reqDeletePrivateResource = Request.newBuilder(privateResourceURL).DELETE().build();
+        client.send(reqDeletePrivateResource, Response.BodyHandlers.discarding());
 
-        final var reqDeletePrivateParent = Request.newBuilder(privateTestContainerURI.resolve("..")).DELETE().build();
-        authClient.send(reqDeletePrivateParent, Response.BodyHandlers.discarding());
+        final var reqDeletePrivateParent = Request.newBuilder(privateResourceURL.resolve(".")).DELETE().build();
+        client.send(reqDeletePrivateParent, Response.BodyHandlers.discarding());
 
-        final var reqDeletePrivateContainer = Request.newBuilder(privateContainerURI).DELETE().build();
-        authClient.send(reqDeletePrivateContainer, Response.BodyHandlers.discarding());
+        final var reqDeletePublic = Request.newBuilder(publicResourceURL).DELETE().build();
+        client.send(reqDeletePublic, Response.BodyHandlers.discarding());
 
-        final var reqDeletePublic = Request.newBuilder(publicTestContainerURI).DELETE().build();
-        authClient.send(reqDeletePublic, Response.BodyHandlers.discarding());
-
-        final var reqDeletePublicParent = Request.newBuilder(publicTestContainerURI.resolve("..")).DELETE().build();
-        authClient.send(reqDeletePublicParent, Response.BodyHandlers.discarding());
-
-        if (publicContainerURI != null) {
-            final var reqDeletePublicContainer = Request.newBuilder(publicContainerURI).DELETE().build();
-            authClient.send(reqDeletePublicContainer, Response.BodyHandlers.discarding());
-        }
+        final var reqDeletePublicParent = Request.newBuilder(publicResourceURL.resolve(".")).DELETE().build();
+        client.send(reqDeletePublicParent, Response.BodyHandlers.discarding());
 
         mockHttpServer.stop();
         identityProviderServer.stop();
@@ -198,10 +172,10 @@ public class AuthenticationScenarios {
     void fetchPublicResourceUnauthenticatedTest() {
         LOGGER.info("Integration Test - Unauthenticated fetch of public resource");
         //create a public resource
-        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURL, null, null)) {
             final SolidSyncClient client = SolidSyncClient.getClient();
             assertDoesNotThrow(() -> client.create(testResource));
-            assertDoesNotThrow(() -> client.read(publicResourceURI, SolidRDFSource.class));
+            assertDoesNotThrow(() -> client.read(publicResourceURL, SolidRDFSource.class));
             assertDoesNotThrow(() -> client.delete(testResource));
         }
     }
@@ -215,12 +189,12 @@ public class AuthenticationScenarios {
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
 
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             final SolidSyncClient client = SolidSyncClient.getClient();
             final var err = assertThrows(UnauthorizedException.class,
-                    () -> client.read(privateResourceURI, SolidRDFSource.class));
+                    () -> client.read(privateResourceURL, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
             assertDoesNotThrow(() -> authClient.delete(testResource));
@@ -235,11 +209,11 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of public resource");
         //create public resource
         final SolidSyncClient client = SolidSyncClient.getClient();
-        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURL, null, null)) {
             assertDoesNotThrow(() -> client.create(testResource));
 
             final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-            assertDoesNotThrow(() -> authClient.read(publicResourceURI, SolidRDFSource.class));
+            assertDoesNotThrow(() -> authClient.read(publicResourceURL, SolidRDFSource.class));
 
             assertDoesNotThrow(() -> client.delete(testResource));
         }
@@ -253,10 +227,10 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of private resource");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
-            assertDoesNotThrow(() -> authClient.read(privateResourceURI, SolidRDFSource.class));
+            assertDoesNotThrow(() -> authClient.read(privateResourceURL, SolidRDFSource.class));
 
             assertDoesNotThrow(() -> authClient.delete(testResource));
         }
@@ -270,16 +244,16 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Unauthenticated, then auth fetch of private resource");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             final SolidSyncClient client = SolidSyncClient.getClient();
             final var err = assertThrows(UnauthorizedException.class,
-                    () -> client.read(privateResourceURI, SolidRDFSource.class));
+                    () -> client.read(privateResourceURL, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
             final SolidSyncClient authClient2 = client.session(session);
-            assertDoesNotThrow(() -> authClient2.read(privateResourceURI, SolidRDFSource.class));
+            assertDoesNotThrow(() -> authClient2.read(privateResourceURL, SolidRDFSource.class));
 
             assertDoesNotThrow(() -> authClient2.delete(testResource));
         }
@@ -292,7 +266,7 @@ public class AuthenticationScenarios {
     void multiSessionTest(final Session session) {
         LOGGER.info("Integration Test - Multiple sessions authenticated in parallel");
         //create private resource
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null)) {
             final SolidSyncClient authClient1 = SolidSyncClient.getClient().session(session);
             assertDoesNotThrow(() -> authClient1.create(testResource));
 
@@ -308,11 +282,11 @@ public class AuthenticationScenarios {
 
                 //read the other resource created with the other client
                 assertDoesNotThrow(() -> authClient1.read(privateResourceURL2, SolidRDFSource.class));
-                assertDoesNotThrow(() -> authClient2.read(privateResourceURI, SolidRDFSource.class));
+                assertDoesNotThrow(() -> authClient2.read(privateResourceURL, SolidRDFSource.class));
 
                 final SolidSyncClient client = SolidSyncClient.getClient();
                 final var err = assertThrows(UnauthorizedException.class,
-                        () -> client.read(privateResourceURI, SolidRDFSource.class));
+                        () -> client.read(privateResourceURL, SolidRDFSource.class));
                 assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
 
                 //delete both resources with whichever client
@@ -323,7 +297,7 @@ public class AuthenticationScenarios {
     }
 
     private static Stream<Arguments> provideSessions() throws SolidClientException {
-        final Session session = OpenIdSession.ofClientCredentials(
+        session = OpenIdSession.ofClientCredentials(
             URI.create(issuer), //Client credentials
             CLIENT_ID,
             CLIENT_SECRET,
@@ -334,43 +308,5 @@ public class AuthenticationScenarios {
         return Stream.of(
             Arguments.of(OpenIdSession.ofIdToken(token), //OpenId token
             Arguments.of(session)));
-    }
-
-    private static void createAuthenticatedClient() {
-        final Session session = OpenIdSession.ofClientCredentials(
-                URI.create(issuer), //Client credentials
-                CLIENT_ID,
-                CLIENT_SECRET,
-                AUTH_METHOD);
-
-        authClient = SolidSyncClient.getClient().session(session);
-    }
-
-    private static void createContainer(final URI publicContainerURI) {
-        final var requestCreate = Request.newBuilder(publicContainerURI)
-                .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
-                .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
-                .PUT(Request.BodyPublishers.noBody())
-                .build();
-        final var resCreate =
-                authClient.send(requestCreate, Response.BodyHandlers.discarding());
-        assertTrue(Utils.isSuccessful(resCreate.statusCode()));
-    }
-
-    private static void prepareACR(final URI publicContainerURI) {
-        try (SolidResource resource = authClient.read(publicContainerURI, SolidRDFSource.class)) {
-            if (resource != null) {
-                // find the acl Link in the header of the resource
-                resource.getMetadata().getAcl().ifPresent(acl -> {
-                    try (final SolidRDFSource acr = authClient.read(acl, SolidRDFSource.class)) {
-                        Utils.publicAgentPolicyTriples(acl)
-                                .forEach(acr.getGraph()::add);
-                        authClient.update(acr);
-                    }
-                });
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -32,12 +32,12 @@ import com.inrupt.client.Response;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.jena.JenaBodyHandlers;
 import com.inrupt.client.jena.JenaBodyPublishers;
-import com.inrupt.client.openid.OpenIdSession;
-import com.inrupt.client.solid.*;
+import com.inrupt.client.solid.SolidRDFSource;
+import com.inrupt.client.solid.SolidResourceHandlers;
+import com.inrupt.client.solid.SolidSyncClient;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.vocabulary.LDP;
 import com.inrupt.client.vocabulary.PIM;
-import com.inrupt.client.vocabulary.Solid;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -75,25 +75,17 @@ public class CoreModulesResource {
 
     private static final SolidSyncClient client = SolidSyncClient.getClient().session(Session.anonymous());
     private static String podUrl;
-    private static String issuer;
     private static final String MOCK_USERNAME = "someuser";
-    private static final String TYPE = "type";
-    private static final String LINK = "Link";
+
+    private static final String PRIVATE_RESOURCE_PATH = config
+        .getOptionalValue("inrupt.test.private-resource-path", String.class)
+        .orElse("private");
     private static final String PUBLIC_RESOURCE_PATH = config
         .getOptionalValue("inrupt.test.public-resource-path", String.class)
         .orElse("");
 
     private static String testContainer = "resource/";
     private static URI testContainerURI;
-    private static URI publicContainerURI;
-
-    private static SolidSyncClient authClient;
-    private static final String AUTH_METHOD = config
-            .getOptionalValue("inrupt.test.auth-method", String.class)
-            .orElse("client_secret_basic");
-    private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
-    private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
-
 
     @BeforeAll
     static void setup() {
@@ -112,6 +104,8 @@ public class CoreModulesResource {
             MOCK_USERNAME);
         webIdService.start();
 
+        State.PRIVATE_RESOURCE_PATH = PRIVATE_RESOURCE_PATH;
+
         final String webidUrl = config
             .getOptionalValue("inrupt.test.webid", String.class)
             .orElse(webIdService.getMockServerUrl() + Utils.FOLDER_SEPARATOR + MOCK_USERNAME);
@@ -120,10 +114,6 @@ public class CoreModulesResource {
         //find storage from WebID using only core module
         final Request requestRdf = Request.newBuilder(URI.create(webidUrl)).GET().build();
         final var responseRdf = client.send(requestRdf, JenaBodyHandlers.ofModel());
-        final var issuers = responseRdf.body()
-                .listObjectsOfProperty(createProperty(Solid.oidcIssuer.toString()))
-                .toList();
-        issuer = issuers.get(0).toString();
         final var storages = responseRdf.body()
                 .listObjectsOfProperty(createProperty(PIM.storage.toString()))
                 .toList();
@@ -140,12 +130,6 @@ public class CoreModulesResource {
                 .path("test-" + UUID.randomUUID())
                 .path(testContainer)
                 .build();
-
-            publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                    .path(PUBLIC_RESOURCE_PATH + "/").build();
-            createAuthenticatedClient();
-            createContainer(publicContainerURI);
-            prepareACR(publicContainerURI);
         }
 
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());
@@ -157,10 +141,6 @@ public class CoreModulesResource {
         client.send(Request.newBuilder(testContainerURI).DELETE().build(), Response.BodyHandlers.discarding());
         client.send(Request.newBuilder(testContainerURI.resolve("..")).DELETE().build(),
                 Response.BodyHandlers.discarding());
-        if (publicContainerURI != null) {
-            authClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
-                    Response.BodyHandlers.discarding());
-        }
 
         mockHttpServer.stop();
         identityProviderServer.stop();
@@ -181,7 +161,7 @@ public class CoreModulesResource {
         final var requestCreateIfNotExist = Request.newBuilder(URI.create(newResourceName))
                 .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
                 .header(Utils.IF_NONE_MATCH, Utils.WILDCARD)
-                .header(LINK, Headers.Link.of(LDP.RDFSource, TYPE).toString())
+                .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
                 .PUT(Request.BodyPublishers.noBody())
                 .build();
         final var resCreateIfNotExist =
@@ -285,7 +265,7 @@ public class CoreModulesResource {
         final Request req = Request.newBuilder(URI.create(containerName))
                 .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
                 .header(Utils.IF_NONE_MATCH, Utils.WILDCARD)
-                .header(LINK, Headers.Link.of(LDP.BasicContainer, TYPE).toString())
+                .header("Link", Headers.Link.of(LDP.BasicContainer, "type").toString())
                 .PUT(Request.BodyPublishers.noBody())
                 .build();
 
@@ -297,7 +277,7 @@ public class CoreModulesResource {
         final Request reqPost = Request.newBuilder(URI.create(containerName))
                 .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
                 .header(Utils.IF_NONE_MATCH, Utils.WILDCARD)
-                .header(LINK, Headers.Link.of(LDP.BasicContainer, TYPE).toString())
+                .header("Link", Headers.Link.of(LDP.BasicContainer, "type").toString())
                 .header("Slug", container2Name)
                 .POST(Request.BodyPublishers.noBody())
                 .build();
@@ -371,7 +351,7 @@ public class CoreModulesResource {
         final Request requestCreateIfNotExist = Request.newBuilder(URI.create(newResourceName))
                 .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
                 .header(Utils.IF_NONE_MATCH, Utils.WILDCARD)
-                .header(LINK, Headers.Link.of(LDP.RDFSource, TYPE).toString())
+                .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
                 .PUT(Request.BodyPublishers.noBody())
                 .build();
         final Response<Void> resp =
@@ -470,42 +450,5 @@ public class CoreModulesResource {
         return sparql;
     }
 
-    private static void createAuthenticatedClient() {
-        final Session session = OpenIdSession.ofClientCredentials(
-                URI.create(issuer), //Client credentials
-                CLIENT_ID,
-                CLIENT_SECRET,
-                AUTH_METHOD);
-
-        authClient = SolidSyncClient.getClient().session(session);
-    }
-
-    private static void createContainer(final URI publicContainerURI) {
-        final var requestCreate = Request.newBuilder(publicContainerURI)
-                .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
-                .header(LINK, Headers.Link.of(LDP.RDFSource, TYPE).toString())
-                .PUT(Request.BodyPublishers.noBody())
-                .build();
-        final var resCreate =
-                authClient.send(requestCreate, Response.BodyHandlers.discarding());
-        assertTrue(Utils.isSuccessful(resCreate.statusCode()));
-    }
-
-    private static void prepareACR(final URI publicContainerURI) {
-        try (SolidResource resource = authClient.read(publicContainerURI, SolidRDFSource.class)) {
-            if (resource != null) {
-                // find the acl Link in the header of the resource
-                resource.getMetadata().getAcl().ifPresent(acl -> {
-                    try (final SolidRDFSource acr = authClient.read(acl, SolidRDFSource.class)) {
-                        Utils.publicAgentPolicyTriples(acl)
-                                .forEach(acr.getGraph()::add);
-                        authClient.update(acr);
-                    }
-                });
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -30,6 +30,7 @@ import com.inrupt.client.openid.OpenIdSession;
 import com.inrupt.client.solid.*;
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
+import com.inrupt.client.vocabulary.LDP;
 import com.inrupt.client.vocabulary.PIM;
 import com.inrupt.client.webid.WebIdProfile;
 
@@ -75,9 +76,6 @@ public class DomainModulesResource {
 
     private static IRI booleanType = rdf.createIRI("http://www.w3.org/2001/XMLSchema#boolean");
 
-    private static final String PRIVATE_RESOURCE_PATH = config
-        .getOptionalValue("inrupt.test.private-resource-path", String.class)
-        .orElse("private");
     private static final String PUBLIC_RESOURCE_PATH = config
         .getOptionalValue("inrupt.test.public-resource-path", String.class)
         .orElse("");
@@ -88,7 +86,11 @@ public class DomainModulesResource {
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
 
     private static String testContainer = "resource/";
+    private static final String FOLDER_SEPARATOR = "/";
     private static URI testContainerURI;
+    private static URI publicContainerURI;
+
+    private static SolidSyncClient authClient;
 
     @BeforeAll
     static void setup() {
@@ -107,8 +109,6 @@ public class DomainModulesResource {
             MOCK_USERNAME);
         webIdService.start();
 
-        State.PRIVATE_RESOURCE_PATH = PRIVATE_RESOURCE_PATH;
-
         webidUrl = config
             .getOptionalValue("inrupt.test.webid", String.class)
             .orElse(webIdService.getMockServerUrl() + Utils.FOLDER_SEPARATOR + MOCK_USERNAME);
@@ -122,6 +122,7 @@ public class DomainModulesResource {
                 podUrl = storages.iterator().next().toString();
             }
         }
+        createAuthenticatedClient();
         if (PUBLIC_RESOURCE_PATH.isEmpty()) {
             testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path("test-" + UUID.randomUUID())
@@ -132,6 +133,11 @@ public class DomainModulesResource {
                 .path("test-" + UUID.randomUUID())
                 .path(testContainer)
                 .build();
+
+            publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
+                    .path(PUBLIC_RESOURCE_PATH + FOLDER_SEPARATOR).build();
+            createContainer(publicContainerURI);
+            prepareACR(publicContainerURI);
         }
 
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());
@@ -143,6 +149,10 @@ public class DomainModulesResource {
         client.send(Request.newBuilder(testContainerURI).DELETE().build(), Response.BodyHandlers.discarding());
         client.send(Request.newBuilder(testContainerURI.resolve("..")).DELETE().build(),
                 Response.BodyHandlers.discarding());
+        if (publicContainerURI != null) {
+            authClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
+                    Response.BodyHandlers.discarding());
+        }
 
         mockHttpServer.stop();
         identityProviderServer.stop();
@@ -279,31 +289,23 @@ public class DomainModulesResource {
     void ldpNavigationTest() {
         LOGGER.info("Integration Test - from a leaf container navigate until finding the root");
 
-        final Session session = OpenIdSession.ofClientCredentials(
-                URI.create(issuer), //Client credentials
-                CLIENT_ID,
-                CLIENT_SECRET,
-                AUTH_METHOD);
-
-        final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-
         //returns: testContainer + "UUID1/UUID2/UUID3/"
         final var leafPath = getNestedContainer(testContainerURI.toString(), 1);
 
-        final String podRoot = podRoot(authClient, leafPath);
+        final String podRoot = podRoot(leafPath);
 
         //cleanup
-        recursiveDeleteLDPcontainers(authClient, leafPath);
+        recursiveDeleteLDPcontainers(leafPath);
         assertFalse(podRoot.isEmpty());
     }
 
-    private String podRoot(final SolidSyncClient client, final String leafPath) {
+    private String podRoot(final String leafPath) {
         String tempURL = leafPath;
         final URI storage = URI.create(PIM.getNamespace() + "Storage");
         while (tempURL.chars().filter(ch -> ch == '/').count() >= 3) {
             final Request req = Request.newBuilder(URI.create(tempURL)).GET().build();
             final Response<SolidRDFSource> headerResponse =
-                    client.send(req, SolidResourceHandlers.ofSolidRDFSource());
+                    authClient.send(req, SolidResourceHandlers.ofSolidRDFSource());
             final var headers = headerResponse.headers();
             final var isRoot = headers.allValues("Link").stream()
                 .flatMap(l -> Headers.Link.parse(l).stream())
@@ -312,20 +314,20 @@ public class DomainModulesResource {
                 return tempURL;
             }
             tempURL = tempURL.substring(0, tempURL.length() - 1 ); //eliminate the last /
-            tempURL = tempURL.substring(0, tempURL.lastIndexOf("/") + 1);
+            tempURL = tempURL.substring(0, tempURL.lastIndexOf(FOLDER_SEPARATOR) + 1);
         }
         return "";
     }
 
-    private void recursiveDeleteLDPcontainers(final SolidSyncClient client, final String leafPath) {
+    private void recursiveDeleteLDPcontainers(final String leafPath) {
         String tempURL = leafPath;
         final String notToDeletePath = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(PUBLIC_RESOURCE_PATH).build().toString();
-        while (!(tempURL.equals(notToDeletePath)) && !(tempURL.equals(notToDeletePath + "/"))) {
+        while (!(tempURL.equals(notToDeletePath)) && !(tempURL.equals(notToDeletePath + FOLDER_SEPARATOR))) {
             final var url = new SolidRDFSource(URI.create(tempURL),null, null);
-            client.delete(url);
-            tempURL = tempURL.substring(0, tempURL.lastIndexOf("/"));
-            tempURL = tempURL.substring(0, tempURL.lastIndexOf("/") + 1);
+            authClient.delete(url);
+            tempURL = tempURL.substring(0, tempURL.lastIndexOf(FOLDER_SEPARATOR));
+            tempURL = tempURL.substring(0, tempURL.lastIndexOf(FOLDER_SEPARATOR) + 1);
         }
     }
 
@@ -338,5 +340,43 @@ public class DomainModulesResource {
         final var resource = new SolidRDFSource(URI.create(newURL));
         client.create(resource);
         return newURL;
+    }
+
+    private static void createAuthenticatedClient() {
+        final Session session = OpenIdSession.ofClientCredentials(
+                URI.create(issuer), //Client credentials
+                CLIENT_ID,
+                CLIENT_SECRET,
+                AUTH_METHOD);
+
+        authClient = SolidSyncClient.getClient().session(session);
+    }
+
+    private static void createContainer(final URI publicContainerURI) {
+        final var requestCreate = Request.newBuilder(publicContainerURI)
+                .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
+                .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
+                .PUT(Request.BodyPublishers.noBody())
+                .build();
+        final var resCreate =
+                authClient.send(requestCreate, Response.BodyHandlers.discarding());
+        assertTrue(Utils.isSuccessful(resCreate.statusCode()));
+    }
+
+    private static void prepareACR(final URI publicContainerURI) {
+        try (SolidResource resource = authClient.read(publicContainerURI, SolidRDFSource.class)) {
+            if (resource != null) {
+                // find the acl Link in the header of the resource
+                resource.getMetadata().getAcl().ifPresent(acl -> {
+                    try (final SolidRDFSource acr = authClient.read(acl, SolidRDFSource.class)) {
+                        Utils.publicAgentPolicyTriples(acl)
+                                .forEach(acr.getGraph()::add);
+                        authClient.update(acr);
+                    }
+                });
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
@@ -58,16 +58,19 @@ class MockAccessGrantServer {
 
     private final WireMockServer wireMockServer;
     private final String webId;
+    private final String sharedFile;
     private final String sharedResource;
 
     private final String authorisationServerUrl;
 
     public MockAccessGrantServer(
             final URI webId,
+            final URI sharedFile,
             final URI sharedResource,
             final String authorisationServerUrl
     ) {
         this.webId = webId.toString();
+        this.sharedFile = sharedFile.toString();
         this.sharedResource = sharedResource.toString();
         this.authorisationServerUrl = authorisationServerUrl;
         wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
@@ -87,7 +90,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.webId, this.sharedFile))));
 
         wireMockServer.stubFor(get(urlPathEqualTo("/vc-request"))
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
@@ -95,7 +98,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.webId, this.sharedFile))));
 
         wireMockServer.stubFor(delete(urlPathMatching("/vc-grant"))
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
@@ -145,7 +148,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.webId, this.sharedFile))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .inScenario(SCENARIO_ACCESS_GRANT)
@@ -158,7 +161,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.webId, this.sharedFile))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .atPriority(1)
@@ -169,7 +172,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.webId, this.sharedFile))));
 
         // Require UMA authentication for the /verify endpoint
         wireMockServer.stubFor(post(urlEqualTo(VERIFY))

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
@@ -58,19 +58,16 @@ class MockAccessGrantServer {
 
     private final WireMockServer wireMockServer;
     private final String webId;
-    private final String sharedFile;
     private final String sharedResource;
 
     private final String authorisationServerUrl;
 
     public MockAccessGrantServer(
             final URI webId,
-            final URI sharedFile,
             final URI sharedResource,
             final String authorisationServerUrl
     ) {
         this.webId = webId.toString();
-        this.sharedFile = sharedFile.toString();
         this.sharedResource = sharedResource.toString();
         this.authorisationServerUrl = authorisationServerUrl;
         wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
@@ -90,7 +87,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedFile))));
+                                this.webId, this.sharedResource))));
 
         wireMockServer.stubFor(get(urlPathEqualTo("/vc-request"))
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
@@ -98,7 +95,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedFile))));
+                                this.webId, this.sharedResource))));
 
         wireMockServer.stubFor(delete(urlPathMatching("/vc-grant"))
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
@@ -148,7 +145,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedFile))));
+                                this.webId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .inScenario(SCENARIO_ACCESS_GRANT)
@@ -161,7 +158,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedFile))));
+                                this.webId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .atPriority(1)
@@ -172,7 +169,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedFile))));
+                                this.webId, this.sharedResource))));
 
         // Require UMA authentication for the /verify endpoint
         wireMockServer.stubFor(post(urlEqualTo(VERIFY))

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockOpenIDProvider.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockOpenIDProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockSolidServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockSolidServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockWebIdService.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockWebIdService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/SolidServerTransformer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/SolidServerTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/State.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/State.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -20,29 +20,16 @@
  */
 package com.inrupt.client.integration.base;
 
-import static com.inrupt.client.vocabulary.RDF.type;
 import static java.nio.charset.StandardCharsets.UTF_8;
-
-import com.inrupt.client.spi.RDFFactory;
-import com.inrupt.client.util.URIBuilder;
-import com.inrupt.client.vocabulary.ACL;
-import com.inrupt.client.vocabulary.ACP;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.net.URI;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDF;
-import org.apache.commons.rdf.api.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.Lang;
@@ -90,9 +77,6 @@ public final class Utils {
     public static final String UMA_JWKS_ENDPOINT = "uma/jwks";
     public static final String OAUTH_JWKS_ENDPOINT = "oauth/jwks";
 
-    private static final RDF rdf = RDFFactory.getInstance();
-    private static final IRI PUBLIC_AGENT = rdf.createIRI("http://www.w3.org/ns/solid/acp#PublicAgent");
-
     public static boolean isSuccessful(final int status) {
         return Arrays.asList(SUCCESS, NO_CONTENT, CREATED).contains(status);
     }
@@ -129,41 +113,6 @@ public final class Utils {
 
     public static boolean isPodRoot(final String url) {
         return "/".equals(url);
-    }
-
-
-    private static IRI asIRI(final URI uri) {
-        return rdf.createIRI(uri.toString());
-    }
-
-    public static Set<Triple> publicAgentPolicyTriples(final URI acl) {
-        final Set<Triple> triples = new HashSet<>();
-        final IRI a = asIRI(type);
-
-        // Matcher
-        final IRI matcher = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
-        triples.add(rdf.createTriple(matcher, a, asIRI(ACP.Matcher)));
-        triples.add(rdf.createTriple(matcher, asIRI(URI.create("http://www.w3.org/ns/solid/acp#agent")), PUBLIC_AGENT));
-
-        // Policy
-        final IRI policy = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
-        triples.add(rdf.createTriple(policy, a, asIRI(ACP.Policy)));
-        triples.add(rdf.createTriple(policy, asIRI(ACP.allOf), matcher));
-        triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(ACL.Read)));
-        triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(ACL.Write)));
-        triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(ACL.Append)));
-
-        // Access Control
-        final IRI accessControl = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
-        triples.add(rdf.createTriple(accessControl, a, asIRI(ACP.AccessControl)));
-        triples.add(rdf.createTriple(accessControl, asIRI(ACP.apply), policy));
-
-        // Access Control Resource
-        final IRI subject = asIRI(acl);
-        triples.add(rdf.createTriple(subject, a, asIRI(ACP.AccessControlResource)));
-        triples.add(rdf.createTriple(subject, asIRI(ACP.accessControl), accessControl));
-        triples.add(rdf.createTriple(subject, asIRI(ACP.memberAccessControl), accessControl));
-        return triples;
     }
 
     private Utils() {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -20,16 +20,29 @@
  */
 package com.inrupt.client.integration.base;
 
+import static com.inrupt.client.vocabulary.RDF.type;
 import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.inrupt.client.spi.RDFFactory;
+import com.inrupt.client.util.URIBuilder;
+import com.inrupt.client.vocabulary.ACL;
+import com.inrupt.client.vocabulary.ACP;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.api.Triple;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.Lang;
@@ -77,6 +90,9 @@ public final class Utils {
     public static final String UMA_JWKS_ENDPOINT = "uma/jwks";
     public static final String OAUTH_JWKS_ENDPOINT = "oauth/jwks";
 
+    private static final RDF rdf = RDFFactory.getInstance();
+    private static final IRI PUBLIC_AGENT = rdf.createIRI("http://www.w3.org/ns/solid/acp#PublicAgent");
+
     public static boolean isSuccessful(final int status) {
         return Arrays.asList(SUCCESS, NO_CONTENT, CREATED).contains(status);
     }
@@ -113,6 +129,41 @@ public final class Utils {
 
     public static boolean isPodRoot(final String url) {
         return "/".equals(url);
+    }
+
+
+    private static IRI asIRI(final URI uri) {
+        return rdf.createIRI(uri.toString());
+    }
+
+    public static Set<Triple> publicAgentPolicyTriples(final URI acl) {
+        final Set<Triple> triples = new HashSet<>();
+        final IRI a = asIRI(type);
+
+        // Matcher
+        final IRI matcher = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(matcher, a, asIRI(ACP.Matcher)));
+        triples.add(rdf.createTriple(matcher, asIRI(URI.create("http://www.w3.org/ns/solid/acp#agent")), PUBLIC_AGENT));
+
+        // Policy
+        final IRI policy = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(policy, a, asIRI(ACP.Policy)));
+        triples.add(rdf.createTriple(policy, asIRI(ACP.allOf), matcher));
+        triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(ACL.Read)));
+        triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(ACL.Write)));
+        triples.add(rdf.createTriple(policy, asIRI(ACP.allow), asIRI(ACL.Append)));
+
+        // Access Control
+        final IRI accessControl = asIRI(URIBuilder.newBuilder(acl).fragment(UUID.randomUUID().toString()).build());
+        triples.add(rdf.createTriple(accessControl, a, asIRI(ACP.AccessControl)));
+        triples.add(rdf.createTriple(accessControl, asIRI(ACP.apply), policy));
+
+        // Access Control Resource
+        final IRI subject = asIRI(acl);
+        triples.add(rdf.createTriple(subject, a, asIRI(ACP.AccessControlResource)));
+        triples.add(rdf.createTriple(subject, asIRI(ACP.accessControl), accessControl));
+        triples.add(rdf.createTriple(subject, asIRI(ACP.memberAccessControl), accessControl));
+        return triples;
     }
 
     private Utils() {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/package-info.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/main/resources/simplelogger.properties
+++ b/integration/base/src/main/resources/simplelogger.properties
@@ -1,1 +1,1 @@
-org.slf4j.simpleLogger.log.org.eclipse.jetty=warn
+org.slf4j.simpleLogger.log.org.eclipse.jetty=INFO

--- a/integration/base/src/main/resources/simplelogger.properties
+++ b/integration/base/src/main/resources/simplelogger.properties
@@ -1,1 +1,1 @@
-org.slf4j.simpleLogger.log.org.eclipse.jetty=INFO
+org.slf4j.simpleLogger.log.org.eclipse.jetty=warn

--- a/integration/base/src/test/java/com/inrupt/client/integration/base/Playlist.java
+++ b/integration/base/src/test/java/com/inrupt/client/integration/base/Playlist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
+++ b/integration/base/src/test/java/com/inrupt/client/integration/base/ServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
@@ -44,13 +44,13 @@ class OpenIdAuthenticationScenariosTest extends AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of private resource uses OpenID authenticator");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
-            assertDoesNotThrow(() -> authClient.read(privateResourceURI, SolidRDFSource.class));
+            assertDoesNotThrow(() -> authClient.read(privateResourceURL, SolidRDFSource.class));
 
             // Lookup the session cache.
-            final Request dummyRequest = Request.newBuilder(privateResourceURI).build();
+            final Request dummyRequest = Request.newBuilder(privateResourceURL).build();
             final var token = session.fromCache(dummyRequest);
             final var credential = session.getCredential(
                     URI.create("http://openid.net/specs/openid-connect-core-1_0.html#IDToken"),

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
@@ -44,13 +44,13 @@ class OpenIdAuthenticationScenariosTest extends AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of private resource uses OpenID authenticator");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURL, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
-            assertDoesNotThrow(() -> authClient.read(privateResourceURL, SolidRDFSource.class));
+            assertDoesNotThrow(() -> authClient.read(privateResourceURI, SolidRDFSource.class));
 
             // Lookup the session cache.
-            final Request dummyRequest = Request.newBuilder(privateResourceURL).build();
+            final Request dummyRequest = Request.newBuilder(privateResourceURI).build();
             final var token = session.fromCache(dummyRequest);
             final var credential = session.getCredential(
                     URI.create("http://openid.net/specs/openid-connect-core-1_0.html#IDToken"),

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdCoreModulesResourceTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdCoreModulesResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdDomainModulesResourceTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdDomainModulesResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAccessGrantScenarioTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAuthenticationScenariosTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaAuthenticationScenariosTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaCoreModulesResourceTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaCoreModulesResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaDomainModulesResourceTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaDomainModulesResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jackson/src/main/java/com/inrupt/client/jackson/JacksonService.java
+++ b/jackson/src/main/java/com/inrupt/client/jackson/JacksonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jackson/src/main/java/com/inrupt/client/jackson/package-info.java
+++ b/jackson/src/main/java/com/inrupt/client/jackson/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jackson/src/test/java/com/inrupt/client/jackson/JacksonServiceTest.java
+++ b/jackson/src/test/java/com/inrupt/client/jackson/JacksonServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/client/jena/JenaBodyPublishers.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaBodyPublishers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/client/jena/JenaService.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/client/jena/package-info.java
+++ b/jena/src/main/java/com/inrupt/client/jena/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/client/jena/JenaBodyPublishersTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaBodyPublishersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/client/jena/JenaServiceTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/client/jena/JenaTestModel.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaTestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jsonb/src/main/java/com/inrupt/client/jsonb/JsonbService.java
+++ b/jsonb/src/main/java/com/inrupt/client/jsonb/JsonbService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jsonb/src/main/java/com/inrupt/client/jsonb/package-info.java
+++ b/jsonb/src/main/java/com/inrupt/client/jsonb/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbServiceTest.java
+++ b/jsonb/src/test/java/com/inrupt/client/jsonb/JsonbServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpResponse.java
+++ b/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpResponseInfo.java
+++ b/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpResponseInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpService.java
+++ b/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/okhttp/src/main/java/com/inrupt/client/okhttp/package-info.java
+++ b/okhttp/src/main/java/com/inrupt/client/okhttp/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/okhttp/src/test/java/com/inrupt/client/okhttp/OkhttpServiceTest.java
+++ b/okhttp/src/test/java/com/inrupt/client/okhttp/OkhttpServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/AuthorizationRequest.java
+++ b/openid/src/main/java/com/inrupt/client/openid/AuthorizationRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/EndSessionRequest.java
+++ b/openid/src/main/java/com/inrupt/client/openid/EndSessionRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/ErrorResponse.java
+++ b/openid/src/main/java/com/inrupt/client/openid/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/Metadata.java
+++ b/openid/src/main/java/com/inrupt/client/openid/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdAuthenticationProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdConfig.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdException.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/PKCE.java
+++ b/openid/src/main/java/com/inrupt/client/openid/PKCE.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/TokenRequest.java
+++ b/openid/src/main/java/com/inrupt/client/openid/TokenRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/TokenResponse.java
+++ b/openid/src/main/java/com/inrupt/client/openid/TokenResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/main/java/com/inrupt/client/openid/package-info.java
+++ b/openid/src/main/java/com/inrupt/client/openid/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdProviderTest.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdSessionTest.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdTestUtils.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/test/java/com/inrupt/client/openid/PKCETest.java
+++ b/openid/src/test/java/com/inrupt/client/openid/PKCETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/openid/src/test/java/com/inrupt/client/openid/TestDpopService.java
+++ b/openid/src/test/java/com/inrupt/client/openid/TestDpopService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/parser/src/main/java/com/inrupt/client/parser/ConsumerErrorListener.java
+++ b/parser/src/main/java/com/inrupt/client/parser/ConsumerErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/parser/src/main/java/com/inrupt/client/parser/package-info.java
+++ b/parser/src/main/java/com/inrupt/client/parser/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf-legacy/src/main/java/com/inrupt/client/rdf/legacy/RDFLegacyService.java
+++ b/rdf-legacy/src/main/java/com/inrupt/client/rdf/legacy/RDFLegacyService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf-legacy/src/main/java/com/inrupt/client/rdf/legacy/package-info.java
+++ b/rdf-legacy/src/main/java/com/inrupt/client/rdf/legacy/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf-legacy/src/test/java/com/inrupt/client/rdf/legacy/RDF4JTestModel.java
+++ b/rdf-legacy/src/test/java/com/inrupt/client/rdf/legacy/RDF4JTestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf-legacy/src/test/java/com/inrupt/client/rdf/legacy/RDFLegacyServiceTest.java
+++ b/rdf-legacy/src/test/java/com/inrupt/client/rdf/legacy/RDFLegacyServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyPublishers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyPublishers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JService.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyPublishersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyPublishersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JServiceTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JTestModel.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JTestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/BadRequestException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/ConflictException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/ConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/DataMappingException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/DataMappingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/ForbiddenException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/ForbiddenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/GoneException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/GoneException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/InternalServerErrorException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/InternalServerErrorException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/Metadata.java
+++ b/solid/src/main/java/com/inrupt/client/solid/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/MethodNotAllowedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/MethodNotAllowedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/NotAcceptableException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/NotAcceptableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/NotFoundException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/PreconditionFailedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/PreconditionFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidRDFSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResourceException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResourceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResourceHandlers.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResourceHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidSyncClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/TooManyRequestsException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/TooManyRequestsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/UnauthorizedException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/UnauthorizedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/UnsupportedMediaTypeException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/UnsupportedMediaTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/main/java/com/inrupt/client/solid/package-info.java
+++ b/solid/src/main/java/com/inrupt/client/solid/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/InvalidType.java
+++ b/solid/src/test/java/com/inrupt/client/solid/InvalidType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/Playlist.java
+++ b/solid/src/test/java/com/inrupt/client/solid/Playlist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/Recipe.java
+++ b/solid/src/test/java/com/inrupt/client/solid/Recipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/SolidExceptionTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/src/main/java/com/inrupt/client/test/HttpMockService.java
+++ b/test/src/main/java/com/inrupt/client/test/HttpMockService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/src/main/java/com/inrupt/client/test/HttpServices.java
+++ b/test/src/main/java/com/inrupt/client/test/HttpServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/src/main/java/com/inrupt/client/test/JsonServices.java
+++ b/test/src/main/java/com/inrupt/client/test/JsonServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/src/main/java/com/inrupt/client/test/RdfMockService.java
+++ b/test/src/main/java/com/inrupt/client/test/RdfMockService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/src/main/java/com/inrupt/client/test/RdfServices.java
+++ b/test/src/main/java/com/inrupt/client/test/RdfServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/src/main/java/com/inrupt/client/test/RdfTestModel.java
+++ b/test/src/main/java/com/inrupt/client/test/RdfTestModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/src/main/java/com/inrupt/client/test/package-info.java
+++ b/test/src/main/java/com/inrupt/client/test/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/ClaimGatheringHandler.java
+++ b/uma/src/main/java/com/inrupt/client/uma/ClaimGatheringHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/ClaimToken.java
+++ b/uma/src/main/java/com/inrupt/client/uma/ClaimToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/ErrorResponse.java
+++ b/uma/src/main/java/com/inrupt/client/uma/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/InvalidGrantException.java
+++ b/uma/src/main/java/com/inrupt/client/uma/InvalidGrantException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/InvalidScopeException.java
+++ b/uma/src/main/java/com/inrupt/client/uma/InvalidScopeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/Metadata.java
+++ b/uma/src/main/java/com/inrupt/client/uma/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/NeedInfo.java
+++ b/uma/src/main/java/com/inrupt/client/uma/NeedInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/RequestDeniedException.java
+++ b/uma/src/main/java/com/inrupt/client/uma/RequestDeniedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/RequiredClaims.java
+++ b/uma/src/main/java/com/inrupt/client/uma/RequiredClaims.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/TokenRequest.java
+++ b/uma/src/main/java/com/inrupt/client/uma/TokenRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/TokenResponse.java
+++ b/uma/src/main/java/com/inrupt/client/uma/TokenResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/UmaAuthenticationProvider.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/UmaClient.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/UmaException.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/UmaSession.java
+++ b/uma/src/main/java/com/inrupt/client/uma/UmaSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/main/java/com/inrupt/client/uma/package-info.java
+++ b/uma/src/main/java/com/inrupt/client/uma/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/test/java/com/inrupt/client/uma/MockAuthorizationServer.java
+++ b/uma/src/test/java/com/inrupt/client/uma/MockAuthorizationServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/uma/src/test/java/com/inrupt/client/uma/UmaClientTest.java
+++ b/uma/src/test/java/com/inrupt/client/uma/UmaClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/ACL.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/ACL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/ACP.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/ACP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/LDP.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/LDP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/PIM.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/PIM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/RDF.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/RDF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/RDFS.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/RDFS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/Solid.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/Solid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/vocabulary/src/main/java/com/inrupt/client/vocabulary/package-info.java
+++ b/vocabulary/src/main/java/com/inrupt/client/vocabulary/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/webid/src/main/java/com/inrupt/client/webid/WebIdException.java
+++ b/webid/src/main/java/com/inrupt/client/webid/WebIdException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
+++ b/webid/src/main/java/com/inrupt/client/webid/WebIdProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/webid/src/main/java/com/inrupt/client/webid/package-info.java
+++ b/webid/src/main/java/com/inrupt/client/webid/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/webid/src/test/java/com/inrupt/client/webid/WebIdMockHttpService.java
+++ b/webid/src/test/java/com/inrupt/client/webid/WebIdMockHttpService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/webid/src/test/java/com/inrupt/client/webid/WebIdProfileTest.java
+++ b/webid/src/test/java/com/inrupt/client/webid/WebIdProfileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
In all java classes and in the license text.