### PR TITLE
Maven logging dependency cleanup

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -34,6 +34,11 @@
       <artifactId>commons-io</artifactId>
       <version>${commons.io.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -53,7 +53,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -59,6 +59,12 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -57,13 +57,19 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -45,6 +45,12 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>

--- a/performance/base/src/main/java/com/inrupt/client/performance/base/MockSolidServer.java
+++ b/performance/base/src/main/java/com/inrupt/client/performance/base/MockSolidServer.java
@@ -38,6 +38,10 @@ class MockSolidServer {
     }
 
     private void setupMocks() {
+        wireMockServer.stubFor(head(anyUrl())
+                .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
+                .willReturn(aResponse()
+                        .withStatus(Utils.SUCCESS)));
         wireMockServer.stubFor(get(anyUrl())
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
                 .willReturn(aResponse()

--- a/performance/uma/pom.xml
+++ b/performance/uma/pom.xml
@@ -57,7 +57,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock-standalone</artifactId>
+      <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -81,6 +81,12 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -29,6 +29,11 @@
       <artifactId>jose4j</artifactId>
       <version>${jose4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -70,6 +70,12 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+     <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
       <scope>test</scope>


### PR DESCRIPTION
This cleans up the maven configuration for logging. Specifically, there are cases where the slf4j-api is used in modules but the dependency is not listed explicitly. This can cause version mismatches when combined with wiremock, leading to log output not being produced.

Secondly, `wiremock-standalone` is being used in cases where it's not necessary (and we should generally prefer `wiremock` over `wiremock-standalone`).

Third, with the better wiremock output, there are some HTTP paths that are not being properly matched, but will be with this change.