### PR TITLE
Prepare for 1.2 development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,44 @@ updates:
       - "backport"
       - "1.0"
 
+# 1.1 Maintenance
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.1"
+    ignore:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+    labels:
+      - "backport"
+      - "1.1"
+
+  - package-ecosystem: "maven"
+    directory: "/rdf4j/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.1"
+    allow:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+    labels:
+      - "backport"
+      - "1.1"
+
+  - package-ecosystem: "gradle"
+    directory: "/gradle/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.1"
+    labels:
+      - "backport"
+      - "1.1"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.1"
+    labels:
+      - "backport"
+      - "1.1"
+

--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-accessgrant</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-api</artifactId>

--- a/archetypes/java/pom.xml
+++ b/archetypes/java/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-archetype-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-archetype-java</artifactId>

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-archetype-parent</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/caffeine/pom.xml
+++ b/caffeine/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-caffeine</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-core</artifactId>

--- a/examples/cli/pom.xml
+++ b/examples/cli/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-examples-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-examples-cli</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>Inrupt Java Client Libraries - CLI Example</name>
   <description>
     Sample CLI application.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-examples-parent</artifactId>

--- a/examples/springboot/pom.xml
+++ b/examples/springboot/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-examples-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-examples-springboot</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>Inrupt Java Client Libraries - Spring Boot Example</name>
   <description>
     Sample Spring Boot application.

--- a/examples/webapp/pom.xml
+++ b/examples/webapp/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-examples-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-examples-webapp</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>Inrupt Java Client Libraries - Quarkus Example</name>
   <description>
     Sample web application.

--- a/gradle/pom.xml
+++ b/gradle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-gradle</artifactId>

--- a/guava/pom.xml
+++ b/guava/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-guava</artifactId>

--- a/httpclient/pom.xml
+++ b/httpclient/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-httpclient</artifactId>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-integration-tests</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>inrupt-client-integration-base-tests</artifactId>
     <name>Inrupt Java Client Libraries - Integration Base Tests</name>

--- a/integration/customokhttp/pom.xml
+++ b/integration/customokhttp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-integration-tests</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-integration-customokhttp</artifactId>

--- a/integration/openid/pom.xml
+++ b/integration/openid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-integration-tests</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-integration-openid-tests</artifactId>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-integration-tests</artifactId>

--- a/integration/uma/pom.xml
+++ b/integration/uma/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-integration-tests</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-integration-uma-tests</artifactId>

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-jackson</artifactId>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-jena</artifactId>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-jsonb</artifactId>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-okhttp</artifactId>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-openid</artifactId>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-parser</artifactId>

--- a/performance/base/pom.xml
+++ b/performance/base/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.inrupt.client</groupId>
         <artifactId>inrupt-client-performance-tests</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>inrupt-client-performance-base-tests</artifactId>
     <name>Inrupt Java Client Libraries - Performance Base Tests</name>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-performance-tests</artifactId>

--- a/performance/uma/pom.xml
+++ b/performance/uma/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client-performance-tests</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-performance-uma-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.inrupt.client</groupId>
   <artifactId>inrupt-client</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <name>Inrupt Java Client Libraries</name>
   <url>https://docs.inrupt.com/developer-tools/java/client-libraries/</url>
   <description>
@@ -261,9 +261,9 @@
               <id>enforce</id>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions/>
-                  <requirePluginVersions/>
-                  <banCircularDependencies/>
+                  <banDuplicatePomDependencyVersions />
+                  <requirePluginVersions />
+                  <banCircularDependencies />
                 </rules>
               </configuration>
               <goals>

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-quarkus</artifactId>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-rdf-legacy</artifactId>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-rdf4j</artifactId>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-report</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-solid</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-spring</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-test</artifactId>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-uma</artifactId>

--- a/vocabulary/pom.xml
+++ b/vocabulary/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-vocabulary</artifactId>

--- a/webid/pom.xml
+++ b/webid/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.client</groupId>
     <artifactId>inrupt-client</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-client-webid</artifactId>


### PR DESCRIPTION
This adjusts dependabot to now include the 1.1 maintenance branch. In addition, the main branch now targets the 1.2 snapshot.

All 1.1 development is now on the `1.1` maintenance branch