### PR TITLE
JCL-423: JSON-B test flakiness

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessGrantClient.java
@@ -398,30 +398,29 @@ public class AccessGrantClient {
         }
 
         return v1Metadata().thenCompose(metadata -> {
-            final List<CompletableFuture<List<T>>> futures = buildQuery(config.getIssuer(), type,
+            final List<CompletableFuture<Response<InputStream>>> responses = buildQuery(config.getIssuer(), type,
                     resource, creator, recipient, purposes, modes).stream()
                 .map(data -> Request.newBuilder(metadata.queryEndpoint)
                         .header(CONTENT_TYPE, APPLICATION_JSON)
                         .POST(Request.BodyPublishers.ofByteArray(serialize(data))).build())
                 .map(req -> client.send(req, Response.BodyHandlers.ofInputStream())
-                        .thenApply(res -> {
-                            try (final InputStream input = res.body()) {
-                                final int status = res.statusCode();
-                                if (isSuccess(status)) {
-                                    return processQueryResponse(input, supportedTypes, clazz);
-                                }
-                                throw new AccessGrantException("Unable to perform Access Grant query: HTTP error " +
-                                        status, status);
-                            } catch (final IOException ex) {
-                                throw new AccessGrantException(
-                                        "Unexpected I/O exception while processing Access Grant query", ex);
-                            }
-                        }).toCompletableFuture())
+                        .toCompletableFuture())
                 .collect(Collectors.toList());
 
-            return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                .thenApply(x -> futures.stream().map(CompletableFuture::join).flatMap(List::stream)
-                        .collect(Collectors.toList()));
+            return CompletableFuture.allOf(responses.toArray(new CompletableFuture[0]))
+                .thenApply(x -> responses.stream().map(CompletableFuture::join).map(response -> {
+                    try (final InputStream input = response.body()) {
+                        final int status = response.statusCode();
+                        if (isSuccess(status)) {
+                            return processQueryResponse(input, supportedTypes, clazz);
+                        }
+                        throw new AccessGrantException("Unable to perform Access Grant query: HTTP error " +
+                                status, status);
+                    } catch (final IOException ex) {
+                        throw new AccessGrantException(
+                                "Unexpected I/O exception while processing Access Grant query", ex);
+                    }
+                }).flatMap(List::stream).collect(Collectors.toList()));
         });
     }
 


### PR DESCRIPTION
The Access Grant query response parsing happens in parallel, and this appears to create a certain level of flakiness in the integration tests when using JSON-B. Although the JSON-B parser claims to be entirely thread-safe, it seems that this may not be strictly the case.

In order to address this, the queries are still performed in parallel but the parsing is processed serially, after all the query responses are collected.