### PR TITLE
Address CVE-2023-44487

### DIFF
--- a/build-tools/owasp/suppressions.xml
+++ b/build-tools/owasp/suppressions.xml
@@ -15,7 +15,15 @@
         This vulnerability appears via wiremock and is used only during test execution. As such, the
         rapid reset DoS vector is not relevant.
     ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-common@.*$</packageUrl>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-.*@.*$</packageUrl>
+    <vulnerabilityName>CVE-2023-44487</vulnerabilityName>
+  </suppress>
+  <suppress until="2023-11-12Z">
+    <notes><![CDATA[
+        This vulnerability appears via wiremock and is used only during test execution. As such, the
+        rapid reset DoS vector is not relevant.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-.*@.*$</packageUrl>
     <vulnerabilityName>CVE-2023-44487</vulnerabilityName>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Wiremock uses a version of Jetty that is vulnerable to a certain category of resource exhaustion attacks, but given that we control both the server and client in this context and it is only during test execution, this vulnerability is not considered relevant to the Java client libraries