### PR TITLE
Dependabot support for spring security versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+      - dependency-name: "org.springframework.security:spring-*"
 
   - package-ecosystem: "maven"
     directory: "/rdf4j/"
@@ -13,6 +14,13 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+
+  - package-ecosystem: "spring"
+    directory: "/spring/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "org.springframework.security:spring-*"
 
   - package-ecosystem: "gradle"
     directory: "/gradle/"
@@ -73,6 +81,7 @@ updates:
     target-branch: "1.1"
     ignore:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+      - dependency-name: "org.springframework.security:spring-*"
     labels:
       - "backport"
       - "1.1"
@@ -84,6 +93,17 @@ updates:
     target-branch: "1.1"
     allow:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+    labels:
+      - "backport"
+      - "1.1"
+
+  - package-ecosystem: "maven"
+    directory: "/spring/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.1"
+    allow:
+      - dependency-name: "org.springframework.security:spring-*"
     labels:
       - "backport"
       - "1.1"

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
     <okhttp.version>4.12.0</okhttp.version>
     <quarkus.version>3.6.0</quarkus.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <spring.security.version>6.1.5</spring.security.version>
+    <!-- pinning to Spring 5.x for Java 11 support -->
+    <spring.security.version>5.8.8</spring.security.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
     <inrupt.rdf.wrapping.version>1.0.0</inrupt.rdf.wrapping.version>
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -18,6 +18,18 @@
     <maven.compiler.source>11</maven.compiler.source>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-bom</artifactId>
+        <version>${spring.security.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.inrupt.client</groupId>
@@ -32,7 +44,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-core</artifactId>
-      <version>${spring.security.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -64,7 +75,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <version>${spring.security.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -89,12 +99,12 @@
 
   <profiles>
     <profile>
-      <id>java-11</id>
+      <id>java-17</id>
       <activation>
-        <jdk>[,17)</jdk>
+        <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <spring.security.version>5.8.8</spring.security.version>
+        <spring.security.version>6.1.5</spring.security.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Similar to how multiple RDF4J versions need to be managed for different parts of the JCL, spring support depends on the Java runtime (Spring 5 works on Java11, Spring 6 requires Java 17+). This restructures the dependabot version management a bit so that the project can better support these differences.

In this case, the `java-11` profile is inverted, and changed to a `java-17` profile. The Java 11-based Spring version is defined in the root pom.xml while the Java 17+ version is defined in the spring/pom.xml file.