### PR TITLE
JCL-415: Consistency across Solid resource constructors

### DIFF
--- a/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
@@ -45,6 +45,25 @@ public class SolidContainer extends SolidRDFSource {
      * Create a new SolidContainer.
      *
      * @param identifier the container's unique identifier
+     */
+    public SolidContainer(final URI identifier) {
+        this(identifier, null);
+    }
+
+    /**
+     * Create a new SolidContainer.
+     *
+     * @param identifier the container's unique identifier
+     * @param dataset the dataset for this container, may be {@code null}
+     */
+    public SolidContainer(final URI identifier, final Dataset dataset) {
+        this(identifier, dataset, null);
+    }
+
+    /**
+     * Create a new SolidContainer.
+     *
+     * @param identifier the container's unique identifier
      * @param dataset the dataset for this container, may be {@code null}
      * @param metadata the container's metadata, may be {@code null}
      */

--- a/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
@@ -38,6 +38,17 @@ public class SolidNonRDFSource extends NonRDFSource implements SolidResource {
      * @param identifier the resource identifier
      * @param contentType the content type
      * @param entity the entity
+     */
+    public SolidNonRDFSource(final URI identifier, final String contentType, final InputStream entity) {
+        this(identifier, contentType, entity, null);
+    }
+
+    /**
+     * Create a non-RDF-bearing Solid Resource.
+     *
+     * @param identifier the resource identifier
+     * @param contentType the content type
+     * @param entity the entity
      * @param metadata the metadata, may be {@code null}
      */
     public SolidNonRDFSource(final URI identifier, final String contentType, final InputStream entity,

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -20,6 +20,7 @@
  */
 package com.inrupt.client.solid;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.ClientProvider;
@@ -28,7 +29,9 @@ import com.inrupt.client.Response;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.spi.RDFFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -211,6 +214,15 @@ class SolidClientTest {
                 assertDoesNotThrow(client.delete(b.getIdentifier()).toCompletableFuture()::join);
             }
         }).toCompletableFuture().join();
+    }
+
+    @Test
+    void testBinaryCreate() throws IOException {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/binary");
+        final InputStream entity = new ByteArrayInputStream("This is a plain text document.".getBytes(UTF_8));
+
+        final SolidNonRDFSource binary = new SolidNonRDFSource(uri, "text/plain", entity);
+        assertDoesNotThrow(client.create(binary).toCompletableFuture()::join);
     }
 
     @Test

--- a/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
@@ -173,7 +173,7 @@ class SolidRDFSourceTest {
     @Test
     void testEmptyContainerBuilder() {
         final URI id = URI.create("https://resource.example/");
-        try (final SolidContainer res = new SolidContainer(id, null, null)) {
+        try (final SolidContainer res = new SolidContainer(id)) {
             assertFalse(res.getMetadata().getStorage().isPresent());
             assertFalse(res.getMetadata().getAcl().isPresent());
             assertTrue(res.getMetadata().getAllowedPatchSyntaxes().isEmpty());


### PR DESCRIPTION
The SolidRDFSource resource has three constructors available to developers, but SolidContainer and SolidNonRDFSource each have only one.

This PR adds some overloads to the SolidContainer and SolidNonRDFSource classes so that developers creating these objects themselves can more easily construct the objects.