### PR TITLE
JCL-401: fetch access requests

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -177,8 +177,7 @@ public class AccessGrantClient {
     /**
      * Issue an access request.
      *
-     * @param recipient the agent to whom the access request is made;
-     *                  i.e., the agent controlling access to the resources
+     * @param recipient the agent controlling access to the resources
      * @param resources the resources to which this credential applies
      * @param modes the access modes for this credential
      * @param purposes the purposes of this credential

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -190,6 +190,7 @@ public class AccessGrantScenarios {
                 .toString());
 
         accessGrantServer = new MockAccessGrantServer(
+                URI.create(webidUrl),
                 URI.create(requesterWebidUrl),
                 sharedTextFileURI,
                 authServer.getMockServerUrl()
@@ -397,7 +398,7 @@ public class AccessGrantScenarios {
                 URI.create(ACCESS_GRANT_PROVIDER)
         ).session(resourceOwnerSession);
 
-        //the owner SHOULD see an access request from requestor
+        //the owner SHOULD see an access request from requester
         //because it is a request concerning the owner's resource
         final AccessRequest fetchedAccessRequest1 = resourceOwnerAccessGrantClient.fetch(
                         grantId,

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -20,10 +20,7 @@
  */
 package com.inrupt.client.integration.base;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.inrupt.client.Headers;
@@ -51,6 +48,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.IRI;
@@ -363,6 +361,68 @@ public class AccessGrantScenarios {
             resourceOwnerAccessGrantClient.query(query2).toCompletableFuture().join();
 
         assertEquals(0, randomGrants.size());
+
+        //cleanup
+        assertDoesNotThrow(resourceOwnerAccessGrantClient.revoke(grant).toCompletableFuture()::join);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSessions")
+    @DisplayName("Given a grant id, approve it")
+    void accessGrantGrantAccessByIdTest(final Session resourceOwnerSession, final Session requesterSession) {
+        LOGGER.info("Integration Test - Grant access by id");
+
+        //setup test
+        final AccessGrantClient requesterAccessGrantClient = new AccessGrantClient(
+                URI.create(ACCESS_GRANT_PROVIDER)
+        ).session(requesterSession);
+
+        final Set<String> modes = new HashSet<>(Arrays.asList(GRANT_MODE_READ));
+        final Instant expiration = Instant.parse(GRANT_EXPIRATION);
+        final AccessRequest request = requesterAccessGrantClient.requestAccess(URI.create(requesterWebidUrl),
+                        new HashSet<>(Arrays.asList(sharedTextFileURI)), modes, PURPOSES, expiration)
+                .toCompletableFuture().join();
+
+        final var grantId = request.getIdentifier();
+
+        //requester has access to see their own access requests
+        final AccessRequest fetchedAccessRequest =
+                requesterAccessGrantClient.fetch(
+                        grantId,
+                        AccessRequest.class).toCompletableFuture().join();
+
+        assertEquals(grantId, fetchedAccessRequest.getIdentifier());
+
+        //switching to owner
+        final AccessGrantClient resourceOwnerAccessGrantClient = new AccessGrantClient(
+                URI.create(ACCESS_GRANT_PROVIDER)
+        ).session(resourceOwnerSession);
+
+        //the owner SHOULD see an access request from requestor
+        //because it is a request concerning the owner's resource
+        final AccessRequest fetchedAccessRequest1 = resourceOwnerAccessGrantClient.fetch(
+                        grantId,
+                        AccessRequest.class).toCompletableFuture().join();
+        assertEquals(grantId, fetchedAccessRequest1.getIdentifier());
+
+        //owner grants the request
+        final AccessGrant grant = resourceOwnerAccessGrantClient.grantAccess(request)
+                .toCompletableFuture().join();
+
+        //owner can see the access grants just granted
+        final AccessGrant accessGrant =
+                resourceOwnerAccessGrantClient.fetch(
+                        grant.getIdentifier(),
+                        AccessGrant.class).toCompletableFuture().join();
+
+        //check that the approved grant is the same we find when querying for all grants
+        final AccessCredentialQuery<AccessGrant> query = AccessCredentialQuery.newBuilder()
+                .recipient(URI.create(requesterWebidUrl)).resource(sharedTextFileURI)
+                .mode(GRANT_MODE_READ).build(AccessGrant.class);
+        final List<AccessGrant> grants = resourceOwnerAccessGrantClient.query(query).toCompletableFuture().join();
+        assertEquals(1, grants.size());
+        assertEquals(grant.getIdentifier(), grants.get(0).getIdentifier());
+        assertEquals(accessGrant.getIdentifier(), grants.get(0).getIdentifier());
 
         //cleanup
         assertDoesNotThrow(resourceOwnerAccessGrantClient.revoke(grant).toCompletableFuture()::join);

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -48,7 +48,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletionException;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.IRI;

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -379,7 +379,7 @@ public class AccessGrantScenarios {
 
         final Set<String> modes = new HashSet<>(Arrays.asList(GRANT_MODE_READ));
         final Instant expiration = Instant.parse(GRANT_EXPIRATION);
-        final AccessRequest request = requesterAccessGrantClient.requestAccess(URI.create(requesterWebidUrl),
+        final AccessRequest request = requesterAccessGrantClient.requestAccess(URI.create(webidUrl),
                         new HashSet<>(Arrays.asList(sharedTextFileURI)), modes, PURPOSES, expiration)
                 .toCompletableFuture().join();
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
@@ -57,17 +57,20 @@ class MockAccessGrantServer {
     private static final String SCENARIO_STATE_REVOKED = "Revoked";
 
     private final WireMockServer wireMockServer;
-    private final String webId;
+    private final String ownerWebId;
+    private final String requesterWebId;
     private final String sharedResource;
 
     private final String authorisationServerUrl;
 
     public MockAccessGrantServer(
-            final URI webId,
+            final URI ownerWebId,
+            final URI requesterWebId,
             final URI sharedResource,
             final String authorisationServerUrl
     ) {
-        this.webId = webId.toString();
+        this.ownerWebId = ownerWebId.toString();
+        this.requesterWebId = requesterWebId.toString();
         this.sharedResource = sharedResource.toString();
         this.authorisationServerUrl = authorisationServerUrl;
         wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
@@ -87,7 +90,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(get(urlPathEqualTo("/vc-request"))
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
@@ -95,7 +98,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(delete(urlPathMatching("/vc-grant"))
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
@@ -120,7 +123,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .inScenario(SCENARIO_ACCESS_GRANT)
@@ -134,7 +137,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .atPriority(1)
@@ -145,7 +148,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .inScenario(SCENARIO_ACCESS_GRANT)
@@ -158,7 +161,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-grant.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(ISSUE))
                 .atPriority(1)
@@ -169,7 +172,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/vc-request.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         // Require UMA authentication for the /verify endpoint
         wireMockServer.stubFor(post(urlEqualTo(VERIFY))
@@ -229,7 +232,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/query_response.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(DERIVE))
                 .atPriority(1)
@@ -241,7 +244,7 @@ class MockAccessGrantServer {
                         .withStatus(Utils.SUCCESS)
                         .withHeader(Utils.CONTENT_TYPE, Utils.APPLICATION_JSON)
                         .withBody(getResource("/query_response.json", wireMockServer.baseUrl(),
-                                this.webId, this.sharedResource))));
+                                this.requesterWebId, this.ownerWebId, this.sharedResource))));
 
         wireMockServer.stubFor(post(urlEqualTo(DERIVE))
                 .atPriority(2)
@@ -265,10 +268,11 @@ class MockAccessGrantServer {
         return getResource(path).replace("{{baseUrl}}", baseUrl);
     }
 
-    private static String getResource(final String path, final String baseUrl, final String webId,
-                                      final String sharedFile) {
+    private static String getResource(final String path, final String baseUrl, final String requesterWebId,
+                                      final String ownerWebId, final String sharedFile) {
         return getResource(path).replace("{{baseUrl}}", baseUrl)
-                .replace("{{webId}}", webId)
+                .replace("{{requesterWebId}}", requesterWebId)
+                .replace("{{ownerWebId}}", ownerWebId)
                 .replace("{{sharedFile}}", sharedFile);
     }
 

--- a/integration/base/src/main/resources/query_response.json
+++ b/integration/base/src/main/resources/query_response.json
@@ -16,11 +16,11 @@
       "revocationListIndex":"2832",
       "type":"RevocationList2020Status"},
     "credentialSubject":{
-      "id":"{{webId}}",
+      "id":"{{ownerWebId}}",
       "providedConsent":{
         "mode":["Read","Append"],
         "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-        "isProvidedTo":"{{webId}}",
+        "isProvidedTo":"{{requesterWebId}}",
         "forPurpose":["https://purpose.example/Purpose1"],
         "forPersonalData":["{{sharedFile}}"]}},
     "proof":{

--- a/integration/base/src/main/resources/vc-grant.json
+++ b/integration/base/src/main/resources/vc-grant.json
@@ -15,11 +15,11 @@
         "revocationListIndex":"2832",
         "type":"RevocationList2020Status"},
     "credentialSubject":{
-        "id":"{{webId}}",
+        "id":"{{ownerWebId}}",
         "providedConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusExplicitlyGiven",
-            "isProvidedToPerson":"{{webId}}",
+            "isProvidedToPerson":"{{requesterWebId}}",
             "forPurpose":[
                 "https://purpose.example/212efdf4-e1a4-4dcd-9d3b-d6eb92e0205f",
                 "https://purpose.example/de605b08-76c7-4f04-9cec-a438810b0c03"],

--- a/integration/base/src/main/resources/vc-request.json
+++ b/integration/base/src/main/resources/vc-request.json
@@ -15,11 +15,11 @@
         "revocationListIndex":"2832",
         "type":"RevocationList2020Status"},
     "credentialSubject":{
-        "id":"{{webId}}",
+        "id":"{{requesterWebId}}",
         "hasConsent":{
             "mode":["Read"],
             "hasStatus":"https://w3id.org/GConsent#ConsentStatusRequested",
-            "isConsentForDataSubject":"{{webId}}",
+            "isConsentForDataSubject":"{{ownerWebId}}",
             "forPurpose":[
                 "https://purpose.example/212efdf4-e1a4-4dcd-9d3b-d6eb92e0205f",
                 "https://purpose.example/de605b08-76c7-4f04-9cec-a438810b0c03"],


### PR DESCRIPTION
This is adding a more complex test scenarios of the fetch endpoint.
Scenario. 
Alice owns a resource Bob wants to access.
Bob makes an access request
Bob calls the fetch with the id -> this works.
Alice calls the fetch with the same id -> this works too. (because the resource belongs to Alice).

Reworded the java doc on the usage of the recipient in the accessRequest API. (I misunderstood it initially)