### PR TITLE
Adjust CD workflow for 1.0 maintenance branch

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -3,11 +3,9 @@ name: Solid Java Client CD
 on:
   push:
     branches:
-      - main
+      - 1.0
     tags:
-      - inrupt-client-[0-9]+.[0-9]+.[0-9]+
-      - inrupt-client-[0-9]+.[0-9]+.[0-9]+.Alpha[0-9]+
-      - inrupt-client-[0-9]+.[0-9]+.[0-9]+.Beta[0-9]+
+      - inrupt-client-1.0.[0-9]+
 
 jobs:
   deployment:


### PR DESCRIPTION
This adjusts the CD workflow for the 1.0 maintenance branch. It is currently pointing at `main` which means that it will not run after merges to the 1.0 branch.

This also adjusts the tag names that will trigger a CD workflow