### PR TITLE
Adjust dependabot for better RDF4J support across versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,24 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+
+  - package-ecosystem: "maven"
+    directory: "/rdf4j/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+
+  - package-ecosystem: "maven"
+    directory: "/rdf-legacy/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+        versions:
+          - "3.x"
 
   - package-ecosystem: "gradle"
     directory: "/gradle/"
@@ -21,6 +39,32 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "1.0"
+    ignore:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+    labels:
+      - "backport"
+      - "1.0"
+
+  - package-ecosystem: "maven"
+    directory: "/rdf4j/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.0"
+    allow:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+    labels:
+      - "backport"
+      - "1.0"
+
+  - package-ecosystem: "maven"
+    directory: "/rdf-legacy/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.0"
+    allow:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+        versions:
+          - "3.x"
     labels:
       - "backport"
       - "1.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,15 +14,6 @@ updates:
     allow:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
 
-  - package-ecosystem: "maven"
-    directory: "/rdf-legacy/"
-    schedule:
-      interval: "weekly"
-    allow:
-      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
-        versions:
-          - "3.x"
-
   - package-ecosystem: "gradle"
     directory: "/gradle/"
     schedule:
@@ -52,19 +43,6 @@ updates:
     target-branch: "1.0"
     allow:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
-    labels:
-      - "backport"
-      - "1.0"
-
-  - package-ecosystem: "maven"
-    directory: "/rdf-legacy/"
-    schedule:
-      interval: "weekly"
-    target-branch: "1.0"
-    allow:
-      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
-        versions:
-          - "3.x"
     labels:
       - "backport"
       - "1.0"

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
     <jose4j.version>0.9.3</jose4j.version>
     <json.bind.version>3.0.0</json.bind.version>
     <okhttp.version>4.11.0</okhttp.version>
-    <rdf4j.version>4.3.6</rdf4j.version>
     <slf4j.version>2.0.9</slf4j.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
     <inrupt.rdf.wrapping.version>1.0.0</inrupt.rdf.wrapping.version>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
+    <rdf4j.version>4.3.6</rdf4j.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Whenever RDF4J has an update, we currently need to manually adjust the dependabot PR so that the legacy version (`rdf-legacy`) continues to use 3.x while the `rdf4j` module uses the new version.

This new configuration is a bit difficult to test, but if this works as I believe it will, it should remove RDF4J updates to the `/` directory scope, but add it individually to the `/rdf4j` directory scope.

If this doesn't work properly, we can revert this commit