### PR TITLE
Sonar cleanup: Unnecessary type specification

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredentialQuery.java
@@ -196,7 +196,7 @@ public class AccessCredentialQuery<T extends AccessCredential> {
          * @return the query object
          */
         public <T extends AccessCredential> AccessCredentialQuery<T> build(final Class<T> clazz) {
-            return new AccessCredentialQuery<T>(builderResource, builderCreator, builderRecipient, purposes, modes,
+            return new AccessCredentialQuery<>(builderResource, builderCreator, builderRecipient, purposes, modes,
                     clazz);
         }
     }


### PR DESCRIPTION
The AccessCredentialQuery builder has a superfluous generic type specification.