### PR TITLE
JCL-435: Add headers data to core API

### DIFF
--- a/api/src/main/java/com/inrupt/client/Headers.java
+++ b/api/src/main/java/com/inrupt/client/Headers.java
@@ -90,6 +90,15 @@ public final class Headers {
         return new Headers(Objects.requireNonNull(headers));
     }
 
+    /**
+     * Create an empty headers object.
+     *
+     * @return the new Headers object
+     */
+    public static Headers empty() {
+        return new Headers(new HashMap<>());
+    }
+
     private Headers(final Map<String, List<String>> headers) {
         this.data.putAll(headers);
     }

--- a/api/src/main/java/com/inrupt/client/NonRDFSource.java
+++ b/api/src/main/java/com/inrupt/client/NonRDFSource.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Objects;
 
 /**
@@ -67,7 +66,7 @@ public class NonRDFSource implements Resource {
         this.identifier = Objects.requireNonNull(identifier, "identifier may not be null!");
         this.contentType = Objects.requireNonNull(contentType, "contentType may not be null!");
         this.entity = Objects.requireNonNull(entity, "entity may not be null!");
-        this.headers = headers == null ? Headers.of(new HashMap<>()) : headers;
+        this.headers = headers == null ? Headers.empty() : headers;
     }
 
     @Override

--- a/api/src/main/java/com/inrupt/client/NonRDFSource.java
+++ b/api/src/main/java/com/inrupt/client/NonRDFSource.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Objects;
 
 /**
@@ -36,6 +37,7 @@ public class NonRDFSource implements Resource {
     private final URI identifier;
     private final String contentType;
     private final InputStream entity;
+    private final Headers headers;
 
     /**
      * Create a new non-RDF-bearing resource.
@@ -47,9 +49,25 @@ public class NonRDFSource implements Resource {
      * @param entity the resource entity
      */
     protected NonRDFSource(final URI identifier, final String contentType, final InputStream entity) {
+        this(identifier, contentType, entity, null);
+    }
+
+    /**
+     * Create a new non-RDF-bearing resource.
+     *
+     * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
+     *
+     * @param identifier the resource identifier
+     * @param contentType the content type of the resource
+     * @param entity the resource entity
+     * @param headers header values associated with the resource, may be {@code null}
+     */
+    protected NonRDFSource(final URI identifier, final String contentType, final InputStream entity,
+            final Headers headers) {
         this.identifier = Objects.requireNonNull(identifier, "identifier may not be null!");
         this.contentType = Objects.requireNonNull(contentType, "contentType may not be null!");
         this.entity = Objects.requireNonNull(entity, "entity may not be null!");
+        this.headers = headers == null ? Headers.of(new HashMap<>()) : headers;
     }
 
     @Override
@@ -60,6 +78,11 @@ public class NonRDFSource implements Resource {
     @Override
     public String getContentType() {
         return contentType;
+    }
+
+    @Override
+    public Headers getHeaders() {
+        return headers;
     }
 
     @Override

--- a/api/src/main/java/com/inrupt/client/RDFSource.java
+++ b/api/src/main/java/com/inrupt/client/RDFSource.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.util.HashMap;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.RDF;
@@ -102,7 +101,7 @@ public class RDFSource extends WrapperDataset implements Resource {
      */
     protected RDFSource(final URI identifier, final RDFSyntax syntax, final Dataset dataset, final Headers headers) {
         super(dataset == null ? rdf.createDataset() : dataset);
-        this.headers = headers == null ? Headers.of(new HashMap<>()) : headers;
+        this.headers = headers == null ? Headers.empty() : headers;
         this.identifier = identifier;
         this.syntax = syntax;
     }

--- a/api/src/main/java/com/inrupt/client/RDFSource.java
+++ b/api/src/main/java/com/inrupt/client/RDFSource.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.HashMap;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.RDF;
@@ -49,6 +50,7 @@ public class RDFSource extends WrapperDataset implements Resource {
 
     private final URI identifier;
     private final RDFSyntax syntax;
+    private final Headers headers;
 
     /**
      * Create a new RDF-bearing resource.
@@ -68,11 +70,39 @@ public class RDFSource extends WrapperDataset implements Resource {
      * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
      *
      * @param identifier the resource identifier
+     * @param dataset the dataset corresponding to this resource, may be {@code null}
+     * @param headers header values associated with the resource, may be {@code null}
+     */
+    protected RDFSource(final URI identifier, final Dataset dataset, final Headers headers) {
+        this(identifier, RDFSyntax.TURTLE, dataset, headers);
+    }
+
+    /**
+     * Create a new RDF-bearing resource.
+     *
+     * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
+     *
+     * @param identifier the resource identifier
      * @param syntax the original RDF syntax in use
      * @param dataset the dataset corresponding to this resource, may be {@code null}
      */
     protected RDFSource(final URI identifier, final RDFSyntax syntax, final Dataset dataset) {
+        this(identifier, syntax, dataset, null);
+    }
+
+    /**
+     * Create a new RDF-bearing resource.
+     *
+     * <p>Subclasses should have the same constructor signature to work with the provided object mapping mechanism.
+     *
+     * @param identifier the resource identifier
+     * @param syntax the original RDF syntax in use
+     * @param dataset the dataset corresponding to this resource, may be {@code null}
+     * @param headers header values associated with the resource, may be {@code null}
+     */
+    protected RDFSource(final URI identifier, final RDFSyntax syntax, final Dataset dataset, final Headers headers) {
         super(dataset == null ? rdf.createDataset() : dataset);
+        this.headers = headers == null ? Headers.of(new HashMap<>()) : headers;
         this.identifier = identifier;
         this.syntax = syntax;
     }
@@ -85,6 +115,11 @@ public class RDFSource extends WrapperDataset implements Resource {
     @Override
     public String getContentType() {
         return syntax.mediaType();
+    }
+
+    @Override
+    public Headers getHeaders() {
+        return headers;
     }
 
     @Override

--- a/api/src/main/java/com/inrupt/client/Resource.java
+++ b/api/src/main/java/com/inrupt/client/Resource.java
@@ -46,6 +46,13 @@ public interface Resource extends AutoCloseable {
     String getContentType();
 
     /**
+     * The resource headers.
+     *
+     * @return the resource headers
+     */
+    Headers getHeaders();
+
+    /**
      * The resource entity.
      *
      * @return the resource entity

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -165,7 +165,7 @@ public class AccessGrantScenarios {
                 .build();
         //create test file in access grant enabled container
         try (final InputStream is = new ByteArrayInputStream(StandardCharsets.UTF_8.encode("Test text").array())) {
-            final SolidNonRDFSource testResource = new SolidNonRDFSource(sharedTextFileURI, Utils.PLAIN_TEXT, is, null);
+            final SolidNonRDFSource testResource = new SolidNonRDFSource(sharedTextFileURI, Utils.PLAIN_TEXT, is);
             assertDoesNotThrow(() -> authResourceOwnerClient.create(testResource));
             prepareAcpOfResource(authResourceOwnerClient, sharedTextFileURI, SolidNonRDFSource.class);
         }
@@ -460,7 +460,7 @@ public class AccessGrantScenarios {
                 .path("resource-accessGrantGetRdfTest.ttl")
                 .build();
 
-        try (final SolidRDFSource resource = new SolidRDFSource(testRDFresourceURI, null, null)) {
+        try (final SolidRDFSource resource = new SolidRDFSource(testRDFresourceURI)) {
             assertDoesNotThrow(() -> resourceOwnerClient.create(resource));
 
             prepareAcpOfResource(resourceOwnerClient, testRDFresourceURI, SolidRDFSource.class);
@@ -613,7 +613,7 @@ public class AccessGrantScenarios {
         try (final InputStream is = new ByteArrayInputStream(
             StandardCharsets.UTF_8.encode("Test test test text").array())) {
             final SolidNonRDFSource testResource =
-                new SolidNonRDFSource(newTestFileURI, Utils.PLAIN_TEXT, is, null);
+                new SolidNonRDFSource(newTestFileURI, Utils.PLAIN_TEXT, is);
             assertDoesNotThrow(() -> resourceOwnerClient.create(testResource));
         }
 
@@ -662,7 +662,7 @@ public class AccessGrantScenarios {
         try (final InputStream is = new ByteArrayInputStream(
             StandardCharsets.UTF_8.encode("Test test test text").array())) {
             final SolidNonRDFSource testResource =
-                new SolidNonRDFSource(newTestFileURI, Utils.PLAIN_TEXT, is, null);
+                new SolidNonRDFSource(newTestFileURI, Utils.PLAIN_TEXT, is);
             assertDoesNotThrow(() -> resourceOwnerClient.create(testResource));
         }
 
@@ -744,7 +744,7 @@ public class AccessGrantScenarios {
         try (final InputStream is = new ByteArrayInputStream(
             StandardCharsets.UTF_8.encode("Test test test text").array())) {
             final SolidNonRDFSource testResource =
-                new SolidNonRDFSource(newTestFileURI, Utils.PLAIN_TEXT, is, null);
+                new SolidNonRDFSource(newTestFileURI, Utils.PLAIN_TEXT, is);
             assertDoesNotThrow(() -> requesterAuthClient.create(testResource));
         }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -166,7 +166,7 @@ public class AuthenticationScenarios {
     void fetchPublicResourceUnauthenticatedTest() {
         LOGGER.info("Integration Test - Unauthenticated fetch of public resource");
         //create a public resource
-        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURI)) {
             final SolidSyncClient client = SolidSyncClient.getClient();
             assertDoesNotThrow(() -> client.create(testResource));
             assertDoesNotThrow(() -> client.read(publicResourceURI, SolidRDFSource.class));
@@ -183,7 +183,7 @@ public class AuthenticationScenarios {
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
 
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             final SolidSyncClient client = SolidSyncClient.getClient();
@@ -203,7 +203,7 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of public resource");
         //create public resource
         final SolidSyncClient client = SolidSyncClient.getClient();
-        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(publicResourceURI)) {
             assertDoesNotThrow(() -> client.create(testResource));
 
             final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
@@ -221,7 +221,7 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of private resource");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             assertDoesNotThrow(() -> authClient.read(privateResourceURI, SolidRDFSource.class));
@@ -238,7 +238,7 @@ public class AuthenticationScenarios {
         LOGGER.info("Integration Test - Unauthenticated, then auth fetch of private resource");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             final SolidSyncClient client = SolidSyncClient.getClient();
@@ -260,7 +260,7 @@ public class AuthenticationScenarios {
     void multiSessionTest(final Session session) {
         LOGGER.info("Integration Test - Multiple sessions authenticated in parallel");
         //create private resource
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI)) {
             final SolidSyncClient authClient1 = SolidSyncClient.getClient().session(session);
             assertDoesNotThrow(() -> authClient1.create(testResource));
 
@@ -268,7 +268,7 @@ public class AuthenticationScenarios {
             final URI privateResourceURL2 = URIBuilder.newBuilder(privateContainerURI)
                 .path("resource2.ttl")
                 .build();
-            try (final SolidRDFSource testResource2 = new SolidRDFSource(privateResourceURL2, null, null)) {
+            try (final SolidRDFSource testResource2 = new SolidRDFSource(privateResourceURL2)) {
                 final SolidSyncClient authClient2 =
                         SolidSyncClient.getClient().session(session);
                 assertDoesNotThrow(() -> authClient2.create(testResource2));

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdAuthenticationScenariosTest.java
@@ -44,7 +44,7 @@ class OpenIdAuthenticationScenariosTest extends AuthenticationScenarios {
         LOGGER.info("Integration Test - Authenticated fetch of private resource uses OpenID authenticator");
         //create private resource
         final SolidSyncClient authClient = SolidSyncClient.getClient().session(session);
-        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI, null, null)) {
+        try (final SolidRDFSource testResource = new SolidRDFSource(privateResourceURI)) {
             assertDoesNotThrow(() -> authClient.create(testResource));
 
             assertDoesNotThrow(() -> authClient.read(privateResourceURI, SolidRDFSource.class));

--- a/performance/base/src/main/java/com/inrupt/client/performance/base/GetResourcesWithGrantCachingTokenScenario.java
+++ b/performance/base/src/main/java/com/inrupt/client/performance/base/GetResourcesWithGrantCachingTokenScenario.java
@@ -242,7 +242,7 @@ public class GetResourcesWithGrantCachingTokenScenario {
             try (final InputStream is =
                          new ByteArrayInputStream(StandardCharsets.UTF_8.encode("Test text").array())) {
                 final SolidNonRDFSource testResource =
-                        new SolidNonRDFSource(resourceURI, Utils.PLAIN_TEXT, is, null);
+                        new SolidNonRDFSource(resourceURI, Utils.PLAIN_TEXT, is);
                 assertDoesNotThrow(() -> client.create(testResource));
             } catch (IOException e) {
                 LOGGER.warn("Could not create performance test resource " + resourceURI);

--- a/performance/base/src/main/java/com/inrupt/client/performance/base/GetResourcesWithGrantScenario.java
+++ b/performance/base/src/main/java/com/inrupt/client/performance/base/GetResourcesWithGrantScenario.java
@@ -239,7 +239,7 @@ public class GetResourcesWithGrantScenario {
                 try (final InputStream is =
                              new ByteArrayInputStream(StandardCharsets.UTF_8.encode("Test text").array())) {
                     final SolidNonRDFSource testResource =
-                            new SolidNonRDFSource(resourceURI, Utils.PLAIN_TEXT, is, null);
+                            new SolidNonRDFSource(resourceURI, Utils.PLAIN_TEXT, is);
                     assertDoesNotThrow(() -> client.create(testResource));
                 } catch (IOException e) {
                     LOGGER.warn("Could not create performance test resource " + resourceURI);

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -138,14 +138,12 @@ public class SolidClient {
                 } else {
                     final String contentType = response.headers().firstValue(CONTENT_TYPE)
                         .orElse("application/octet-stream");
-                    final Metadata metadata = SolidResourceHandlers.buildMetadata(response.uri(),
-                            response.headers());
                     try {
                         // Check that this is an RDFSoure
                         if (RDFSource.class.isAssignableFrom(clazz)) {
                             final Dataset dataset = SolidResourceHandlers.buildDataset(contentType, response.body(),
                                     identifier.toString()).orElse(null);
-                            final T obj = construct(identifier, clazz, dataset, metadata);
+                            final T obj = construct(identifier, clazz, dataset, response.headers());
                             final ValidationResult res = RDFSource.class.cast(obj).validate();
                             if (!res.isValid()) {
                                 throw new DataMappingException(
@@ -156,7 +154,7 @@ public class SolidClient {
                         // Otherwise, create a non-RDF-bearing resource
                         } else {
                             return construct(identifier, clazz, contentType,
-                                    new ByteArrayInputStream(response.body()), metadata);
+                                    new ByteArrayInputStream(response.body()), response.headers());
                         }
                     } catch (final ReflectiveOperationException ex) {
                         throw new SolidResourceException("Unable to read resource into type " + clazz.getName(),
@@ -388,30 +386,54 @@ public class SolidClient {
     }
 
     static <T extends Resource> T construct(final URI identifier, final Class<T> clazz,
-            final Dataset dataset, final Metadata metadata) throws ReflectiveOperationException {
+            final Dataset dataset, final Headers headers) throws ReflectiveOperationException {
+        // First try an arity-3 ctor with headers
         try {
-            // First try an arity-3 ctor
+            return clazz.getConstructor(URI.class, Dataset.class, Headers.class)
+                .newInstance(identifier, dataset, headers);
+        } catch (final NoSuchMethodException ex) {
+            // no-op
+        }
+
+        // Next, try an arity-3 ctor with metadata
+        // TODO: this construct is deprecated and can be removed in a future version
+        try {
+            final Metadata metadata = Metadata.of(identifier, headers);
             return clazz.getConstructor(URI.class, Dataset.class, Metadata.class)
                         .newInstance(identifier, dataset, metadata);
         } catch (final NoSuchMethodException ex) {
-            // Fall back to an arity-2 ctor
-            return clazz.getConstructor(URI.class, Dataset.class)
-                        .newInstance(identifier, dataset);
+            // no-op
         }
+
+        // Fall back to an arity-2 ctor
+        return clazz.getConstructor(URI.class, Dataset.class)
+                    .newInstance(identifier, dataset);
     }
 
     static <T extends Resource> T construct(final URI identifier, final Class<T> clazz,
-            final String contentType, final InputStream entity, final Metadata metadata)
+            final String contentType, final InputStream entity, final Headers headers)
             throws ReflectiveOperationException {
+        // First try an arity-3 ctor with headers
         try {
-            // First try an arity-4 ctor
+            return clazz.getConstructor(URI.class, String.class, InputStream.class, Headers.class)
+                .newInstance(identifier, contentType, entity, headers);
+        } catch (final NoSuchMethodException ex) {
+            // no-op
+        }
+
+        // Next try an arity-3 ctor with metadata
+        // TODO: this construct is deprecated and can be removed in a future version
+        try {
+            final Metadata metadata = Metadata.of(identifier, headers);
             return clazz.getConstructor(URI.class, String.class, InputStream.class, Metadata.class)
                 .newInstance(identifier, contentType, entity, metadata);
         } catch (final NoSuchMethodException ex) {
-            // Fall back to an arity-3 ctor
-            return clazz.getConstructor(URI.class, String.class, InputStream.class)
-                .newInstance(identifier, contentType, entity);
+            // no-op
         }
+
+        // Fall back to an arity-3 ctor
+        return clazz.getConstructor(URI.class, String.class, InputStream.class)
+            .newInstance(identifier, contentType, entity);
     }
 
     static void decorateHeaders(final Request.Builder builder, final Headers headers) {

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -413,7 +413,7 @@ public class SolidClient {
     static <T extends Resource> T construct(final URI identifier, final Class<T> clazz,
             final String contentType, final InputStream entity, final Headers headers)
             throws ReflectiveOperationException {
-        // First try an arity-3 ctor with headers
+        // First try an arity-4 ctor with headers
         try {
             return clazz.getConstructor(URI.class, String.class, InputStream.class, Headers.class)
                 .newInstance(identifier, contentType, entity, headers);
@@ -421,7 +421,7 @@ public class SolidClient {
             // no-op
         }
 
-        // Next try an arity-3 ctor with metadata
+        // Next try an arity-4 ctor with metadata
         // TODO: this construct is deprecated and can be removed in a future version
         try {
             final Metadata metadata = Metadata.of(identifier, headers);

--- a/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidNonRDFSource.java
@@ -20,6 +20,7 @@
  */
 package com.inrupt.client.solid;
 
+import com.inrupt.client.Headers;
 import com.inrupt.client.NonRDFSource;
 
 import java.io.InputStream;
@@ -40,7 +41,7 @@ public class SolidNonRDFSource extends NonRDFSource implements SolidResource {
      * @param entity the entity
      */
     public SolidNonRDFSource(final URI identifier, final String contentType, final InputStream entity) {
-        this(identifier, contentType, entity, null);
+        this(identifier, contentType, entity, (Headers) null);
     }
 
     /**
@@ -50,7 +51,9 @@ public class SolidNonRDFSource extends NonRDFSource implements SolidResource {
      * @param contentType the content type
      * @param entity the entity
      * @param metadata the metadata, may be {@code null}
+     * @deprecated use {@link #SolidNonRDFSource(URI, String, InputStream, Headers)} instead
      */
+    @Deprecated
     public SolidNonRDFSource(final URI identifier, final String contentType, final InputStream entity,
             final Metadata metadata) {
         super(identifier, contentType, entity);
@@ -58,6 +61,24 @@ public class SolidNonRDFSource extends NonRDFSource implements SolidResource {
             this.metadata = Metadata.newBuilder().build();
         } else {
             this.metadata = metadata;
+        }
+    }
+
+    /**
+     * Create a non-RDF-bearing Solid Resource.
+     *
+     * @param identifier the resource identifier
+     * @param contentType the content type
+     * @param entity the entity
+     * @param headers the headers, may be {@code null}
+     */
+    public SolidNonRDFSource(final URI identifier, final String contentType, final InputStream entity,
+            final Headers headers) {
+        super(identifier, contentType, entity, headers);
+        if (headers == null) {
+            this.metadata = Metadata.newBuilder().build();
+        } else {
+            this.metadata = Metadata.of(identifier, headers);
         }
     }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidRDFSource.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidRDFSource.java
@@ -20,6 +20,7 @@
  */
 package com.inrupt.client.solid;
 
+import com.inrupt.client.Headers;
 import com.inrupt.client.RDFSource;
 
 import java.net.URI;
@@ -49,7 +50,7 @@ public class SolidRDFSource extends RDFSource implements SolidResource {
      * @param dataset the resource dataset, may be {@code null}
      */
     public SolidRDFSource(final URI identifier, final Dataset dataset) {
-        this(identifier, dataset, null);
+        this(identifier, dataset, (Headers) null);
     }
 
     /**
@@ -58,13 +59,31 @@ public class SolidRDFSource extends RDFSource implements SolidResource {
      * @param identifier the Solid Resource identifier
      * @param dataset the resource dataset, may be {@code null}
      * @param metadata metadata associated with this resource, may be {@code null}
+     * @deprecated use {@link #SolidRDFSource(URI, Dataset, Headers)} instead
      */
+    @Deprecated
     public SolidRDFSource(final URI identifier, final Dataset dataset, final Metadata metadata) {
         super(identifier, dataset);
         if (metadata == null) {
             this.metadata = Metadata.newBuilder().build();
         } else {
             this.metadata = metadata;
+        }
+    }
+
+    /**
+     * Create a Solid resource.
+     *
+     * @param identifier the Solid Resource identifier
+     * @param dataset the resource dataset, may be {@code null}
+     * @param headers headers associated with this resource, may be {@code null}
+     */
+    public SolidRDFSource(final URI identifier, final Dataset dataset, final Headers headers) {
+        super(identifier, dataset, headers);
+        if (headers == null) {
+            this.metadata = Metadata.newBuilder().build();
+        } else {
+            this.metadata = Metadata.of(identifier, headers);
         }
     }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
@@ -20,11 +20,14 @@
  */
 package com.inrupt.client.solid;
 
+import com.inrupt.client.Headers;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.util.HashMap;
 
 /**
  * A reference to a Solid Resource without any corresponding data.
@@ -34,6 +37,7 @@ public class SolidResourceReference implements SolidResource {
     private final InputStream entity;
     private final Metadata metadata;
     private final URI identifier;
+    private final Headers headers;
 
     /**
      * Create a reference to a Solid resource.
@@ -49,6 +53,7 @@ public class SolidResourceReference implements SolidResource {
             this.metadata = metadata;
         }
         this.entity = new ByteArrayInputStream(new byte[0]);
+        this.headers = Headers.of(new HashMap<>());
     }
 
     @Override
@@ -64,6 +69,11 @@ public class SolidResourceReference implements SolidResource {
     @Override
     public InputStream getEntity() throws IOException {
         return entity;
+    }
+
+    @Override
+    public Headers getHeaders() {
+        return headers;
     }
 
     @Override

--- a/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidResourceReference.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.util.HashMap;
 
 /**
  * A reference to a Solid Resource without any corresponding data.
@@ -53,7 +52,7 @@ public class SolidResourceReference implements SolidResource {
             this.metadata = metadata;
         }
         this.entity = new ByteArrayInputStream(new byte[0]);
-        this.headers = Headers.of(new HashMap<>());
+        this.headers = Headers.empty();
     }
 
     @Override

--- a/solid/src/test/java/com/inrupt/client/solid/BasicBinary.java
+++ b/solid/src/test/java/com/inrupt/client/solid/BasicBinary.java
@@ -20,20 +20,12 @@
  */
 package com.inrupt.client.solid;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
 import java.net.URI;
 
-import org.apache.commons.rdf.api.RDFSyntax;
-
-public class InvalidType extends SolidRDFSource {
-    public InvalidType(final URI identifier) {
-        super(identifier);
-    }
-
-    @Override
-    public void serialize(final RDFSyntax syntax, final OutputStream out) throws IOException {
-        throw new IOException("Expected exception");
+public class BasicBinary extends SolidNonRDFSource {
+    public BasicBinary(final URI identifier, final String contentType, final InputStream entity) {
+        super(identifier, contentType, entity);
     }
 }
 

--- a/solid/src/test/java/com/inrupt/client/solid/DeprecatedBinary.java
+++ b/solid/src/test/java/com/inrupt/client/solid/DeprecatedBinary.java
@@ -20,20 +20,12 @@
  */
 package com.inrupt.client.solid;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
 import java.net.URI;
 
-import org.apache.commons.rdf.api.RDFSyntax;
-
-public class InvalidType extends SolidRDFSource {
-    public InvalidType(final URI identifier) {
-        super(identifier);
-    }
-
-    @Override
-    public void serialize(final RDFSyntax syntax, final OutputStream out) throws IOException {
-        throw new IOException("Expected exception");
+public class DeprecatedBinary extends SolidNonRDFSource {
+    public DeprecatedBinary(final URI identifier, final String contentType, final InputStream entity,
+            final Metadata metadata) {
+        super(identifier, contentType, entity, metadata);
     }
 }
-

--- a/solid/src/test/java/com/inrupt/client/solid/DeprecatedType.java
+++ b/solid/src/test/java/com/inrupt/client/solid/DeprecatedType.java
@@ -20,8 +20,6 @@
  */
 package com.inrupt.client.solid;
 
-import com.inrupt.client.Headers;
-import com.inrupt.client.ValidationResult;
 import com.inrupt.rdf.wrapping.commons.TermMappings;
 import com.inrupt.rdf.wrapping.commons.ValueMappings;
 import com.inrupt.rdf.wrapping.commons.WrapperIRI;
@@ -34,18 +32,20 @@ import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.RDFTerm;
 
-public class Playlist extends SolidRDFSource {
+public class DeprecatedType extends SolidRDFSource {
 
     private final IRI dcTitle;
-    private final IRI exSong;
+    private final IRI exIngredient;
+    private final IRI exStep;
     private final Node subject;
 
-    public Playlist(final URI identifier, final Dataset dataset, final Headers headers) {
-        super(identifier, dataset, headers);
+    public DeprecatedType(final URI identifier, final Dataset dataset, final Metadata metadata) {
+        super(identifier, dataset, metadata);
 
         this.subject = new Node(rdf.createIRI(identifier.toString()), getGraph());
         this.dcTitle = rdf.createIRI("http://purl.org/dc/terms/title");
-        this.exSong = rdf.createIRI("https://example.com/song");
+        this.exStep = rdf.createIRI("https://example.com/step");
+        this.exIngredient = rdf.createIRI("https://example.com/ingredient");
     }
 
     public String getTitle() {
@@ -56,17 +56,12 @@ public class Playlist extends SolidRDFSource {
         subject.setTitle(value);
     }
 
-    public Set<URI> getSongs() {
-        return subject.getSongs();
+    public Set<String> getIngredients() {
+        return subject.getIngredients();
     }
 
-    @Override
-    public ValidationResult validate() {
-        //EX: a playlist must contain at least one song
-        if (getSongs().isEmpty()) {
-            return new ValidationResult(false, "A playlist must contain at least one song.");
-        }
-        return new ValidationResult(true);
+    public Set<String> getSteps() {
+        return subject.getSteps();
     }
 
     class Node extends WrapperIRI {
@@ -83,8 +78,12 @@ public class Playlist extends SolidRDFSource {
             overwriteNullable(dcTitle, value, TermMappings::asStringLiteral);
         }
 
-        Set<URI> getSongs() {
-            return objects(exSong, TermMappings::asIri, ValueMappings::iriAsUri);
+        Set<String> getIngredients() {
+            return objects(exIngredient, TermMappings::asStringLiteral, ValueMappings::literalAsString);
+        }
+
+        Set<String> getSteps() {
+            return objects(exStep, TermMappings::asStringLiteral, ValueMappings::literalAsString);
         }
     }
 }

--- a/solid/src/test/java/com/inrupt/client/solid/Recipe.java
+++ b/solid/src/test/java/com/inrupt/client/solid/Recipe.java
@@ -20,6 +20,7 @@
  */
 package com.inrupt.client.solid;
 
+import com.inrupt.client.Headers;
 import com.inrupt.client.RDFSource;
 import com.inrupt.rdf.wrapping.commons.TermMappings;
 import com.inrupt.rdf.wrapping.commons.ValueMappings;
@@ -40,8 +41,8 @@ public class Recipe extends RDFSource {
     private final IRI exStep;
     private final Node subject;
 
-    public Recipe(final URI identifier, final Dataset dataset) {
-        super(identifier, dataset);
+    public Recipe(final URI identifier, final Dataset dataset, final Headers headers) {
+        super(identifier, dataset, headers);
 
         this.subject = new Node(rdf.createIRI(identifier.toString()), getGraph());
         this.dcTitle = rdf.createIRI("http://purl.org/dc/terms/title");

--- a/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidRDFSourceTest.java
@@ -155,7 +155,7 @@ class SolidRDFSourceTest {
     @Test
     void testEmptyResourceBuilder() {
         final URI id = URI.create("https://resource.example/");
-        try (final SolidRDFSource res = new SolidRDFSource(id, null, null)) {
+        try (final SolidRDFSource res = new SolidRDFSource(id)) {
             assertFalse(res.getMetadata().getStorage().isPresent());
             assertFalse(res.getMetadata().getAcl().isPresent());
             assertTrue(res.getMetadata().getAllowedPatchSyntaxes().isEmpty());


### PR DESCRIPTION
This add a `getHeaders()` method to the `com.inrupt.client.Resource` interface. The `SolidClient` then will add response headers to any Resource subtypes.