### PR TITLE
JCL-416: Reduce maven warnings

### DIFF
--- a/archetypes/java/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/java/src/main/resources/archetype-resources/pom.xml
@@ -10,6 +10,8 @@
   <packaging>jar</packaging>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Java version -->
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -93,4 +95,54 @@
         <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>3.2.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.6.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.3.0</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>3.3.1</version>
+          <configuration>
+            <propertiesEncoding>UTF-8</propertiesEncoding>
+            <encoding>UTF-8</encoding>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -14,23 +14,7 @@
   </description>
   <packaging>pom</packaging>
 
-  <properties>
-    <archetype.plugin.version>3.2.1</archetype.plugin.version>
-  </properties>
-
   <modules>
     <module>java</module>
   </modules>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-archetype-plugin</artifactId>
-          <version>${archetype.plugin.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,13 @@
     <inrupt.rdf.wrapping.version>0.4.0</inrupt.rdf.wrapping.version>
 
     <!-- plugins -->
+    <antrun.plugin.version>3.1.0</antrun.plugin.version>
+    <archetype.plugin.version>3.2.1</archetype.plugin.version>
+    <assembly.plugin.version>3.6.0</assembly.plugin.version>
     <checkstyle.plugin.version>3.3.0</checkstyle.plugin.version>
     <clean.plugin.version>3.2.0</clean.plugin.version>
     <compiler.plugin.version>3.11.0</compiler.plugin.version>
+    <dependency.plugin.version>3.6.0</dependency.plugin.version>
     <deploy.plugin.version>3.1.1</deploy.plugin.version>
     <exec.plugin.version>3.1.0</exec.plugin.version>
     <install.plugin.version>3.1.1</install.plugin.version>
@@ -139,8 +143,28 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-archetype-plugin</artifactId>
+          <version>${archetype.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${deploy.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>${antrun.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${assembly.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>${dependency.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Some of the maven stages use implicitly-defined plugin versions (coming from the 2.x series). This applies to both the main build of the JCL as well as the archetype.

This PR adds explicitly managed plugin versions.