### PR TITLE
JCL-443: Add a spring integration module

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
           server-id: 'ossrh'
           server-username: MAVEN_REPO_USERNAME

--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -66,11 +66,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'maven'
 
       - name: Build the code with Maven

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 17 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -100,6 +100,11 @@
       </dependency>
       <dependency>
         <groupId>com.inrupt.client</groupId>
+        <artifactId>inrupt-client-spring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-uma</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -113,6 +118,7 @@
         <artifactId>inrupt-client-vocabulary</artifactId>
         <version>${project.version}</version>
       </dependency>
+
 
       <!-- transitive dependencies -->
       <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -119,7 +119,6 @@
         <version>${project.version}</version>
       </dependency>
 
-
       <!-- transitive dependencies -->
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <module>webid</module>
     <module>vocabulary</module>
     <module>runtime</module>
+    <module>spring</module>
     <module>integration</module>
     <module>performance</module>
     <module>reports</module>
@@ -811,15 +812,6 @@
       </activation>
       <modules>
         <module>gradle</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>java-17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <modules>
-        <module>spring</module>
       </modules>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,6 @@
     <module>rdf4j</module>
     <module>rdf-legacy</module>
     <module>solid</module>
-    <module>spring</module>
     <module>test</module>
     <module>uma</module>
     <module>webid</module>
@@ -812,6 +811,15 @@
       </activation>
       <modules>
         <module>gradle</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>java-17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <modules>
+        <module>spring</module>
       </modules>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <json.bind.version>3.0.0</json.bind.version>
     <okhttp.version>4.12.0</okhttp.version>
     <slf4j.version>2.0.9</slf4j.version>
+    <spring.security.version>6.1.5</spring.security.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
     <inrupt.rdf.wrapping.version>1.0.0</inrupt.rdf.wrapping.version>
 
@@ -73,6 +74,8 @@
     <equalsverifier.version>3.15.3</equalsverifier.version>
     <glassfish.json.version>2.0.1</glassfish.json.version>
     <junit.version>5.10.1</junit.version>
+    <smallrye.jwt.version>4.3.1</smallrye.jwt.version>
+    <smallrye.config.version>3.4.1</smallrye.config.version>
     <yasson.version>3.0.3</yasson.version>
     <wiremock.version>3.2.0</wiremock.version>
 
@@ -105,6 +108,7 @@
     <module>rdf4j</module>
     <module>rdf-legacy</module>
     <module>solid</module>
+    <module>spring</module>
     <module>test</module>
     <module>uma</module>
     <module>webid</module>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -94,6 +94,11 @@
     </dependency>
     <dependency>
       <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-spring</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-uma</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.inrupt.client</groupId>
+    <artifactId>inrupt-client</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>inrupt-client-spring</artifactId>
+  <name>Inrupt Java Client Libraries - Spring integration</name>
+  <description>
+      Integration utilities for Spring support.
+  </description>
+
+  <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-openid</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
+      <version>${spring.security.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-core</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <version>${spring.security.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-jwt-build</artifactId>
+      <version>${smallrye.jwt.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.smallrye.config</groupId>
+      <artifactId>smallrye-config</artifactId>
+      <version>${smallrye.config.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.json</artifactId>
+      <version>${glassfish.json.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables />
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables />
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -14,8 +14,8 @@
   </description>
 
   <properties>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
   </properties>
 
   <dependencies>
@@ -86,6 +86,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>java-17</id>
+      <activation>
+        <jdk>[,17)</jdk>
+      </activation>
+      <properties>
+        <spring.security.version>5.8.8</spring.security.version>
+      </properties>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -89,7 +89,7 @@
 
   <profiles>
     <profile>
-      <id>java-17</id>
+      <id>java-11</id>
       <activation>
         <jdk>[,17)</jdk>
       </activation>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -14,8 +14,8 @@
   </description>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
   </properties>
 
   <dependencies>

--- a/spring/src/main/java/com/inrupt/client/spring/SessionUtils.java
+++ b/spring/src/main/java/com/inrupt/client/spring/SessionUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.spring;
+
+import com.inrupt.client.auth.Session;
+import com.inrupt.client.openid.OpenIdSession;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public final class SessionUtils {
+
+    /**
+     * Convert a Spring {@link OAuth2User} to a {@link Session} object.
+     *
+     * <p>This method uses the {@link OpenIdSession} library to create a Session
+     *
+     * @param user the Spring user object
+     * @return the session, if present and unexpired
+     */
+    public static Optional<Session> asSession(final OAuth2User user) {
+        return asSession(user, OpenIdSession::ofIdToken);
+    }
+
+    /**
+     * Convert a Spring {@link OAuth2User} to a {@link Session} object.
+     *
+     * @param user the Spring user object
+     * @param mapping a mapping function for creating a Session from an ID token
+     * @return the session, if present and unexpired
+     */
+    public static Optional<Session> asSession(final OAuth2User user, final Function<String, Session> mapping) {
+        if (user instanceof OidcUser) {
+            final var oidc = (OidcUser) user;
+            final var token = oidc.getIdToken();
+            if (Instant.now().isBefore(token.getExpiresAt())) {
+                return Optional.ofNullable(mapping.apply(token.getTokenValue()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private SessionUtils() {
+        // Prevent instantiation
+    }
+}
+

--- a/spring/src/main/java/com/inrupt/client/spring/SessionUtils.java
+++ b/spring/src/main/java/com/inrupt/client/spring/SessionUtils.java
@@ -36,7 +36,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public final class SessionUtils {
 
     /**
-     * Convert a Spring OAuth2User to a {@link Session} object.
+     * Convert a Spring {@link OAuth2User} to a {@link Session} object.
      *
      * <p>This method uses the {@link OpenIdSession} library to create a Session
      *
@@ -48,7 +48,7 @@ public final class SessionUtils {
     }
 
     /**
-     * Convert a Spring OAuth2User to a {@link Session} object.
+     * Convert a Spring {@link OAuth2User} to a {@link Session} object.
      *
      * @param user the Spring user object
      * @param mapping a mapping function for creating a Session from an ID token

--- a/spring/src/main/java/com/inrupt/client/spring/SessionUtils.java
+++ b/spring/src/main/java/com/inrupt/client/spring/SessionUtils.java
@@ -30,10 +30,13 @@ import java.util.function.Function;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+/**
+ * A utility class for converting Spring constructs into session objects for use with the Java Client libraries.
+ */
 public final class SessionUtils {
 
     /**
-     * Convert a Spring {@link OAuth2User} to a {@link Session} object.
+     * Convert a Spring OAuth2User to a {@link Session} object.
      *
      * <p>This method uses the {@link OpenIdSession} library to create a Session
      *
@@ -45,7 +48,7 @@ public final class SessionUtils {
     }
 
     /**
-     * Convert a Spring {@link OAuth2User} to a {@link Session} object.
+     * Convert a Spring OAuth2User to a {@link Session} object.
      *
      * @param user the Spring user object
      * @param mapping a mapping function for creating a Session from an ID token

--- a/spring/src/test/java/com/inrupt/client/spring/SessionUtilsTest.java
+++ b/spring/src/test/java/com/inrupt/client/spring/SessionUtilsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.spring;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.inrupt.client.auth.Session;
+import com.inrupt.client.openid.OpenIdSession;
+
+import io.smallrye.jwt.build.Jwt;
+import io.smallrye.jwt.util.ResourceUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.jose4j.jwk.PublicJsonWebKey;
+import org.jose4j.lang.JoseException;
+import org.jose4j.lang.UncheckedJoseException;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+
+class SessionUtilsTest {
+
+    static final String WEBID = "https://example.com/user";
+    static final String ISSUER = "https://issuer.example";
+
+    @Test
+    void testSession() {
+        final var token = generateIdToken("user", ISSUER, WEBID);
+        final var oauthUser = new DefaultOidcUser(AuthorityUtils.NO_AUTHORITIES, token);
+        final var session = SessionUtils.asSession(oauthUser, OpenIdSession::ofIdToken);
+        assertTrue(session.isPresent());
+        session.ifPresent(s ->
+            assertEquals(Optional.of(URI.create(WEBID)), s.getPrincipal()));
+    }
+
+    @Test
+    void testAnonymousSession() {
+        final var token = generateIdToken("user", ISSUER, WEBID);
+        final var oauthUser = new DefaultOidcUser(AuthorityUtils.NO_AUTHORITIES, token);
+        final var session = SessionUtils.asSession(oauthUser, t -> Session.anonymous());
+        assertTrue(session.isPresent());
+        session.ifPresent(s ->
+            assertEquals(Optional.empty(), s.getPrincipal()));
+    }
+
+    @Test
+    void testSessionNoMapper() {
+        final var token = generateIdToken("user", ISSUER, WEBID);
+        final var oauthUser = new DefaultOidcUser(AuthorityUtils.NO_AUTHORITIES, token);
+        final var session = SessionUtils.asSession(oauthUser);
+        assertTrue(session.isPresent());
+        session.ifPresent(s ->
+            assertEquals(Optional.of(URI.create(WEBID)), s.getPrincipal()));
+    }
+
+    static OidcIdToken generateIdToken(final String sub, final String issuer, final String webid) {
+        try {
+            final var jwk = PublicJsonWebKey.Factory
+                   .newPublicJwk(ResourceUtils.readResource("testKey.json"));
+            final var token = Jwt.claims()
+                    .subject(sub)
+                    .issuer(issuer)
+                    .claim("webid", webid)
+                    .audience("solid").jws()
+                    .keyId("E1amq-dXv6METCuD2iRwAQ").sign(jwk.getPrivateKey());
+            return OidcIdToken.withTokenValue(token).expiresAt(Instant.now().plusSeconds(100)).subject(sub)
+                .issuer(issuer).claim("webid", webid).build();
+        } catch (final IOException | JoseException ex) {
+            throw new UncheckedJoseException("Could not build token", ex);
+        }
+    }
+}
+

--- a/spring/src/test/resources/testKey.json
+++ b/spring/src/test/resources/testKey.json
@@ -1,0 +1,11 @@
+{
+    "kty":"EC",
+    "kid":"E1amq-dXv6METCuD2iRwAQ",
+    "use":"sig",
+    "alg":"ES256",
+    "x":"wvWxj3Xdh8iG44q5cQrONfwj6SuTjzzouqsS53V5xAs",
+    "y":"9V1QqMrYuVXE29k2VFXuaOzRiRBXwwO5f-DVE-dWSFY",
+    "crv":"P-256",
+    "d":"OtoNBDywb522vDbw_CNDrKPLZmt_d_7XMdQyXQyd7Ho"
+}
+


### PR DESCRIPTION
This adds a spring integration module, making it easier to convert Spring security's `OAuth2User` objects into `Session` objects that can be used with the JCL.

This introduces two methods:

`com.inrupt.client.spring.SessionUtils.asSession(OAuth2User, Function<String, Session>)`

The first method allows a caller to use any mechanism to convert a raw OpenID ID Token into a Session object, such as:

```java
SessionUtils.asSession(user, token -> OpenIdSession.ofIdToken(token));
```

`com.inrupt.client.spring.SessionUtils.asSession(OAuth2User)`

The second option uses the OpenIdSession class to handle session generation (i.e. the example from the first instance)


Please note: Spring Security 6.x requires Java 17. I have added some profile magic to downgrade to Spring Security 5.x when Java 11 is used. The dependency is scoped to `provided`, which means that the downstream developer has flexibility over which version to use