### PR TITLE
Extend CVE-44487 Suppressions by one month

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17, 21 ]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4

--- a/build-tools/owasp/suppressions.xml
+++ b/build-tools/owasp/suppressions.xml
@@ -10,7 +10,7 @@
   </suppress>
 
   <!-- Suppressed vulnerabilities. These need monthly review. -->
-  <suppress until="2023-11-12Z">
+  <suppress until="2023-12-12Z">
     <notes><![CDATA[
         This vulnerability appears via wiremock and is used only during test execution. As such, the
         rapid reset DoS vector is not relevant.
@@ -18,7 +18,7 @@
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2\-.*@.*$</packageUrl>
     <vulnerabilityName>CVE-2023-44487</vulnerabilityName>
   </suppress>
-  <suppress until="2023-11-12Z">
+  <suppress until="2023-12-12Z">
     <notes><![CDATA[
         This vulnerability appears via wiremock and is used only during test execution. As such, the
         rapid reset DoS vector is not relevant.

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -100,12 +100,11 @@ public class AccessGrantScenarios {
     private static final URI PURPOSE1 = URI.create("https://purpose.example/212efdf4-e1a4-4dcd-9d3b-d6eb92e0205f");
     private static final URI PURPOSE2 = URI.create("https://purpose.example/de605b08-76c7-4f04-9cec-a438810b0c03");
     protected static final Set<URI> PURPOSES = new HashSet<>(Arrays.asList(PURPOSE1, PURPOSE2));
-    protected static final String GRANT_EXPIRATION = "2024-04-03T12:00:00Z";
+    protected static final String GRANT_EXPIRATION = Instant.now().plus(1, ChronoUnit.HOURS)
+        .truncatedTo(ChronoUnit.SECONDS).toString();
     private static final String sharedTextFileName = "sharedFile.txt";
     protected static URI sharedTextFileURI;
     private static URI privateContainerURI;
-    private static Session requesterSession;
-    private static Session resourceOwnerSession;
 
     private static SolidSyncClient authResourceOwnerClient;
 
@@ -780,13 +779,13 @@ public class AccessGrantScenarios {
     }
 
     private static Stream<Arguments> provideSessions() throws SolidClientException {
-        resourceOwnerSession = OpenIdSession.ofClientCredentials(
+        final var resourceOwnerSession = OpenIdSession.ofClientCredentials(
             URI.create(issuer),
             RESOURCE_OWNER_CLIENT_ID,
             RESOURCE_OWNER_CLIENT_SECRET,
             AUTH_METHOD);
 
-        requesterSession = OpenIdSession.ofClientCredentials(
+        final var requesterSession = OpenIdSession.ofClientCredentials(
             URI.create(issuer),
             REQUESTER_CLIENT_ID,
             REQUESTER_CLIENT_SECRET,

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -65,7 +65,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <rerunFailingTestsCount>2</rerunFailingTestsCount>
+          <rerunFailingTestsCount>5</rerunFailingTestsCount>
           <systemPropertyVariables />
         </configuration>
       </plugin>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -69,7 +69,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <rerunFailingTestsCount>2</rerunFailingTestsCount>
+          <rerunFailingTestsCount>5</rerunFailingTestsCount>
           <systemPropertyVariables />
         </configuration>
       </plugin>


### PR DESCRIPTION
This extends the CVE-44487 suppressions by one month

This particular issue affects Wiremock via the `inrupt-client-test` module.