### PR TITLE
JCL-419: harden e2e code

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -30,8 +30,6 @@ All the possible value are listed next:
 * `inrupt.test.client-secret` // mandatory
 * `inrupt.test.auth-method` // default is `client_secret_basic`
 * `inrupt.test.webid`
-* `inrupt.test.public-resource-path` // default is no dedicated container, everything gets created on the storage root
-* `inrupt.test.private-resource-path` // default is a container named `private`
 * `inrupt.test.access-grant.provider`
 * `inrupt.test.requester.webid`
 * `inrupt.test.requester.client-id` // mandatory
@@ -45,7 +43,6 @@ Optional fields are:
 * `inrupt.test.webid` is needed only if we want to run the integration tests on a live service. Otherwise, this property needs to be left out because it will be populated by the Mocked services with a mock username called `someuser`.
 * `inrupt.test.requester.webid` is only needed in the access grants test scenarios and can be also left empty because the Mocked services will create a username called `requester`.
 * `inrupt.test.auth-method` refers to the [client authentication](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication) method and has a default value of `client_secret_basic`. This value is used when this property is not provided.
-* `inrupt.test.public-resource-path` & `inrupt.test.private-resource-path` are properties used to fine grain the containers we use for testing.
 
 ## The embedded Mock Solid Server
 
@@ -58,7 +55,7 @@ The Mock Solid Server is actually a collection of services which try to mock, as
   * provide a token on its token endpoint (found under `oauth/oauth20/token`);
   * provide a jwks on its jwks endpoint (found under `oauth/jwks`).
 
-* `MockSolidServer` - mocks the storage service of a Pod provider. It mocks the behavior of private and public resources by looking if the resource path contains the `inrupt.test.private-resource-path`. And it mocks, according to Solid Protocol methods like GET, PUT, POST and PATCH.
+* `MockSolidServer` - mocks the storage service of a Pod provider. It mocks the behavior of private and public resources by looking if the resource path contains the `State.PRIVATE_RESOURCE_PATH` which is set to `private`. And it mocks, according to Solid Protocol methods like GET, PUT, POST, HEAD and PATCH.
 
 * `MockUMAAuthorizationServer` - mocks the authorization service, in our case a UMA service. UMA authorization is the default, hard-coded, in the Mocked services. This can be seen in any request on a private resource in the MockSolidServer. When not authorized, the Solid Server will respond with a WWW-Authenticate header which contains a UMA ticket.
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -94,10 +94,6 @@ public class AccessGrantScenarios {
         .orElse("client_secret_basic");
 
     protected static String ACCESS_GRANT_PROVIDER;
-    private static final String PRIVATE_RESOURCE_PATH = config
-        .getOptionalValue("inrupt.test.private-resource-path", String.class)
-        .orElse("private");
-
     protected static final String GRANT_MODE_READ = "Read";
     private static final String GRANT_MODE_APPEND = "Append";
     private static final String GRANT_MODE_WRITE = "Write";
@@ -137,7 +133,6 @@ public class AccessGrantScenarios {
                 .build()
                 .toString());
 
-        State.PRIVATE_RESOURCE_PATH = PRIVATE_RESOURCE_PATH;
         State.WEBID = URI.create(webidUrl);
         final SolidSyncClient client = SolidSyncClient.getClientBuilder().build();
         try (final WebIdProfile profile = client.read(URI.create(webidUrl), WebIdProfile.class)) {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -219,7 +219,7 @@ public class AccessGrantScenarios {
             if (privateContainerURI != null) {
                 Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
             }
-        }  catch (SolidClientException ex) {
+        }  catch (SolidClientException ignored) {
             //do nothing because we are only cleaning up
         }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -153,8 +153,6 @@ public class AccessGrantScenarios {
                 .path(State.PRIVATE_RESOURCE_PATH + "-access-test-" + UUID.randomUUID() + "/")
                 .build();
 
-        //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-        Utils.deleteContentsRecursively(authResourceOwnerClient, privateContainerURI);
         Utils.createContainer(authResourceOwnerClient, privateContainerURI);
         prepareAcpOfResource(authResourceOwnerClient, privateContainerURI, SolidRDFSource.class);
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -158,7 +158,6 @@ public class AccessGrantScenarios {
         authResourceOwnerClient = createAuthenticatedClient();
         //if a tests fails it can be that the cleanup was not properly done, so we do it here too
         Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
-        client.send(Request.newBuilder(privateContainerURI).DELETE().build(), Response.BodyHandlers.discarding());
         Utils.createContainer(authResourceOwnerClient, privateContainerURI);
 
         testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
@@ -219,7 +218,6 @@ public class AccessGrantScenarios {
         }
         if (privateContainerURI != null) {
             Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
-            authResourceOwnerClient.delete(privateContainerURI);
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -157,7 +157,7 @@ public class AccessGrantScenarios {
 
         authResourceOwnerClient = createAuthenticatedClient();
         //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-        Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
+        Utils.deleteContentsRecursively(authResourceOwnerClient, privateContainerURI);
 
         testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(State.PRIVATE_RESOURCE_PATH)
@@ -217,7 +217,7 @@ public class AccessGrantScenarios {
                 authResourceOwnerClient.delete(testContainerURI);
             }
             if (privateContainerURI != null) {
-                Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
+                Utils.deleteContentsRecursively(authResourceOwnerClient, privateContainerURI);
             }
         }  catch (SolidClientException ignored) {
             //do nothing because we are only cleaning up

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -158,7 +158,6 @@ public class AccessGrantScenarios {
         authResourceOwnerClient = createAuthenticatedClient();
         //if a tests fails it can be that the cleanup was not properly done, so we do it here too
         Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
-        //Utils.createContainer(authResourceOwnerClient, privateContainerURI);
 
         testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(State.PRIVATE_RESOURCE_PATH)

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -209,14 +209,18 @@ public class AccessGrantScenarios {
     @AfterAll
     static void teardown() {
         //cleanup pod
-        if (sharedTextFileURI != null) {
-            authResourceOwnerClient.delete(sharedTextFileURI);
-        }
-        if (testContainerURI != null) {
-            authResourceOwnerClient.delete(testContainerURI);
-        }
-        if (privateContainerURI != null) {
-            Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
+        try {
+            if (sharedTextFileURI != null) {
+                authResourceOwnerClient.delete(sharedTextFileURI);
+            }
+            if (testContainerURI != null) {
+                authResourceOwnerClient.delete(testContainerURI);
+            }
+            if (privateContainerURI != null) {
+                Utils.cleanContainerContent(authResourceOwnerClient, privateContainerURI);
+            }
+        }  catch (SolidClientException ex) {
+            //do nothing because we are only cleaning up
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -144,7 +144,7 @@ public class AuthenticationScenarios {
                     .path(PUBLIC_RESOURCE_PATH + "/").build();
 
             //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-            Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+            Utils.deleteContentsRecursively(localAuthClient, publicContainerURI);
             Utils.createPublicContainer(localAuthClient, publicContainerURI);
         }
 
@@ -164,7 +164,7 @@ public class AuthenticationScenarios {
         privateContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(PRIVATE_RESOURCE_PATH + "/").build();
         //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-        Utils.cleanContainerContent(localAuthClient, privateContainerURI);
+        Utils.deleteContentsRecursively(localAuthClient, privateContainerURI);
         Utils.createContainer(localAuthClient, privateContainerURI);
 
         LOGGER.info("Integration Test Issuer: [{}]", issuer);
@@ -178,10 +178,10 @@ public class AuthenticationScenarios {
                 localAuthClient.delete(publicTestContainerURI);
             }
             if (PUBLIC_RESOURCE_PATH != null) {
-                Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+                Utils.deleteContentsRecursively(localAuthClient, publicContainerURI);
             }
             if (privateContainerURI != null) {
-                Utils.cleanContainerContent(localAuthClient, privateContainerURI);
+                Utils.deleteContentsRecursively(localAuthClient, privateContainerURI);
             }
         } catch (SolidClientException ignored) {
             //do nothing because we are only cleaning up

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -131,8 +131,6 @@ public class AuthenticationScenarios {
                 .path(testResourceName)
                 .build();
 
-        //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-        Utils.deleteContentsRecursively(localAuthClient, publicContainerURI);
         Utils.createPublicContainer(localAuthClient, publicContainerURI);
 
         privateContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
@@ -143,8 +141,6 @@ public class AuthenticationScenarios {
             .path(testResourceName)
             .build();
 
-        //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-        Utils.deleteContentsRecursively(localAuthClient, privateContainerURI);
         Utils.createContainer(localAuthClient, privateContainerURI);
 
         LOGGER.info("Integration Test Issuer: [{}]", issuer);

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -173,14 +173,18 @@ public class AuthenticationScenarios {
     @AfterAll
     static void teardown() {
         //cleanup pod
-        if (publicTestContainerURI != null) {
-            localAuthClient.delete(publicTestContainerURI);
-        }
-        if (PUBLIC_RESOURCE_PATH != null) {
-            Utils.cleanContainerContent(localAuthClient, publicContainerURI);
-        }
-        if (privateContainerURI != null) {
-            Utils.cleanContainerContent(localAuthClient, privateContainerURI);
+        try {
+            if (publicTestContainerURI != null) {
+                localAuthClient.delete(publicTestContainerURI);
+            }
+            if (PUBLIC_RESOURCE_PATH != null) {
+                Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+            }
+            if (privateContainerURI != null) {
+                Utils.cleanContainerContent(localAuthClient, privateContainerURI);
+            }
+        } catch (SolidClientException ex) {
+            //do nothing because we are only cleaning up
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -75,9 +75,6 @@ public class AuthenticationScenarios {
     private static final String AUTH_METHOD = config
         .getOptionalValue("inrupt.test.auth-method", String.class)
         .orElse("client_secret_basic");
-    private static final String PRIVATE_RESOURCE_PATH = config
-        .getOptionalValue("inrupt.test.private-resource-path", String.class)
-        .orElse("private");
     private static SolidSyncClient localAuthClient;
 
     @BeforeAll
@@ -96,8 +93,6 @@ public class AuthenticationScenarios {
             identityProviderServer.getMockServerUrl(),
             MOCK_USERNAME);
         webIdService.start();
-
-        State.PRIVATE_RESOURCE_PATH = PRIVATE_RESOURCE_PATH;
 
         webidUrl = config
             .getOptionalValue("inrupt.test.webid", String.class)

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -131,13 +131,13 @@ public class AuthenticationScenarios {
 
         if (PUBLIC_RESOURCE_PATH.isEmpty()) {
             publicTestContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                    .path("test-" + UUID.randomUUID())
+                    .path("auth-test-" + UUID.randomUUID())
                     .build();
 
         } else {
             publicTestContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(PUBLIC_RESOURCE_PATH)
-                .path("test-" + UUID.randomUUID())
+                .path("auth-test-" + UUID.randomUUID())
                 .build();
 
             publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
@@ -154,7 +154,7 @@ public class AuthenticationScenarios {
 
         privateTestContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(State.PRIVATE_RESOURCE_PATH)
-                .path("test-" + UUID.randomUUID())
+                .path("auth-test-" + UUID.randomUUID())
                 .build();
 
         privateResourceURI = URIBuilder.newBuilder(privateTestContainerURI)

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -183,7 +183,7 @@ public class AuthenticationScenarios {
             if (privateContainerURI != null) {
                 Utils.cleanContainerContent(localAuthClient, privateContainerURI);
             }
-        } catch (SolidClientException ex) {
+        } catch (SolidClientException ignored) {
             //do nothing because we are only cleaning up
         }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -22,8 +22,6 @@ package com.inrupt.client.integration.base;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.inrupt.client.Request;
-import com.inrupt.client.Response;
 import com.inrupt.client.auth.Credential;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.openid.OpenIdException;
@@ -147,7 +145,6 @@ public class AuthenticationScenarios {
 
             //if a tests fails it can be that the cleanup was not properly done, so we do it here too
             Utils.cleanContainerContent(localAuthClient, publicContainerURI);
-            localAuthClient.delete(publicContainerURI);
             Utils.createPublicContainer(localAuthClient, publicContainerURI);
         }
 
@@ -168,8 +165,6 @@ public class AuthenticationScenarios {
                 .path(PRIVATE_RESOURCE_PATH + "/").build();
         //if a tests fails it can be that the cleanup was not properly done, so we do it here too
         Utils.cleanContainerContent(localAuthClient, privateContainerURI);
-        localAuthClient.send(Request.newBuilder(privateContainerURI).DELETE().build(),
-                Response.BodyHandlers.discarding());
         Utils.createContainer(localAuthClient, privateContainerURI);
 
         LOGGER.info("Integration Test Issuer: [{}]", issuer);
@@ -183,11 +178,9 @@ public class AuthenticationScenarios {
         }
         if (PUBLIC_RESOURCE_PATH != null) {
             Utils.cleanContainerContent(localAuthClient, publicContainerURI);
-            localAuthClient.delete(publicContainerURI);
         }
         if (privateContainerURI != null) {
             Utils.cleanContainerContent(localAuthClient, privateContainerURI);
-            localAuthClient.delete(privateContainerURI);
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -138,8 +138,6 @@ public class CoreModulesResource {
                 .path("public-core-test-" + UUID.randomUUID() + "/")
                 .build();
 
-        //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-        Utils.deleteContentsRecursively(localAuthClient, publicContainerURI);
         Utils.createPublicContainer(localAuthClient, publicContainerURI);
 
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -161,13 +161,17 @@ public class CoreModulesResource {
     @AfterAll
     static void teardown() {
         //cleanup pod
-        if (testContainerURI != null) {
-            client.send(Request.newBuilder(testContainerURI).DELETE().build(), Response.BodyHandlers.discarding());
-            client.send(Request.newBuilder(testContainerURI.resolve("..")).DELETE().build(),
-                    Response.BodyHandlers.discarding());
-        }
-        if (publicContainerURI != null) {
-            Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+        try {
+            if (testContainerURI != null) {
+                client.send(Request.newBuilder(testContainerURI).DELETE().build(), Response.BodyHandlers.discarding());
+                client.send(Request.newBuilder(testContainerURI.resolve("..")).DELETE().build(),
+                        Response.BodyHandlers.discarding());
+            }
+            if (publicContainerURI != null) {
+                Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+            }
+        } catch (SolidClientException ex) {
+            //do nothing because we are only cleaning up
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -170,7 +170,7 @@ public class CoreModulesResource {
             if (publicContainerURI != null) {
                 Utils.cleanContainerContent(localAuthClient, publicContainerURI);
             }
-        } catch (SolidClientException ex) {
+        } catch (SolidClientException ignored) {
             //do nothing because we are only cleaning up
         }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -87,7 +87,7 @@ public class CoreModulesResource {
     private static URI testContainerURI;
     private static URI publicContainerURI;
 
-    private static SolidSyncClient authClient;
+    private static SolidClient localAuthClient;
     private static final String AUTH_METHOD = config
             .getOptionalValue("inrupt.test.auth-method", String.class)
             .orElse("client_secret_basic");
@@ -143,9 +143,14 @@ public class CoreModulesResource {
 
             publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                     .path(PUBLIC_RESOURCE_PATH + "/").build();
-            createAuthenticatedClient();
-            createContainer(publicContainerURI);
-            prepareACR(publicContainerURI);
+            final Session session = OpenIdSession.ofClientCredentials(
+                    URI.create(issuer), //Client credentials
+                    CLIENT_ID,
+                    CLIENT_SECRET,
+                    AUTH_METHOD);
+
+            localAuthClient = SolidClient.getClient().session(session);
+            Utils.createPublicContainer(localAuthClient, publicContainerURI);
         }
 
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());
@@ -158,8 +163,8 @@ public class CoreModulesResource {
         client.send(Request.newBuilder(testContainerURI.resolve("..")).DELETE().build(),
                 Response.BodyHandlers.discarding());
         if (publicContainerURI != null) {
-            authClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
-                    Response.BodyHandlers.discarding());
+            localAuthClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
+                    Response.BodyHandlers.discarding()).toCompletableFuture().join();
         }
 
         mockHttpServer.stop();
@@ -470,42 +475,5 @@ public class CoreModulesResource {
         return sparql;
     }
 
-    private static void createAuthenticatedClient() {
-        final Session session = OpenIdSession.ofClientCredentials(
-                URI.create(issuer), //Client credentials
-                CLIENT_ID,
-                CLIENT_SECRET,
-                AUTH_METHOD);
-
-        authClient = SolidSyncClient.getClient().session(session);
-    }
-
-    private static void createContainer(final URI publicContainerURI) {
-        final var requestCreate = Request.newBuilder(publicContainerURI)
-                .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
-                .header(LINK, Headers.Link.of(LDP.RDFSource, TYPE).toString())
-                .PUT(Request.BodyPublishers.noBody())
-                .build();
-        final var resCreate =
-                authClient.send(requestCreate, Response.BodyHandlers.discarding());
-        assertTrue(Utils.isSuccessful(resCreate.statusCode()));
-    }
-
-    private static void prepareACR(final URI publicContainerURI) {
-        try (SolidResource resource = authClient.read(publicContainerURI, SolidRDFSource.class)) {
-            if (resource != null) {
-                // find the acl Link in the header of the resource
-                resource.getMetadata().getAcl().ifPresent(acl -> {
-                    try (final SolidRDFSource acr = authClient.read(acl, SolidRDFSource.class)) {
-                        Utils.publicAgentPolicyTriples(acl)
-                                .forEach(acr.getGraph()::add);
-                        authClient.update(acr);
-                    }
-                });
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -132,12 +132,12 @@ public class CoreModulesResource {
         }
         if (PUBLIC_RESOURCE_PATH.isEmpty()) {
             testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path("test-" + UUID.randomUUID())
+                .path("core-test-" + UUID.randomUUID())
                 .path(testContainer).build();
         } else {
             testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(PUBLIC_RESOURCE_PATH)
-                .path("test-" + UUID.randomUUID())
+                .path("core-test-" + UUID.randomUUID())
                 .path(testContainer)
                 .build();
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -152,8 +152,6 @@ public class CoreModulesResource {
             localAuthClient = SolidSyncClient.getClient().session(session);
             //if a tests fails it can be that the cleanup was not properly done, so we do it here too
             Utils.cleanContainerContent(localAuthClient, publicContainerURI);
-            localAuthClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
-                    Response.BodyHandlers.discarding());
             Utils.createPublicContainer(localAuthClient, publicContainerURI);
         }
 
@@ -170,8 +168,6 @@ public class CoreModulesResource {
         }
         if (publicContainerURI != null) {
             Utils.cleanContainerContent(localAuthClient, publicContainerURI);
-            localAuthClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
-                    Response.BodyHandlers.discarding());
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/CoreModulesResource.java
@@ -76,14 +76,9 @@ public class CoreModulesResource {
     private static final String MOCK_USERNAME = "someuser";
     private static final String TYPE = "type";
     private static final String LINK = "Link";
-    private static URI testContainerURI;
     private static URI publicContainerURI;
 
     private static SolidSyncClient localAuthClient;
-    //this is important for the Mock setup
-    private static final String PRIVATE_RESOURCE_PATH = config
-            .getOptionalValue("inrupt.test.private-resource-path", String.class)
-            .orElse("private");
     private static final String AUTH_METHOD = config
             .getOptionalValue("inrupt.test.auth-method", String.class)
             .orElse("client_secret_basic");
@@ -113,7 +108,6 @@ public class CoreModulesResource {
             .orElse(webIdService.getMockServerUrl() + Utils.FOLDER_SEPARATOR + MOCK_USERNAME);
 
         State.WEBID = URI.create(webidUrl);
-        State.PRIVATE_RESOURCE_PATH = PRIVATE_RESOURCE_PATH; //needed in the Mocks
         //find storage from WebID using only core module
         final Request requestRdf = Request.newBuilder(URI.create(webidUrl)).GET().build();
         final var responseRdf = client.send(requestRdf, JenaBodyHandlers.ofModel());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -133,8 +133,6 @@ public class DomainModulesResource {
                 .path("public-domain-test-" + UUID.randomUUID() + FOLDER_SEPARATOR)
                 .build();
 
-        //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-        Utils.deleteContentsRecursively(localAuthClient, publicContainerURI);
         Utils.createPublicContainer(localAuthClient, publicContainerURI);
 
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -161,7 +161,7 @@ public class DomainModulesResource {
             if (publicContainerURI != null) {
                 Utils.cleanContainerContent(localAuthClient, publicContainerURI);
             }
-        } catch (SolidClientException ex) {
+        } catch (SolidClientException ignored) {
             //do nothing because we are only cleaning up
         }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -30,7 +30,6 @@ import com.inrupt.client.openid.OpenIdSession;
 import com.inrupt.client.solid.*;
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
-import com.inrupt.client.vocabulary.LDP;
 import com.inrupt.client.vocabulary.PIM;
 import com.inrupt.client.webid.WebIdProfile;
 
@@ -90,7 +89,7 @@ public class DomainModulesResource {
     private static URI testContainerURI;
     private static URI publicContainerURI;
 
-    private static SolidSyncClient authClient;
+    private static SolidClient localAuthClient;
 
     @BeforeAll
     static void setup() {
@@ -122,7 +121,14 @@ public class DomainModulesResource {
                 podUrl = storages.iterator().next().toString();
             }
         }
-        createAuthenticatedClient();
+        final Session session = OpenIdSession.ofClientCredentials(
+                URI.create(issuer), //Client credentials
+                CLIENT_ID,
+                CLIENT_SECRET,
+                AUTH_METHOD);
+
+        localAuthClient = SolidClient.getClient().session(session);
+
         if (PUBLIC_RESOURCE_PATH.isEmpty()) {
             testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path("test-" + UUID.randomUUID())
@@ -136,8 +142,8 @@ public class DomainModulesResource {
 
             publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                     .path(PUBLIC_RESOURCE_PATH + FOLDER_SEPARATOR).build();
-            createContainer(publicContainerURI);
-            prepareACR(publicContainerURI);
+
+            Utils.createPublicContainer(localAuthClient, publicContainerURI);
         }
 
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());
@@ -150,8 +156,8 @@ public class DomainModulesResource {
         client.send(Request.newBuilder(testContainerURI.resolve("..")).DELETE().build(),
                 Response.BodyHandlers.discarding());
         if (publicContainerURI != null) {
-            authClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
-                    Response.BodyHandlers.discarding());
+            localAuthClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
+                    Response.BodyHandlers.discarding()).toCompletableFuture().join();
         }
 
         mockHttpServer.stop();
@@ -305,7 +311,8 @@ public class DomainModulesResource {
         while (tempURL.chars().filter(ch -> ch == '/').count() >= 3) {
             final Request req = Request.newBuilder(URI.create(tempURL)).GET().build();
             final Response<SolidRDFSource> headerResponse =
-                    authClient.send(req, SolidResourceHandlers.ofSolidRDFSource());
+                    localAuthClient.send(req, SolidResourceHandlers.ofSolidRDFSource())
+                            .toCompletableFuture().join();
             final var headers = headerResponse.headers();
             final var isRoot = headers.allValues("Link").stream()
                 .flatMap(l -> Headers.Link.parse(l).stream())
@@ -325,7 +332,7 @@ public class DomainModulesResource {
                 .path(PUBLIC_RESOURCE_PATH).build().toString();
         while (!(tempURL.equals(notToDeletePath)) && !(tempURL.equals(notToDeletePath + FOLDER_SEPARATOR))) {
             final var url = new SolidRDFSource(URI.create(tempURL),null, null);
-            authClient.delete(url);
+            localAuthClient.delete(url);
             tempURL = tempURL.substring(0, tempURL.lastIndexOf(FOLDER_SEPARATOR));
             tempURL = tempURL.substring(0, tempURL.lastIndexOf(FOLDER_SEPARATOR) + 1);
         }
@@ -340,43 +347,5 @@ public class DomainModulesResource {
         final var resource = new SolidRDFSource(URI.create(newURL));
         client.create(resource);
         return newURL;
-    }
-
-    private static void createAuthenticatedClient() {
-        final Session session = OpenIdSession.ofClientCredentials(
-                URI.create(issuer), //Client credentials
-                CLIENT_ID,
-                CLIENT_SECRET,
-                AUTH_METHOD);
-
-        authClient = SolidSyncClient.getClient().session(session);
-    }
-
-    private static void createContainer(final URI publicContainerURI) {
-        final var requestCreate = Request.newBuilder(publicContainerURI)
-                .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
-                .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
-                .PUT(Request.BodyPublishers.noBody())
-                .build();
-        final var resCreate =
-                authClient.send(requestCreate, Response.BodyHandlers.discarding());
-        assertTrue(Utils.isSuccessful(resCreate.statusCode()));
-    }
-
-    private static void prepareACR(final URI publicContainerURI) {
-        try (SolidResource resource = authClient.read(publicContainerURI, SolidRDFSource.class)) {
-            if (resource != null) {
-                // find the acl Link in the header of the resource
-                resource.getMetadata().getAcl().ifPresent(acl -> {
-                    try (final SolidRDFSource acr = authClient.read(acl, SolidRDFSource.class)) {
-                        Utils.publicAgentPolicyTriples(acl)
-                                .forEach(acr.getGraph()::add);
-                        authClient.update(acr);
-                    }
-                });
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -131,12 +131,12 @@ public class DomainModulesResource {
 
         if (PUBLIC_RESOURCE_PATH.isEmpty()) {
             testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path("test-" + UUID.randomUUID())
+                .path("domain-test-" + UUID.randomUUID())
                 .path(testContainer).build();
         } else {
             testContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                 .path(PUBLIC_RESOURCE_PATH)
-                .path("test-" + UUID.randomUUID())
+                .path("domain-test-" + UUID.randomUUID())
                 .path(testContainer)
                 .build();
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -161,7 +161,6 @@ public class DomainModulesResource {
         }
         if (publicContainerURI != null) {
             Utils.cleanContainerContent(localAuthClient, publicContainerURI);
-            localAuthClient.delete(publicContainerURI);
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -78,10 +78,6 @@ public class DomainModulesResource {
             .orElse("client_secret_basic");
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
-    //this is important for the Mock setup
-    private static final String PRIVATE_RESOURCE_PATH = config
-            .getOptionalValue("inrupt.test.private-resource-path", String.class)
-            .orElse("private");
     private static final String FOLDER_SEPARATOR = "/";
     private static URI publicContainerURI;
 
@@ -109,7 +105,6 @@ public class DomainModulesResource {
             .orElse(webIdService.getMockServerUrl() + Utils.FOLDER_SEPARATOR + MOCK_USERNAME);
 
         State.WEBID = URI.create(webidUrl);
-        State.PRIVATE_RESOURCE_PATH = PRIVATE_RESOURCE_PATH; //needed in the Mocks
         //find storage from WebID using domain-specific webID solid concept
         try (final WebIdProfile sameProfile = client.read(URI.create(webidUrl), WebIdProfile.class)) {
             final var storages = sameProfile.getStorages();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -31,7 +31,6 @@ import com.inrupt.client.solid.*;
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.vocabulary.PIM;
-import com.inrupt.client.vocabulary.Solid;
 import com.inrupt.client.webid.WebIdProfile;
 
 import java.net.URI;

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -31,6 +31,7 @@ import com.inrupt.client.solid.*;
 import com.inrupt.client.spi.RDFFactory;
 import com.inrupt.client.util.URIBuilder;
 import com.inrupt.client.vocabulary.PIM;
+import com.inrupt.client.vocabulary.Solid;
 import com.inrupt.client.webid.WebIdProfile;
 
 import java.net.URI;
@@ -155,12 +156,16 @@ public class DomainModulesResource {
     @AfterAll
     static void teardown() {
         //cleanup pod
-        if (testContainerURI != null) {
-            client.delete(testContainerURI);
-            client.delete(testContainerURI.resolve(".."));
-        }
-        if (publicContainerURI != null) {
-            Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+        try {
+            if (testContainerURI != null) {
+                client.delete(testContainerURI);
+                client.delete(testContainerURI.resolve(".."));
+            }
+            if (publicContainerURI != null) {
+                Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+            }
+        } catch (SolidClientException ex) {
+            //do nothing because we are only cleaning up
         }
 
         mockHttpServer.stop();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -145,8 +145,6 @@ public class DomainModulesResource {
                     .path(PUBLIC_RESOURCE_PATH + FOLDER_SEPARATOR).build();
             //if a tests fails it can be that the cleanup was not properly done, so we do it here too
             Utils.cleanContainerContent(localAuthClient, publicContainerURI);
-            localAuthClient.send(Request.newBuilder(publicContainerURI).DELETE().build(),
-                    Response.BodyHandlers.discarding());
             Utils.createPublicContainer(localAuthClient, publicContainerURI);
         }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -143,7 +143,7 @@ public class DomainModulesResource {
             publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
                     .path(PUBLIC_RESOURCE_PATH + FOLDER_SEPARATOR).build();
             //if a tests fails it can be that the cleanup was not properly done, so we do it here too
-            Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+            Utils.deleteContentsRecursively(localAuthClient, publicContainerURI);
             Utils.createPublicContainer(localAuthClient, publicContainerURI);
         }
 
@@ -159,7 +159,7 @@ public class DomainModulesResource {
                 client.delete(testContainerURI.resolve(".."));
             }
             if (publicContainerURI != null) {
-                Utils.cleanContainerContent(localAuthClient, publicContainerURI);
+                Utils.deleteContentsRecursively(localAuthClient, publicContainerURI);
             }
         } catch (SolidClientException ignored) {
             //do nothing because we are only cleaning up

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/SolidServerTransformer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/SolidServerTransformer.java
@@ -106,6 +106,15 @@ class SolidServerTransformer extends ResponseDefinitionTransformer {
             return res.build();
         }
 
+        if (request.getMethod().isOneOf(RequestMethod.HEAD)) {
+            if (this.storage.containsKey(request.getUrl())) {
+                res.withStatus(Utils.SUCCESS);
+            } else {
+                res.withStatus(Utils.NOT_FOUND);
+            }
+            res.build();
+        }
+
         if (request.getMethod().isOneOf(RequestMethod.PUT)) {
             final boolean exists = this.storage.containsKey(request.getUrl());
             if (!Utils.WILDCARD.equals(request.getHeader(Utils.IF_NONE_MATCH)) || !exists) {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/State.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/State.java
@@ -25,7 +25,7 @@ import java.net.URI;
 final class State {
 
     static URI WEBID;
-    static String PRIVATE_RESOURCE_PATH;
+    static String PRIVATE_RESOURCE_PATH = "private";
     static final String AZP = "https://localhost:8080";
 
     private State() {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -178,20 +178,16 @@ public final class Utils {
             try (SolidContainer newContainer = new SolidContainer(publicContainerURI)) {
                 try (final SolidContainer container = authClient.create(newContainer)) {
                     container.getMetadata().getAcl().ifPresent(acl -> {
-                        int i = 0; // in case we cannot read the acl, we try 2 times before giving up
-                        while (i <= 1) {
-                            try (final SolidRDFSource acr = authClient.read(acl, SolidRDFSource.class)) {
-                                Utils.publicAgentPolicyTriples(acl)
-                                        .forEach(acr.getGraph()::add);
-                                authClient.update(acr);
-                                i = 2;
-                            } catch (SolidClientException ignored) {
-                                i++;
-                            }
+                        try (final SolidRDFSource acr = authClient.read(acl, SolidRDFSource.class)) {
+                            Utils.publicAgentPolicyTriples(acl)
+                                    .forEach(acr.getGraph()::add);
+                            authClient.update(acr);
+                        } catch (SolidClientException ignored) {
+                            LOGGER.error("Integration tests - Problem reading and modifying the acl");
                         }
                     });
                 } catch (SolidClientException ex) {
-                    LOGGER.debug(ex.getStatusCode() + " " + ex.getCause() + " " + ex.getMessage());
+                    LOGGER.error(ex.getStatusCode() + " " + ex.getCause() + " " + ex.getMessage());
                 }
             }
         }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -208,13 +208,13 @@ public final class Utils {
             try (final SolidContainer container = client.read(containerURI, SolidContainer.class)) {
                 container.getResources().forEach(value -> cleanContainerContent(client, value.getIdentifier()));
                 client.delete(container);
-                LOGGER.info("deleted: " + container.getIdentifier());
+                LOGGER.debug("deleted: " + container.getIdentifier());
             } catch (NotFoundException ex) {
                 //since it is only a cleanup we do not care if it fails
             }
         } else {
             client.delete(containerURI);
-            LOGGER.info("deleted: " + containerURI);
+            LOGGER.debug("deleted: " + containerURI);
         }
     }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -190,6 +190,8 @@ public final class Utils {
                             }
                         }
                     });
+                } catch (SolidClientException ex) {
+                    LOGGER.debug(ex.getStatusCode() + " " + ex.getCause() + " " + ex.getMessage());
                 }
             }
         }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -196,14 +196,21 @@ public final class Utils {
     }
 
     public static void createContainer(final SolidSyncClient authClient, final URI containerURI) {
-        final var requestCreate = Request.newBuilder(containerURI)
-                .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
-                .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
-                .PUT(Request.BodyPublishers.noBody())
+        final var headReq = Request.newBuilder(containerURI)
+                .HEAD()
                 .build();
-        final var resCreate =
-                authClient.send(requestCreate, Response.BodyHandlers.discarding());
-        assertTrue(Utils.isSuccessful(resCreate.statusCode()));
+        final var resCheckIfExists =
+                authClient.send(headReq, Response.BodyHandlers.discarding());
+        if (!Utils.isSuccessful(resCheckIfExists.statusCode())) {
+            final var requestCreate = Request.newBuilder(containerURI)
+                    .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
+                    .header("Link", Headers.Link.of(LDP.RDFSource, "type").toString())
+                    .PUT(Request.BodyPublishers.noBody())
+                    .build();
+            final var resCreate =
+                    authClient.send(requestCreate, Response.BodyHandlers.discarding());
+            assertTrue(Utils.isSuccessful(resCreate.statusCode()));
+        }
     }
 
     static void cleanContainerContent(final SolidSyncClient client, final URI containerURI) {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -206,12 +206,9 @@ public final class Utils {
     static void cleanContainerContent(final SolidSyncClient client, final URI containerURI) {
         if (containerURI != null && containerURI.toString().endsWith("/")) {
             try (final SolidContainer container = client.read(containerURI, SolidContainer.class)) {
-                if (container.getResources().size() == 0) {
-                    client.delete(container);
-                    LOGGER.info("deleted: " + container.getIdentifier());
-                } else {
-                    container.getResources().forEach(value -> cleanContainerContent(client, value.getIdentifier()));
-                }
+                container.getResources().forEach(value -> cleanContainerContent(client, value.getIdentifier()));
+                client.delete(container);
+                LOGGER.info("deleted: " + container.getIdentifier());
             } catch (NotFoundException ex) {
                 //since it is only a cleanup we do not care if it fails
             }


### PR DESCRIPTION
We saw lately too many CI problems. On investigation, it turned out that the problem occurs because the tests do not do a proper cleanup.
A solution here is to also clean up before starting the tests (making sure the containers are empty for example).

It still happens that some tests randomly fail, I am not sure if we can simply up the retry number...