### PR TITLE
Fix typo in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
     allow:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
 
-  - package-ecosystem: "spring"
+  - package-ecosystem: "maven"
     directory: "/spring/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This fixes a typo in the dependabot configuration that was introduced with #817 