### PR TITLE
JCL-426: Normalize URI resource identifiers

### DIFF
--- a/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
+++ b/access-grant/src/main/java/com/inrupt/client/accessgrant/AccessCredential.java
@@ -64,7 +64,7 @@ public class AccessCredential {
      */
     protected AccessCredential(final URI identifier, final String credential,
             final CredentialData data, final CredentialMetadata metadata) {
-        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null");
+        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null").normalize();
         this.credential = Objects.requireNonNull(credential, "credential may not be null!");
         Objects.requireNonNull(data, "credential data may not be null!");
         Objects.requireNonNull(metadata, "credential metadata may not be null!");

--- a/api/src/main/java/com/inrupt/client/NonRDFSource.java
+++ b/api/src/main/java/com/inrupt/client/NonRDFSource.java
@@ -63,7 +63,7 @@ public class NonRDFSource implements Resource {
      */
     protected NonRDFSource(final URI identifier, final String contentType, final InputStream entity,
             final Headers headers) {
-        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null!");
+        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null!").normalize();
         this.contentType = Objects.requireNonNull(contentType, "contentType may not be null!");
         this.entity = Objects.requireNonNull(entity, "entity may not be null!");
         this.headers = headers == null ? Headers.empty() : headers;

--- a/api/src/main/java/com/inrupt/client/RDFSource.java
+++ b/api/src/main/java/com/inrupt/client/RDFSource.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.Objects;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.RDF;
@@ -102,8 +103,8 @@ public class RDFSource extends WrapperDataset implements Resource {
     protected RDFSource(final URI identifier, final RDFSyntax syntax, final Dataset dataset, final Headers headers) {
         super(dataset == null ? rdf.createDataset() : dataset);
         this.headers = headers == null ? Headers.empty() : headers;
-        this.identifier = identifier;
-        this.syntax = syntax;
+        this.identifier = Objects.requireNonNull(identifier, "identifier may not be null!").normalize();
+        this.syntax = Objects.requireNonNull(syntax);
     }
 
     @Override

--- a/api/src/main/java/com/inrupt/client/Request.java
+++ b/api/src/main/java/com/inrupt/client/Request.java
@@ -117,7 +117,7 @@ public final class Request {
 
     Request(final URI uri, final String method, final Map<String, List<String>> headers,
             final BodyPublisher publisher, final Duration timeout) {
-        this.requestUri = Objects.requireNonNull(uri, "Request URI may not be null!");
+        this.requestUri = Objects.requireNonNull(uri, "Request URI may not be null!").normalize();
         this.requestMethod = Objects.requireNonNull(method, "Request method may not be null!");
         this.requestHeaders = Headers.of(Objects.requireNonNull(headers, "Request headers may not be null!"));
         this.requestTimeout = timeout;

--- a/api/src/main/java/com/inrupt/client/util/URIBuilder.java
+++ b/api/src/main/java/com/inrupt/client/util/URIBuilder.java
@@ -111,7 +111,7 @@ public final class URIBuilder {
             schemeSpecificPart.append(String.join("&", queryParams));
         }
         try {
-            return new URI(scheme, schemeSpecificPart.toString(), uriFragment);
+            return new URI(scheme, schemeSpecificPart.toString(), uriFragment).normalize();
         } catch (final URISyntaxException ex) {
             throw new IllegalArgumentException("Invalid URI value", ex);
         }

--- a/api/src/test/java/com/inrupt/client/util/URIBuilderTest.java
+++ b/api/src/test/java/com/inrupt/client/util/URIBuilderTest.java
@@ -142,4 +142,13 @@ class URIBuilderTest {
 
         assertEquals(expected, URIBuilder.newBuilder(uri).path(null).path("").path("/data/").build());
     }
+
+    @Test
+    void testNormalized() {
+        final URI uri = URI.create("https://storage.example/container1/../container2/");
+        final URI expected = URI.create("https://storage.example/container2/");
+
+        assertNotEquals(expected, uri);
+        assertEquals(expected, URIBuilder.newBuilder(uri).build());
+    }
 }


### PR DESCRIPTION
This adds URI normalization at key points in the code. This makes it unnecessary for users to manually normalize URIs before passing them into the JCL APIs