### PR TITLE
JCL-434: Upgrade wiremock to 3.0

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -49,8 +49,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -54,13 +54,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,8 +87,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,13 +92,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -51,13 +51,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -46,8 +46,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -111,27 +111,6 @@
             <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-fileupload</groupId>
-                    <artifactId>commons-fileupload</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- transitive dependency via wiremock -->
-        <!-- when wiremock is updated beyond 2.35, this can be removed -->
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -107,8 +107,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
             <scope>provided</scope>
             <exclusions>

--- a/integration/customokhttp/pom.xml
+++ b/integration/customokhttp/pom.xml
@@ -35,14 +35,6 @@
       <version>${slf4j.version}</version>
     </dependency>
 
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
-
     <!-- transitive dependencies -->
     <!-- upgraded because of CVE-2023-3635 -->
     <dependency>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -52,8 +52,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -57,13 +57,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -61,13 +61,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -56,8 +56,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -69,13 +69,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -64,8 +64,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -62,8 +62,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -67,13 +67,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -50,8 +50,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -54,19 +54,6 @@
       <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-            <groupId>net.minidev</groupId>
-            <artifactId>accessors-smart</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -68,13 +68,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -63,8 +63,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -53,13 +53,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-caffeine</artifactId>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -48,8 +48,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/performance/base/pom.xml
+++ b/performance/base/pom.xml
@@ -111,27 +111,6 @@
             <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-fileupload</groupId>
-                    <artifactId>commons-fileupload</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- transitive dependency via wiremock -->
-        <!-- when wiremock is updated beyond 2.35, this can be removed -->
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->

--- a/performance/base/pom.xml
+++ b/performance/base/pom.xml
@@ -107,8 +107,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
             <scope>provided</scope>
             <exclusions>

--- a/performance/uma/pom.xml
+++ b/performance/uma/pom.xml
@@ -61,13 +61,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/performance/uma/pom.xml
+++ b/performance/uma/pom.xml
@@ -56,8 +56,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <glassfish.json.version>2.0.1</glassfish.json.version>
     <junit.version>5.10.0</junit.version>
     <yasson.version>3.0.3</yasson.version>
-    <wiremock.version>2.35.0</wiremock.version>
+    <wiremock.version>3.0.0</wiremock.version>
 
     <!-- disable by default (enabled by profile in CI) -->
     <dependency-check.skip>true</dependency-check.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,16 @@
     </site>
   </distributionManagement>
 
+  <dependencyManagement>
+    <dependencies>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>${guava.version}</version>
+        </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -125,19 +125,6 @@
       <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-            <groupId>net.minidev</groupId>
-            <artifactId>accessors-smart</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -121,8 +121,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -119,13 +119,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -114,8 +114,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -49,13 +49,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -44,8 +44,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,27 +42,6 @@
       <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- transitive dependency via wiremock -->
-    <!-- when wiremock is updated beyond 2.35, this can be removed -->
-    <dependency>
-      <groupId>net.minidev</groupId>
-      <artifactId>json-smart</artifactId>
-      <version>2.5.0</version>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -38,8 +38,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>provided</scope>
       <exclusions>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -55,13 +55,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-guava</artifactId>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -50,8 +50,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -27,8 +27,8 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -32,13 +32,6 @@
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-core</artifactId>


### PR DESCRIPTION
This upgrades wiremock to the 3.0 release series, updating the corresponding groupId and artifactId values.