### PR TITLE
Clean up sonar warnings

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
@@ -32,10 +32,6 @@ import java.util.Set;
  */
 public class AccessCredentialQuery<T extends AccessCredential> {
 
-    private static final URI SOLID_ACCESS_GRANT = URI.create("SolidAccessGrant");
-    private static final URI SOLID_ACCESS_REQUEST = URI.create("SolidAccessRequest");
-    private static final URI SOLID_ACCESS_DENIAL = URI.create("SolidAccessDenial");
-
     private final Set<URI> purposes;
     private final Set<String> modes;
     private final URI resource;
@@ -199,7 +195,7 @@ public class AccessCredentialQuery<T extends AccessCredential> {
          * @param clazz the credential type
          * @return the query object
          */
-        public <T extends AccessCredential> AccessCredentialQuery build(final Class<T> clazz) {
+        public <T extends AccessCredential> AccessCredentialQuery<T> build(final Class<T> clazz) {
             return new AccessCredentialQuery<T>(builderResource, builderCreator, builderRecipient, purposes, modes,
                     clazz);
         }

--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -168,6 +168,7 @@ public class AccessGrantClient {
         this.config = Objects.requireNonNull(config, "config may not be null!");
         this.metadataCache = Objects.requireNonNull(metadataCache, "metadataCache may not be null!");
         this.jsonService = ServiceProvider.getJsonService();
+        LOGGER.debug("Initializing Access Grant client with issuer: {}", config.getIssuer());
     }
 
     /**

--- a/jena/src/test/java/com/inrupt/client/jena/JenaBodyPublishersTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaBodyPublishersTest.java
@@ -32,8 +32,8 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jena.graph.Factory;
 import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.GraphMemFactory;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.rdf.model.Model;
@@ -121,7 +121,7 @@ class JenaBodyPublishersTest {
 
     @Test
     void testOfGraphPublisher() throws IOException, InterruptedException {
-        graph = Factory.createDefaultGraph();
+        graph = GraphMemFactory.createDefaultGraph();
 
         graph.add(JenaTestModel.S_NODE, JenaTestModel.P_NODE, JenaTestModel.O_NODE);
         graph.add(JenaTestModel.S1_NODE, JenaTestModel.P1_NODE, JenaTestModel.O1_NODE);

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -243,7 +243,7 @@ public final class OpenIdSession implements Session {
             final Request request, final Set<String> algorithms) {
         return auth.authenticate(this, request, algorithms)
                 .thenApply(cred-> {
-                    if (cred!= null) {
+                    if (cred != null) {
                         LOGGER.debug("Setting cache entry for request: {}", request.uri());
                         requestCache.put(cacheKey(request.uri()), cred);
                     }

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -242,7 +242,7 @@ public final class OpenIdSession implements Session {
     public CompletionStage<Optional<Credential>> authenticate(final Authenticator auth,
             final Request request, final Set<String> algorithms) {
         return auth.authenticate(this, request, algorithms)
-                .thenApply(cred-> {
+                .thenApply(cred -> {
                     if (cred != null) {
                         LOGGER.debug("Setting cache entry for request: {}", request.uri());
                         requestCache.put(cacheKey(request.uri()), cred);

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdSession.java
@@ -242,12 +242,12 @@ public final class OpenIdSession implements Session {
     public CompletionStage<Optional<Credential>> authenticate(final Authenticator auth,
             final Request request, final Set<String> algorithms) {
         return auth.authenticate(this, request, algorithms)
-                .thenApply(credential -> {
-                    if (credential != null) {
+                .thenApply(cred-> {
+                    if (cred!= null) {
                         LOGGER.debug("Setting cache entry for request: {}", request.uri());
-                        requestCache.put(cacheKey(request.uri()), credential);
+                        requestCache.put(cacheKey(request.uri()), cred);
                     }
-                    return Optional.ofNullable(credential);
+                    return Optional.ofNullable(cred);
                 });
     }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
@@ -66,6 +66,7 @@ public class SolidNonRDFSource extends NonRDFSource implements SolidResource {
      *
      * @return the metadata
      */
+    @Override
     public Metadata getMetadata() {
         return metadata;
     }


### PR DESCRIPTION
This cleans up some sonar/PMD warnings, including:

* Removing or using otherwise unused private fields
* Returning parameterized (rather than raw) types, where appropriate
* Use `@Override` where appropriate
* Avoid using the same variable name in a lambda that is used at the class level
* Replace the use of some deprecated methods in the Jena (test) module