### PR TITLE
Enable OkHttpClient tests for solid module

### DIFF
--- a/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpService.java
+++ b/okhttp/src/main/java/com/inrupt/client/okhttp/OkHttpService.java
@@ -88,6 +88,8 @@ public class OkHttpService implements HttpService {
                 try (final okhttp3.Response r = res) {
                     final Response.ResponseInfo info = new OkHttpResponseInfo(r);
                     future.complete(new OkHttpResponse<>(res.request().url().uri(), info, handler.apply(info)));
+                } catch (final RuntimeException ex) {
+                    future.completeExceptionally(ex);
                 }
             }
 

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -103,7 +103,6 @@
           <execution>
             <id>default-test</id>
             <phase>none</phase>
-            <configuration><skip>true</skip></configuration>
           </execution>
           <execution>
             <id>httpclient-jena-test</id>
@@ -112,7 +111,6 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <skip>true</skip>
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-okhttp</classpathDependencyExclude>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-rdf4j</classpathDependencyExclude>
@@ -126,7 +124,6 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <skip>true</skip>
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-okhttp</classpathDependencyExclude>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-jena</classpathDependencyExclude>
@@ -140,7 +137,6 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <skip>true</skip>
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-httpclient</classpathDependencyExclude>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-rdf4j</classpathDependencyExclude>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -103,6 +103,7 @@
           <execution>
             <id>default-test</id>
             <phase>none</phase>
+            <configuration><skip>true</skip></configuration>
           </execution>
           <execution>
             <id>httpclient-jena-test</id>
@@ -111,6 +112,7 @@
               <goal>test</goal>
             </goals>
             <configuration>
+              <skip>true</skip>
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-okhttp</classpathDependencyExclude>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-rdf4j</classpathDependencyExclude>
@@ -124,9 +126,39 @@
               <goal>test</goal>
             </goals>
             <configuration>
+              <skip>true</skip>
               <classpathDependencyExcludes>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-okhttp</classpathDependencyExclude>
                 <classpathDependencyExclude>com.inrupt.client:inrupt-client-jena</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>okhttp-jena-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <skip>true</skip>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-httpclient</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-rdf4j</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-rdf-legacy</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>okhttp-rdf4j-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-httpclient</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-jena</classpathDependencyExclude>
+                <classpathDependencyExclude>com.inrupt.client:inrupt-client-rdf-legacy</classpathDependencyExclude>
               </classpathDependencyExcludes>
             </configuration>
           </execution>


### PR DESCRIPTION
This fixes an issue where the `OkHttpClient` would throw an uncaught exception processing a response if the body handler threw a `RuntimeException` (`IOException` are handled gracefully).