### PR TITLE
JCL-394: AccessRequest builder

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -30,6 +30,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -130,6 +132,126 @@ public class AccessRequest extends AccessCredential {
                 return new AccessRequest(identifier, serialization, credentialData, credentialMetadata);
             } else {
                 throw new IllegalArgumentException("Invalid Access Request: missing VerifiablePresentation type");
+            }
+        }
+    }
+
+    public static class RequestParameters {
+
+        private final URI recipient;
+        private final Set<URI> resources;
+        private final Set<String> modes;
+        private final Set<URI> purposes;
+        private final Instant expiration;
+        private final Instant issuedAt;
+
+        RequestParameters(final URI recipient, final Set<URI> resources,
+                final Set<String> modes, final Set<URI> purposes, final Instant expiration, final Instant issuedAt) {
+            this.recipient = recipient;
+            this.resources = resources;
+            this.modes = modes;
+            this.purposes = purposes;
+            this.expiration = expiration;
+            this.issuedAt = issuedAt;
+        }
+
+        public URI getRecipient() {
+            return recipient;
+        }
+
+        public Set<URI> getResources() {
+            return resources;
+        }
+
+        public Set<String> getModes() {
+            return modes;
+        }
+
+        public Set<URI> getPurposes() {
+            return purposes;
+        }
+
+        public Instant getExpiration() {
+            return expiration;
+        }
+
+        public Instant getIssuedAt() {
+            return issuedAt;
+        }
+
+        public static class Builder {
+
+            private final Set<URI> builderResources = new HashSet<>();
+            private final Set<String> builderModes = new HashSet<>();
+            private final Set<URI> builderPurposes = new HashSet<>();
+            private URI builderRecipient;
+            private Instant builderExpiration;
+            private Instant builderIssuedAt;
+
+            Builder() {
+                // Prevent external instantiation
+            }
+
+            public Builder recipient(final URI recipient) {
+                builderRecipient = recipient;
+                return this;
+            }
+
+            public Builder resource(final URI resource) {
+                builderResources.add(resource);
+                return this;
+            }
+
+            public Builder resources(final Collection<URI> resources) {
+                if (resources != null) {
+                    builderResources.addAll(resources);
+                } else {
+                    builderResources.clear();
+                }
+                return this;
+            }
+
+            public Builder mode(final String mode) {
+                builderModes.add(mode);
+                return this;
+            }
+
+            public Builder modes(final Collection<String> modes) {
+                if (modes != null) {
+                    builderModes.addAll(modes);
+                } else {
+                    builderModes.clear();
+                }
+                return this;
+            }
+
+            public Builder purpose(final URI purpose) {
+                builderPurposes.add(purpose);
+                return this;
+            }
+
+            public Builder purposes(final Collection<URI> purposes) {
+                if (purposes != null) {
+                    builderPurposes.addAll(purposes);
+                } else {
+                    builderPurposes.clear();
+                }
+                return this;
+            }
+
+            public Builder expiration(final Instant expiration) {
+                builderExpiration = expiration;
+                return this;
+            }
+
+            public Builder issuedAt(final Instant issuedAt) {
+                builderIssuedAt = issuedAt;
+                return this;
+            }
+
+            public RequestParameters build() {
+                return new RequestParameters(builderRecipient, builderResources, builderModes, builderPurposes,
+                        builderExpiration, builderIssuedAt);
             }
         }
     }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -222,6 +222,15 @@ public class AccessRequest extends AccessCredential {
         }
 
         /**
+         * Create a new {@link RequestParameters} builder.
+         *
+         * @return the new builder
+         */
+        public static Builder newBuilder() {
+            return new Builder();
+        }
+
+        /**
          * A class for building access request parameters.
          */
         public static class Builder {

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -136,6 +136,11 @@ public class AccessRequest extends AccessCredential {
         }
     }
 
+    /**
+     * A collection of parameters used for creating access requests.
+     *
+     * <p>See, in particular, the {@link AccessGrantClient.requestAccess(RequestParameters)} method.
+     */
     public static class RequestParameters {
 
         private final URI recipient;
@@ -145,6 +150,7 @@ public class AccessRequest extends AccessCredential {
         private final Instant expiration;
         private final Instant issuedAt;
 
+        /* package private */
         RequestParameters(final URI recipient, final Set<URI> resources,
                 final Set<String> modes, final Set<URI> purposes, final Instant expiration, final Instant issuedAt) {
             this.recipient = recipient;
@@ -155,26 +161,62 @@ public class AccessRequest extends AccessCredential {
             this.issuedAt = issuedAt;
         }
 
+        /**
+         * Get the recipient used with an access request operation.
+         *
+         * <p>Note: the recipient will typically be the resource owner
+         *
+         * @return the recipient's identifier
+         */
         public URI getRecipient() {
             return recipient;
         }
 
+        /**
+         * Get the resources used with an access request operation.
+         *
+         * @return the resource idnetifiers
+         */
         public Set<URI> getResources() {
             return resources;
         }
 
+        /**
+         * Get the access modes used with an access request operation.
+         *
+         * @return the access modes
+         */
         public Set<String> getModes() {
             return modes;
         }
 
+        /**
+         * Get the purpose identifiers used with an access request operation.
+         *
+         * @return the purpose identifiers
+         */
         public Set<URI> getPurposes() {
             return purposes;
         }
 
+        /**
+         * Get the requested expiration date used with an access request operation.
+         *
+         * <p>Note: an access grant server may select a different expiration date
+         *
+         * @return the requested expiration date
+         */
         public Instant getExpiration() {
             return expiration;
         }
 
+        /**
+         * Get the requested issuance date used with an access request operation.
+         *
+         * <p>Note: an access grant server may select a different issuance date
+         *
+         * @return the requested issuance date
+         */
         public Instant getIssuedAt() {
             return issuedAt;
         }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessRequest.java
@@ -139,7 +139,7 @@ public class AccessRequest extends AccessCredential {
     /**
      * A collection of parameters used for creating access requests.
      *
-     * <p>See, in particular, the {@link AccessGrantClient.requestAccess(RequestParameters)} method.
+     * <p>See, in particular, the {@link AccessGrantClient#requestAccess(RequestParameters)} method.
      */
     public static class RequestParameters {
 
@@ -221,6 +221,9 @@ public class AccessRequest extends AccessCredential {
             return issuedAt;
         }
 
+        /**
+         * A class for building access request parameters.
+         */
         public static class Builder {
 
             private final Set<URI> builderResources = new HashSet<>();
@@ -230,20 +233,43 @@ public class AccessRequest extends AccessCredential {
             private Instant builderExpiration;
             private Instant builderIssuedAt;
 
+            /* package-private */
             Builder() {
                 // Prevent external instantiation
             }
 
+            /**
+             * Set a recipient for the access request operation.
+             *
+             * <p>Note: this will typically be the identifier of resource owner
+             *
+             * @param recipient the recipient identifier, may be {@code null}
+             * @return this builder
+             */
             public Builder recipient(final URI recipient) {
                 builderRecipient = recipient;
                 return this;
             }
 
+            /**
+             * Set a single resource for the access request operation.
+             *
+             * @param resource the resource identifier, not {@code null}
+             * @return this builder
+             */
             public Builder resource(final URI resource) {
                 builderResources.add(resource);
                 return this;
             }
 
+            /**
+             * Set multiple resources for the access request operation.
+             *
+             * <p>Note: A null value will clear all existing resource values
+             *
+             * @param resources the resource identifiers, may be {@code null}
+             * @return this builder
+             */
             public Builder resources(final Collection<URI> resources) {
                 if (resources != null) {
                     builderResources.addAll(resources);
@@ -253,11 +279,25 @@ public class AccessRequest extends AccessCredential {
                 return this;
             }
 
+            /**
+             * Set a single access mode for the access request operation.
+             *
+             * @param mode the access mode, not {@code null}
+             * @return this builder
+             */
             public Builder mode(final String mode) {
                 builderModes.add(mode);
                 return this;
             }
 
+            /**
+             * Set multiple access modes for the access request operation.
+             *
+             * <p>Note: A null value will clear all existing mode values
+             *
+             * @param modes the access modes, may be {@code null}
+             * @return this builder
+             */
             public Builder modes(final Collection<String> modes) {
                 if (modes != null) {
                     builderModes.addAll(modes);
@@ -267,11 +307,25 @@ public class AccessRequest extends AccessCredential {
                 return this;
             }
 
+            /**
+             * Set a single purpose for the access request operation.
+             *
+             * @param purpose the purpose identifier, not {@code null}
+             * @return this builder
+             */
             public Builder purpose(final URI purpose) {
                 builderPurposes.add(purpose);
                 return this;
             }
 
+            /**
+             * Set multiple purposes for the access request operation.
+             *
+             * <p>Note: A null value will clear all existing purpose values
+             *
+             * @param purposes the purpose identifiers, may be {@code null}
+             * @return this builder
+             */
             public Builder purposes(final Collection<URI> purposes) {
                 if (purposes != null) {
                     builderPurposes.addAll(purposes);
@@ -281,16 +335,37 @@ public class AccessRequest extends AccessCredential {
                 return this;
             }
 
+            /**
+             * Set a preferred expiration time for the access request operation.
+             *
+             * <p>Note: an access grant server may select a different expiration value
+             *
+             * @param expiration the expiration time, may be {@code null}.
+             * @return this builder
+             */
             public Builder expiration(final Instant expiration) {
                 builderExpiration = expiration;
                 return this;
             }
 
+            /**
+             * Set a preferred issuance time for the access request operation, likely at a time in the future.
+             *
+             * <p>Note: an access grant server may select a different issuance value
+             *
+             * @param issuedAt the issuance time, may be {@code null}.
+             * @return this builder
+             */
             public Builder issuedAt(final Instant issuedAt) {
                 builderIssuedAt = issuedAt;
                 return this;
             }
 
+            /**
+             * Build the {@link RequestParameters} object.
+             *
+             * @return the access request parameters
+             */
             public RequestParameters build() {
                 return new RequestParameters(builderRecipient, builderResources, builderModes, builderPurposes,
                         builderExpiration, builderIssuedAt);

--- a/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
+++ b/access-grant/src/test/java/com/inrupt/client/accessgrant/AccessRequestTest.java
@@ -43,6 +43,65 @@ class AccessRequestTest {
     private static final JsonService jsonService = ServiceProvider.getJsonService();
 
     @Test
+    void testBuilderWithNulls() {
+        final URI uri1 = URI.create("https://example.com/resource1");
+        final URI uri2 = URI.create("https://example.com/resource2");
+        final URI uri3 = URI.create("https://example.com/resource3");
+        final URI uri4 = URI.create("https://example.com/resource4");
+        final AccessRequest.RequestParameters params = AccessRequest.RequestParameters.newBuilder()
+            .resource(uri1).resource(uri2)
+            .mode("Read").mode("Append")
+            .purpose(uri3).purpose(uri4)
+            .recipient(null)
+            .modes(null)
+            .resources(null)
+            .purposes(null).build();
+
+        assertTrue(params.getPurposes().isEmpty());
+        assertTrue(params.getResources().isEmpty());
+        assertTrue(params.getModes().isEmpty());
+        assertNull(params.getRecipient());
+        assertNull(params.getExpiration());
+        assertNull(params.getIssuedAt());
+    }
+
+    @Test
+    void testBuilderWithCollections() {
+        final URI uri1 = URI.create("https://example.com/resource1");
+        final URI uri2 = URI.create("https://example.com/resource2");
+        final URI uri3 = URI.create("https://example.com/resource3");
+        final URI uri4 = URI.create("https://example.com/resource4");
+        final AccessRequest.RequestParameters params = AccessRequest.RequestParameters.newBuilder()
+            .resource(uri1)
+            .mode("Read")
+            .purpose(uri3)
+            .recipient(uri2)
+            .modes(Collections.singleton("Append"))
+            .resources(Collections.singleton(uri2))
+            .purposes(Collections.singleton(uri4)).build();
+
+        final Set<URI> expectedPurposes = new HashSet<>();
+        expectedPurposes.add(uri3);
+        expectedPurposes.add(uri4);
+        assertEquals(expectedPurposes, params.getPurposes());
+
+        final Set<URI> expectedResources = new HashSet<>();
+        expectedResources.add(uri1);
+        expectedResources.add(uri2);
+        assertEquals(expectedResources, params.getResources());
+
+        final Set<String> expectedModes = new HashSet<>();
+        expectedModes.add("Read");
+        expectedModes.add("Append");
+        assertEquals(expectedModes, params.getModes());
+
+        assertEquals(uri2, params.getRecipient());
+        assertNull(params.getExpiration());
+        assertNull(params.getIssuedAt());
+    }
+
+
+    @Test
     void testReadAccessRequest() throws IOException {
         try (final InputStream resource = AccessRequestTest.class.getResourceAsStream("/access_request1.json")) {
             final AccessRequest request = AccessRequest.of(resource);


### PR DESCRIPTION
This adds the implementation code for a builder pattern for access requests. In particular, this makes it possible to set an issuance date in the future, which is otherwise not possible in the current API.

The first commit just adds the boilerplate code for the new `AccessRequest.RequestParameter` class and connects that to the `AccessGrantClient.requestAccess` method (adding a new overload). The `getIssuedAt` value is then propagated through the rest of the methods (e.g. `grantAccess()` and `denyAccess()`).

Note: I re-ordered the parameters for some internal (private) methods to group the arguments into a more logical order. This does not affect the public API.

Some items still needed here include:

- [x] javadocs
- [x] tests

The way this would be used is like so:

```java

var req = AccessRequest.RequestParameters.newBuilder()
        .recipient(agent)
        .resource(uri)
        .modes(modes)
        .purposes(purposes)
        .expiration(expiration)
        .issuedAt(issuance).build();

agclient.requestAccess(req);
```
