### PR TITLE
JCL-427: Ensure that the inherited project URLs are correct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.inrupt.client</groupId>
@@ -781,7 +781,7 @@
     </developer>
   </developers>
 
-  <scm>
+  <scm child.scm.url.inherit.append.path="false" child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false">
     <connection>scm:git:https://github.com/inrupt/solid-client-java.git</connection>
     <developerConnection>scm:git:git@github.com:inrupt/solid-client-java.git</developerConnection>
     <url>https://github.com/inrupt/solid-client-java</url>


### PR DESCRIPTION
At present, individual modules contain the incorrect project URL and source URL. An example is at https://central.sonatype.com/artifact/com.inrupt.client/inrupt-client-webid/1.0.0

This is due to the default behavior of module inheritance in Maven where URL paths are appended to include the submodule name. See the [Maven documentation](https://maven.apache.org/ref/3.8.1/maven-model-builder/) for more details.

To verify this change, use the following command on a submodule:

```
$ mvn help:evaluate -Dexpression=project.url -q -DforceStdout
```

The result will be the following value in all submodules.

```
https://docs.inrupt.com/developer-tools/java/client-libraries/
```

With this PR, similar behavior can also be seen with `project.scm.url`, `project.scm.connection` and `project.scm.developerConnection`