### PR TITLE
Add support for dependency-check 9.x using an NVD API key

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -110,4 +110,4 @@ jobs:
           cache: 'maven'
 
       - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pdependencies
+        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.key=${{ secrets.NVD_API_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <javadoc.plugin.version>3.6.2</javadoc.plugin.version>
     <license.plugin.version>4.3</license.plugin.version>
     <nexus.plugin.version>1.6.13</nexus.plugin.version>
-    <owasp.plugin.version>8.4.3</owasp.plugin.version>
+    <owasp.plugin.version>9.0.2</owasp.plugin.version>
     <projectinfo.plugin.version>3.5.0</projectinfo.plugin.version>
     <pmd.plugin.version>3.21.2</pmd.plugin.version>
     <site.plugin.version>3.12.1</site.plugin.version>
@@ -79,6 +79,7 @@
     <!-- disable by default (enabled by profile in CI) -->
     <dependency-check.skip>true</dependency-check.skip>
     <archetype.test.skip>true</archetype.test.skip>
+    <nvd.api.key/>
 
     <!-- sonar -->
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/reports/target/site/jacoco-merged/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -589,6 +590,8 @@
           <suppressionFile>
               ./build-tools/owasp/suppressions.xml
           </suppressionFile>
+          <nvdApiKey>${nvd.api.key}</nvdApiKey>
+          <knownExploitedEnabled>false</knownExploitedEnabled>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,6 @@
               ./build-tools/owasp/suppressions.xml
           </suppressionFile>
           <nvdApiKey>${nvd.api.key}</nvdApiKey>
-          <knownExploitedEnabled>false</knownExploitedEnabled>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This is a backport of #832 