### PR TITLE
JCL-431: Improve containment validation

### DIFF
--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -231,6 +231,8 @@ class SolidClientTest {
         expected.add(URIBuilder.newBuilder(uri).path("newContainer/").build());
         expected.add(URIBuilder.newBuilder(uri).path("test.txt").build());
         expected.add(URIBuilder.newBuilder(uri).path("test2.txt").build());
+        expected.add(URIBuilder.newBuilder(uri).path("test3").build());
+        expected.add(URIBuilder.newBuilder(uri).path("test4").build());
 
         client.send(Request.newBuilder(uri).build(), SolidResourceHandlers.ofSolidContainer())
             .thenAccept(response -> {

--- a/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
@@ -195,6 +195,25 @@ class SolidRDFSourceTest {
     }
 
     @Test
+    void testNonContainer() {
+        final URI resource = URI.create(config.get("solid_resource_uri") + "/recipe");
+        final Request request = Request.newBuilder()
+            .uri(resource)
+            .header("Accept", "text/turtle")
+            .GET()
+            .build();
+
+        final Response<SolidContainer> response = client.send(request, SolidResourceHandlers.ofSolidContainer())
+            .toCompletableFuture().join();
+
+        try (final SolidContainer container = response.body()) {
+            assertEquals(resource, container.getIdentifier());
+            assertTrue(container.getResources().isEmpty());
+            assertFalse(container.validate().isValid());
+        }
+    }
+
+    @Test
     void testInvalidRdf() {
         final URI resource = URI.create(config.get("solid_resource_uri") + "/nonRDF");
         final Request request = Request.newBuilder()

--- a/solid/src/test/resources/__files/container.ttl
+++ b/solid/src/test/resources/__files/container.ttl
@@ -7,6 +7,14 @@
     a ldp:BasicContainer ;
     dct:modified "2022-11-25T10:36:36Z"^^xsd:dateTime;
     ldp:contains <newContainer/>, <test.txt>, <test2.txt> .
+<intermediate/..>
+    a ldp:BasicContainer ;
+    dct:modified "2022-11-25T10:38:12Z"^^xsd:dateTime ;
+    ldp:contains <test3> .
+<intermediate/../>
+    a ldp:BasicContainer ;
+    dct:modified "2022-11-25T10:38:47Z"^^xsd:dateTime ;
+    ldp:contains <test4> .
 <newContainer/>
     a ldp:BasicContainer ;
     dct:modified "2022-11-25T10:36:36Z"^^xsd:dateTime .
@@ -16,10 +24,16 @@
 <test2.txt>
     a pl:Resource, ldp:NonRDFSource;
     dct:modified "2022-11-25T10:37:06Z"^^xsd:dateTime .
+<test3>
+    a ldp:RDFSource ;
+    dct:modified "2022-11-25T10:37:31Z"^^xsd:dateTime .
+<test4>
+    a ldp:RDFSource ;
+    dct:modified "2022-11-25T10:39:22Z"^^xsd:dateTime .
 
 # These containment triples should not be included in a getResources response
 <>
-    ldp:contains <https://example.com/other> , <newContainer/child> , <> , <./> ,
+    ldp:contains <https://example.com/other> , <newContainer/child> , <newContainer%2Fchild2> ,  <> , <./> ,
     <?foo> , <#bar> , <?foo#bar> , <./?foo> , <./#bar> , <./?foo#bar> ,
     <../?foo> , <../#bar> , <../?foo#bar> , <child?foo> , <child#bar> , <child?foo#bar> .
 <https://example.test/container/>

--- a/solid/src/test/resources/__files/container.ttl
+++ b/solid/src/test/resources/__files/container.ttl
@@ -19,7 +19,9 @@
 
 # These containment triples should not be included in a getResources response
 <>
-    ldp:contains <https://example.com/other> , <newContainer/child> , <> , <./> .
+    ldp:contains <https://example.com/other> , <newContainer/child> , <> , <./> ,
+    <?foo> , <#bar> , <?foo#bar> , <./?foo> , <./#bar> , <./?foo#bar> ,
+    <../?foo> , <../#bar> , <../?foo#bar> , <child?foo> , <child#bar> , <child?foo#bar> .
 <https://example.test/container/>
     a ldp:BasicContainer ;
     ldp:contains <https://example.test/container/external> .


### PR DESCRIPTION
Resolves #634 

This improves containment validation by considering more cases to be handled, specifically those containment triples that include fragment and query components.

The test cases have been expanded to include the additional cases.

The implementation makes more extensive use of normalized Java URI objects to achieve the improved validation.