### PR TITLE
JCL-439: Address CVE-2023-44487

### DIFF
--- a/build-tools/owasp/suppressions.xml
+++ b/build-tools/owasp/suppressions.xml
@@ -10,4 +10,12 @@
   </suppress>
 
   <!-- Suppressed vulnerabilities. These need monthly review. -->
+  <suppress until="2023-11-12Z">
+    <notes><![CDATA[
+        This vulnerability appears via wiremock and is used only during test execution. As such, the
+        rapid reset DoS vector is not relevant.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-common@.*$</packageUrl>
+    <vulnerabilityName>CVE-2023-44487</vulnerabilityName>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
This [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2023-44487) relates to a denial of service over HTTP/2 by rapidly resetting open streams. Because this library is used only via wiremock for testing, this exploit is not relevant for the Java Client libraries.