### PR TITLE
JCL-394: Issued At javadoc

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -118,6 +118,11 @@ public class AccessCredential {
         return expiration != null ? expiration : Instant.MAX;
     }
 
+    /**
+     * Get the issuance date for the credential.
+     *
+     * @return the issuance date
+     */
     public Instant getIssuedAt() {
         return issuedAt;
     }


### PR DESCRIPTION
The issuance date is already supported by AccessCredential subtypes, but the base class is missing a javadoc.