### PR TITLE
JCL-434: Upgrade wiremock

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -49,16 +49,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -87,16 +87,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -46,16 +46,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -107,30 +107,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-fileupload</groupId>
-                    <artifactId>commons-fileupload</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- transitive dependency via wiremock -->
-        <!-- when wiremock is updated beyond 2.35, this can be removed -->
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/integration/customokhttp/pom.xml
+++ b/integration/customokhttp/pom.xml
@@ -35,14 +35,6 @@
       <version>${slf4j.version}</version>
     </dependency>
 
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
-
     <!-- transitive dependencies -->
     <!-- upgraded because of CVE-2023-3635 -->
     <dependency>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -52,16 +52,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -56,16 +56,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -64,16 +64,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -62,16 +62,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -50,8 +50,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
       <exclusions>
@@ -60,13 +60,6 @@
             <artifactId>accessors-smart</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse</groupId>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -63,16 +63,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -48,16 +48,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/performance/base/pom.xml
+++ b/performance/base/pom.xml
@@ -107,30 +107,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <version>${wiremock.version}</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-fileupload</groupId>
-                    <artifactId>commons-fileupload</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!-- transitive dependency via wiremock -->
-        <!-- when wiremock is updated beyond 2.35, this can be removed -->
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.5.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/performance/uma/pom.xml
+++ b/performance/uma/pom.xml
@@ -56,16 +56,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8-standalone</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <glassfish.json.version>2.0.1</glassfish.json.version>
     <junit.version>5.10.0</junit.version>
     <yasson.version>3.0.3</yasson.version>
-    <wiremock.version>2.35.0</wiremock.version>
+    <wiremock.version>3.0.3</wiremock.version>
 
     <!-- disable by default (enabled by profile in CI) -->
     <dependency-check.skip>true</dependency-check.skip>
@@ -133,6 +133,16 @@
       <url>${project.baseUri}</url>
     </site>
   </distributionManagement>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -121,22 +121,9 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-            <groupId>net.minidev</groupId>
-            <artifactId>accessors-smart</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -121,7 +121,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -120,16 +120,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -44,16 +44,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -38,30 +38,9 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>provided</scope>
-      <exclusions>
-        <exclusion>
-            <groupId>commons-fileupload</groupId>
-            <artifactId>commons-fileupload</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- transitive dependency via wiremock -->
-    <!-- when wiremock is updated beyond 2.35, this can be removed -->
-    <dependency>
-      <groupId>net.minidev</groupId>
-      <artifactId>json-smart</artifactId>
-      <version>2.5.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -50,16 +50,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -27,16 +27,9 @@
 
     <!-- test dependencies -->
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock-jre8</artifactId>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <!-- patch CVE-2023-2976 guava-31.x.x in wiremock 2.35.0 -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This upgrades the 1.0 branch to use the 3.x version of wiremock