### PR TITLE
JCL-417: Validate LDP containment data in SolidContainer::getResources

### DIFF
--- a/api/src/main/java/com/inrupt/client/ValidationResult.java
+++ b/api/src/main/java/com/inrupt/client/ValidationResult.java
@@ -38,8 +38,18 @@ public class ValidationResult {
      * @param messages the messages from validation method
      */
     public ValidationResult(final boolean valid, final String... messages) {
+        this(valid, Arrays.asList(messages));
+    }
+
+    /**
+     * Create a ValidationResult object.
+     *
+     * @param valid the result from validation
+     * @param messages the messages from validation method
+     */
+    public ValidationResult(final boolean valid, final List<String> messages) {
         this.valid = valid;
-        this.result = Arrays.asList(messages);
+        this.result = messages;
     }
 
     /**

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -28,6 +28,7 @@ import com.inrupt.client.Headers;
 import com.inrupt.client.Response;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.spi.RDFFactory;
+import com.inrupt.client.util.URIBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -36,6 +37,7 @@ import java.net.URI;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.RDF;
@@ -212,6 +214,22 @@ class SolidClientTest {
                 assertDoesNotThrow(client.create(b).toCompletableFuture()::join);
                 assertDoesNotThrow(client.delete(b).toCompletableFuture()::join);
                 assertDoesNotThrow(client.delete(b.getIdentifier()).toCompletableFuture()::join);
+            }
+        }).toCompletableFuture().join();
+    }
+
+    @Test
+    void testSolidContainer() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/container/");
+        final Set<URI> expected = new HashSet<>();
+        expected.add(URIBuilder.newBuilder(uri).path("newContainer/").build());
+        expected.add(URIBuilder.newBuilder(uri).path("test.txt").build());
+        expected.add(URIBuilder.newBuilder(uri).path("test2.txt").build());
+
+        client.read(uri, SolidContainer.class).thenAccept(container -> {
+            try (final SolidContainer c = container) {
+                assertEquals(expected,
+                        c.getResources().stream().map(SolidResource::getIdentifier).collect(Collectors.toSet()));
             }
         }).toCompletableFuture().join();
     }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
@@ -149,6 +149,40 @@ public class SolidMockHttpService {
             .willReturn(aResponse()
                 .withStatus(204)));
 
+        wireMockServer.stubFor(get(urlEqualTo("/playlists/"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/turtle")
+                .withHeader("Link", Link.of(LDP.BasicContainer, "type").toString())
+                .withHeader("Link", Link.of(URI.create("http://storage.example/"),
+                        PIM.storage).toString())
+                .withHeader("Link", Link.of(URI.create("https://history.test/"), "timegate").toString())
+                .withHeader("Link", Link.of(URI.create("http://acl.example/playlists"), "acl").toString())
+                .withHeader("WAC-Allow", "user=\"read write\",public=\"read\"")
+                .withHeader("Allow", "POST, PUT, PATCH")
+                .withHeader("Accept-Post", "application/ld+json, text/turtle")
+                .withHeader("Accept-Put", "application/ld+json, text/turtle")
+                .withHeader("Accept-Patch", "application/sparql-update, text/n3")
+                .withBodyFile("playlist.ttl")
+            )
+        );
+
+        wireMockServer.stubFor(put(urlEqualTo("/playlists/"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .withHeader("Content-Type", containing("text/turtle"))
+            .withRequestBody(containing(
+                    "<https://library.test/12345/song1.mp3>"))
+            .willReturn(aResponse()
+                .withStatus(204)));
+
+        wireMockServer.stubFor(delete(urlEqualTo("/playlists/"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(204)));
+
+
+
 
         wireMockServer.stubFor(get(urlEqualTo("/playlist"))
             .withHeader("User-Agent", equalTo(USER_AGENT))
@@ -159,7 +193,7 @@ public class SolidMockHttpService {
                 .withHeader("Link", Link.of(URI.create("http://storage.example/"),
                         PIM.storage).toString())
                 .withHeader("Link", Link.of(URI.create("https://history.test/"), "timegate").toString())
-                .withHeader("Link", Link.of(URI.create("http://acl.example/playlist"), "acl").toString())
+                .withHeader("Link", Link.of(URI.create("http://acl.example/playlists"), "acl").toString())
                 .withHeader("WAC-Allow", "user=\"read write\",public=\"read\"")
                 .withHeader("Allow", "POST, PUT, PATCH")
                 .withHeader("Accept-Post", "application/ld+json, text/turtle")

--- a/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidMockHttpService.java
@@ -80,6 +80,25 @@ public class SolidMockHttpService {
             )
         );
 
+        wireMockServer.stubFor(get(urlEqualTo("/container/"))
+            .withHeader("User-Agent", equalTo(USER_AGENT))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "text/turtle")
+                .withHeader("Link", Link.of(LDP.BasicContainer, "type").toString())
+                .withHeader("Link", Link.of(URI.create("http://acl.example/solid/"), "acl").toString())
+                .withHeader("Link", Link.of(URI.create("http://storage.example/"),
+                        PIM.storage).toString())
+                .withHeader("Link", Link.of(URI.create("https://history.test/"), "timegate").toString())
+                .withHeader("WAC-Allow", "user=\"read write\",public=\"read\"")
+                .withHeader("Allow", "POST, PUT, PATCH")
+                .withHeader("Accept-Post", "application/ld+json, text/turtle")
+                .withHeader("Accept-Put", "application/ld+json, text/turtle")
+                .withHeader("Accept-Patch", "application/sparql-update, text/n3")
+                .withBodyFile("container.ttl")
+            )
+        );
+
         wireMockServer.stubFor(get(urlEqualTo("/recipe"))
             .withHeader("User-Agent", equalTo(USER_AGENT))
             .willReturn(aResponse()

--- a/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidSyncClientTest.java
@@ -134,7 +134,7 @@ class SolidSyncClientTest {
 
     @Test
     void testGetContainer() {
-        final URI uri = URI.create(config.get("solid_resource_uri") + "/playlist");
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/playlists/");
 
         try (final SolidContainer container = client.read(uri, SolidContainer.class)) {
             assertEquals(uri, container.getIdentifier());
@@ -154,6 +154,12 @@ class SolidSyncClientTest {
             assertDoesNotThrow(() -> client.delete(container));
             assertDoesNotThrow(() -> client.delete(container.getIdentifier()));
         }
+    }
+
+    @Test
+    void testGetContainerDataMappingError() {
+        final URI uri = URI.create(config.get("solid_resource_uri") + "/playlist");
+        assertThrows(DataMappingException.class, () -> client.read(uri, SolidContainer.class));
     }
 
     @Test

--- a/solid/src/test/resources/__files/container.ttl
+++ b/solid/src/test/resources/__files/container.ttl
@@ -1,0 +1,25 @@
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ldp: <http://www.w3.org/ns/ldp#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix pl: <http://www.w3.org/ns/iana/media-types/text/plain#>.
+
+<>
+    a ldp:BasicContainer ;
+    dct:modified "2022-11-25T10:36:36Z"^^xsd:dateTime;
+    ldp:contains <newContainer/>, <test.txt>, <test2.txt> .
+<newContainer/>
+    a ldp:BasicContainer ;
+    dct:modified "2022-11-25T10:36:36Z"^^xsd:dateTime .
+<test.txt>
+    a pl:Resource, ldp:NonRDFSource;
+    dct:modified "2022-11-25T10:34:14Z"^^xsd:dateTime .
+<test2.txt>
+    a pl:Resource, ldp:NonRDFSource;
+    dct:modified "2022-11-25T10:37:06Z"^^xsd:dateTime .
+
+# These containment triples should not be included in a getResources response
+<>
+    ldp:contains <https://example.com/other> , <newContainer/child> , <> , <./> .
+<https://example.test/container/>
+    a ldp:BasicContainer ;
+    ldp:contains <https://example.test/container/external> .


### PR DESCRIPTION
At present, the `SolidContainer::getResources` method includes references to every resource that fits the pattern:

    ?container ldp:contains ?child

Where `?container` is the target container resource. This means that a non-compliant server could return a set of (apparent) child resources that are not really part of the Solid containment hierarchy. For applications that are built with the Solid specification in mind, it could lead to unexpected behavior.