### PR TITLE
JCL-412: deal with guava 31.1. CVE

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -53,12 +53,13 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>

--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -53,6 +53,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,12 +91,13 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -91,6 +91,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -51,6 +51,13 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock - exclusion was not possible-->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -51,7 +51,7 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock - exclusion was not possible-->
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -113,17 +113,20 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
+        <!-- transitive dependency via wiremock -->
+        <!-- when wiremock is updated beyond 2.35, this can be removed -->
                     <groupId>commons-fileupload</groupId>
                     <artifactId>commons-fileupload</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
-        <!-- transitive dependency via wiremock -->
-        <!-- when wiremock is updated beyond 2.35, this can be removed -->
+        <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -116,6 +116,10 @@
                     <groupId>commons-fileupload</groupId>
                     <artifactId>commons-fileupload</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- transitive dependency via wiremock -->

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -113,8 +113,6 @@
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
-        <!-- transitive dependency via wiremock -->
-        <!-- when wiremock is updated beyond 2.35, this can be removed -->
                     <groupId>commons-fileupload</groupId>
                     <artifactId>commons-fileupload</artifactId>
                 </exclusion>
@@ -127,6 +125,8 @@
             <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- transitive dependency via wiremock -->
+        <!-- when wiremock is updated beyond 2.35, this can be removed -->
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -56,12 +56,13 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -56,6 +56,12 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -60,12 +60,13 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -60,6 +60,12 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -68,6 +68,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -68,12 +68,13 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -66,12 +66,13 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -66,6 +66,12 @@
       <artifactId>wiremock-jre8-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -59,11 +59,14 @@
             <groupId>net.minidev</groupId>
             <artifactId>accessors-smart</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
       </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -59,6 +59,10 @@
             <groupId>net.minidev</groupId>
             <artifactId>accessors-smart</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -60,6 +60,13 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock - exclusion was not possible-->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -60,7 +60,7 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock - exclusion was not possible-->
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -53,7 +53,7 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock - exclusion was not possible-->
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -53,6 +53,13 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock - exclusion was not possible-->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-caffeine</artifactId>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -123,11 +123,14 @@
             <groupId>net.minidev</groupId>
             <artifactId>accessors-smart</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
       </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -123,6 +123,10 @@
             <groupId>net.minidev</groupId>
             <artifactId>accessors-smart</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -110,12 +110,13 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -110,6 +110,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -48,6 +48,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -48,12 +48,13 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -43,12 +43,16 @@
       <version>${wiremock.version}</version>
       <scope>provided</scope>
       <exclusions>
+    <!-- transitive dependency via wiremock -->
+    <!-- when wiremock is updated beyond 2.35, this can be removed -->
         <exclusion>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
         </exclusion>
-    <!-- transitive dependency via wiremock -->
-    <!-- when wiremock is updated beyond 2.35, this can be removed -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -49,11 +49,14 @@
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
       </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.minidev</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -43,8 +43,6 @@
       <version>${wiremock.version}</version>
       <scope>provided</scope>
       <exclusions>
-    <!-- transitive dependency via wiremock -->
-    <!-- when wiremock is updated beyond 2.35, this can be removed -->
         <exclusion>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
@@ -58,6 +56,8 @@
       <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- transitive dependency via wiremock -->
+    <!-- when wiremock is updated beyond 2.35, this can be removed -->
     <dependency>
       <groupId>net.minidev</groupId>
       <artifactId>json-smart</artifactId>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -54,12 +54,13 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -54,6 +54,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -31,12 +31,13 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -31,6 +31,12 @@
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2023-2976
I excluded the lib in wiremock where we could. The other modules make use of it in testing so I upgraded it. 