### PR TITLE
JCL-446: config application metadata request tests

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -38,6 +38,7 @@ jobs:
           INRUPT_TEST_REQUESTER_CLIENT_ID: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_ID }}
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_SECRET }}
           INRUPT_TEST_REQUEST_METADATA_FEATURE: false
+          INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE:
 
       - name: Dev Integration tests
         if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 11 }}

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -38,7 +38,7 @@ jobs:
           INRUPT_TEST_REQUESTER_CLIENT_ID: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_ID }}
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_SECRET }}
           INRUPT_TEST_REQUEST_METADATA_FEATURE: false
-          INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE:
+          INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ''
 
       - name: Dev Integration tests
         if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 11 }}

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -37,6 +37,7 @@ jobs:
           INRUPT_TEST_REQUESTER_WEBID: ${{ secrets.INRUPT_PROD_REQUESTER_WEBID }}
           INRUPT_TEST_REQUESTER_CLIENT_ID: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_ID }}
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_SECRET }}
+          INRUPT_TEST_REQUEST_METADATA_FEATURE: false
 
       - name: Dev Integration tests
         if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 11 }}
@@ -50,6 +51,8 @@ jobs:
           INRUPT_TEST_REQUESTER_WEBID: ${{ secrets.INRUPT_DEV_REQUESTER_WEBID }}
           INRUPT_TEST_REQUESTER_CLIENT_ID: ${{ secrets.INRUPT_DEV_REQUESTER_CLIENT_ID }}
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_DEV_REQUESTER_CLIENT_SECRET }}
+          INRUPT_TEST_REQUEST_METADATA_FEATURE: true
+          INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_DEV_HEADERS_THAT_PROPAGATE }}
 
   performance:
     name: Performance Tests

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -38,7 +38,7 @@ jobs:
           INRUPT_TEST_REQUESTER_CLIENT_ID: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_ID }}
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_SECRET }}
           INRUPT_TEST_REQUEST_METADATA_FEATURE: false
-          INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ''
+          INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_PROD_HEADERS_THAT_PROPAGATE }}
 
       - name: Dev Integration tests
         if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 11 }}

--- a/integration/README.md
+++ b/integration/README.md
@@ -32,8 +32,8 @@ All the possible value are listed next:
 * `inrupt.test.webid`
 * `inrupt.test.access-grant.provider`
 * `inrupt.test.requester.webid`
-* `inrupt.test.requester.client-id` // mandatory
-* `inrupt.test.requester.client-secret` // mandatory
+* `inrupt.test.requester.client-id` // mandatory for running the AccessGrant scenarios
+* `inrupt.test.requester.client-secret` // mandatory for running the AccessGrant scenarios
 
 Mandatory fields are:
 * `inrupt.test.client-id` & `inrupt.test.client-secret` are used to signal the server that this is a registered client acting as the owner of resources.

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -137,7 +137,7 @@ public class ApplicationRequestMetadataScenarios {
         LOGGER.info("Integration Test - Request and response headers match for a successful authenticated request");
 
         final Headers applicationHeaders = Headers.of(
-                Map.of("somecid", List.of("a6d87d0e-2454-4501-8110-ecc082aa975f"))
+                Map.of("someblabla", List.of("a6d87d0e-2454-4501-8110-ecc082aa975f"))
         );
 
         final SolidClient authClient = SolidClient.getClientBuilder()

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -263,8 +263,8 @@ public class ApplicationRequestMetadataScenarios {
         // Create a new resource and check response headers
         final URI resourceUri = URI.create(resourceName);
         try ( var resource = authClient.create(new SolidRDFSource(resourceUri, dataset))) {
-            for (String value: REQUEST_METADATA_HEADERS_THAT_PROPAGATE) {
-                assertEquals(headers.get(value), resource.getHeaders().allValues(value));
+            for (String header: REQUEST_METADATA_HEADERS_THAT_PROPAGATE) {
+                assertEquals(headers.get(header), resource.getHeaders().allValues(header));
             }
             assertTrue(resource.getHeaders().allValues("someblabla").isEmpty());
         }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -74,7 +74,7 @@ public class ApplicationRequestMetadataScenarios {
 
     private static final String[] REQUEST_METADATA_HEADERS_THAT_PROPAGATE = config
             .getOptionalValue("inrupt.test.request-metadata-headers-that-propagate", String[].class)
-            .orElse(new String[]{""});
+            .orElse(new String[0]);
 
     private static final String AUTH_METHOD = config
             .getOptionalValue("inrupt.test.auth-method", String.class)

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -1,0 +1,186 @@
+package com.inrupt.client.integration.base;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.inrupt.client.Headers;
+import com.inrupt.client.auth.Credential;
+import com.inrupt.client.auth.Session;
+import com.inrupt.client.openid.OpenIdException;
+import com.inrupt.client.openid.OpenIdSession;
+import com.inrupt.client.solid.SolidClient;
+import com.inrupt.client.solid.SolidClientException;
+import com.inrupt.client.solid.SolidRDFSource;
+import com.inrupt.client.solid.SolidSyncClient;
+import com.inrupt.client.spi.RDFFactory;
+import com.inrupt.client.util.URIBuilder;
+import com.inrupt.client.webid.WebIdProfile;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.apache.commons.rdf.api.Dataset;
+import org.apache.commons.rdf.api.IRI;
+import org.apache.commons.rdf.api.Literal;
+import org.apache.commons.rdf.api.RDF;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ApplicationRequestMetadataScenarios {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplicationRequestMetadataScenarios.class);
+    private static String podUrl;
+    private static String webidUrl;
+
+    private static final Config config = ConfigProvider.getConfig();
+
+    private static String issuer;
+
+    private static final RDF rdf = RDFFactory.getInstance();
+
+    private static final String APPLICATION_REQUEST_METADATA_FEATURE = config
+            .getOptionalValue("inrupt.test.feature.application-request-metadata", String.class)
+            .orElse("false");
+
+    private static final String AUTH_METHOD = config
+            .getOptionalValue("inrupt.test.auth-method", String.class)
+            .orElse("client_secret_basic");
+    private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
+    private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
+
+    private static final String FOLDER_SEPARATOR = "/";
+
+    private static URI publicContainerURI;
+    private static URI privateContainerURI;
+
+    private static SolidSyncClient authenticatedClient;
+    private static Session session;
+
+    @BeforeAll
+    static void setup() {
+       /* if (!featureIsActive()) {
+            LOGGER.info("ApplicationRequestMetadataScenarios are skipped, feature not active");
+            return;
+        }*/
+        LOGGER.info("Setup ApplicationRequestMetadataScenarios test");
+        if (config.getOptionalValue("inrupt.test.webid", String.class).isPresent()) {
+            LOGGER.info("Running ApplicationRequestMetadataScenarios on live server");
+            webidUrl = config.getOptionalValue("inrupt.test.webid", String.class).get();
+        }
+
+        State.WEBID = URI.create(webidUrl);
+        //find storage from WebID using domain-specific webID solid concept
+        final SolidSyncClient client = SolidSyncClient.getClient().session(Session.anonymous());
+        try (final WebIdProfile sameProfile = client.read(URI.create(webidUrl), WebIdProfile.class)) {
+            final var storages = sameProfile.getStorages();
+            issuer = sameProfile.getOidcIssuers().iterator().next().toString();
+            if (!storages.isEmpty()) {
+                podUrl = storages.iterator().next().toString();
+            }
+
+            session = OpenIdSession.ofClientCredentials(
+                    URI.create(issuer), //Client credentials
+                    CLIENT_ID,
+                    CLIENT_SECRET,
+                    AUTH_METHOD);
+
+            authenticatedClient = client.session(session);
+        } catch (SolidClientException ex) {
+            LOGGER.error("problems reading the webId");
+        }
+
+        publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
+                .path("public-domain-test-" + UUID.randomUUID() + FOLDER_SEPARATOR)
+                .build();
+
+        Utils.createPublicContainer(authenticatedClient, publicContainerURI);
+
+        privateContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
+                .path(State.PRIVATE_RESOURCE_PATH + "-auth-test-" + UUID.randomUUID() + "/")
+                .build();
+
+        Utils.createContainer(authenticatedClient, privateContainerURI);
+
+
+        LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());
+    }
+
+    @AfterAll
+    static void teardown() {
+       // if (featureIsActive()) {
+            //cleanup pod
+            Utils.deleteContentsRecursively(authenticatedClient, publicContainerURI);
+            Utils.deleteContentsRecursively(authenticatedClient, privateContainerURI);
+      //  }
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSessions")
+    @DisplayName(" " +
+            "Request and response headers match for a successful authenticated request")
+    void requestResponseMatchOnAuthRequestTest(final Session session) {
+       // assumeTrue(featureIsActive());
+
+        LOGGER.info("Integration Test - Request and response headers match for a successful authenticated request");
+
+        final Headers applicationHeaders = Headers.of(
+                Map.of("somecid", List.of("a6d87d0e-2454-4501-8110-ecc082aa975f"))
+        );
+
+        final SolidClient authClient = SolidClient.getClientBuilder()
+                .headers(applicationHeaders).build()
+                .session(session);
+
+        final String resourceName = privateContainerURI + "e2e-test-application-metadata1";
+        final String predicateName = "https://example.example/predicate";
+        final IRI booleanType = rdf.createIRI("http://www.w3.org/2001/XMLSchema#boolean");
+
+        final IRI subject = rdf.createIRI(resourceName);
+        final IRI predicate = rdf.createIRI(predicateName);
+        final Literal objectTrue = rdf.createLiteral("true", booleanType);
+
+        // Populate data for this resource
+        final Dataset dataset = rdf.createDataset();
+        dataset.add(null, subject, predicate, objectTrue);
+
+        // Create a new resource and check response
+        final URI resourceUri = URI.create(resourceName);
+        authClient.create(
+                new SolidRDFSource(resourceUri, dataset)).thenAccept(response -> {
+
+            assertEquals("0d1e63a3-b635-4d50-ba7f-34b7176defdf",
+                    response.getHeaders().allValues("somecid").get(0));
+        });
+    }
+
+    private static Stream<Arguments> provideSessions() throws SolidClientException {
+        final Session session = OpenIdSession.ofClientCredentials(
+                URI.create(issuer), //Client credentials
+                CLIENT_ID,
+                CLIENT_SECRET,
+                AUTH_METHOD);
+        final Optional<Credential> credential = session.getCredential(OpenIdSession.ID_TOKEN, null);
+        final var token = credential.map(Credential::getToken)
+                .orElseThrow(() -> new OpenIdException("We could not get a token"));
+        return Stream.of(
+                        Arguments.of(OpenIdSession.ofIdToken(token), //OpenId token
+                        Arguments.of(session)));
+    }
+
+    private static boolean featureIsActive() {
+        return APPLICATION_REQUEST_METADATA_FEATURE.equals("true");
+    }
+}

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -91,10 +91,6 @@ public class ApplicationRequestMetadataScenarios {
 
     @BeforeAll
     static void setup() {
-        if (!featureIsActive()) {
-            LOGGER.info("ApplicationRequestMetadataScenarios are skipped, feature not active");
-            return;
-        }
         LOGGER.info("Setup ApplicationRequestMetadataScenarios test");
         if (config.getOptionalValue("inrupt.test.webid", String.class).isPresent()) {
             LOGGER.info("Running ApplicationRequestMetadataScenarios on live server");
@@ -134,17 +130,17 @@ public class ApplicationRequestMetadataScenarios {
 
         Utils.createContainer(authenticatedClient, privateContainerURI);
 
-
         LOGGER.info("Integration Test Pod Host: [{}]", URI.create(podUrl).getHost());
+        if (!featureIsActive()) {
+            LOGGER.info("ApplicationRequestMetadataScenarios are skipped, feature not active");
+        }
     }
 
     @AfterAll
     static void teardown() {
-        if (featureIsActive()) {
-            //cleanup pod
-            Utils.deleteContentsRecursively(authenticatedClient, publicContainerURI);
-            Utils.deleteContentsRecursively(authenticatedClient, privateContainerURI);
-        }
+        //cleanup pod
+        Utils.deleteContentsRecursively(authenticatedClient, publicContainerURI);
+        Utils.deleteContentsRecursively(authenticatedClient, privateContainerURI);
     }
 
     @ParameterizedTest

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -1,7 +1,26 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.inrupt.client.integration.base;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.inrupt.client.Headers;
 import com.inrupt.client.auth.Credential;

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -290,8 +290,8 @@ public class ApplicationRequestMetadataScenarios {
 
     private Map<String, List<String>> fillHeaders(final String headerValue) {
         final var headers = new HashMap<String, List<String>>();
-        for (String value: REQUEST_METADATA_HEADERS_THAT_PROPAGATE) {
-            headers.put(value, List.of(headerValue + "-" + UUID.randomUUID()));
+        for (String header: REQUEST_METADATA_HEADERS_THAT_PROPAGATE) {
+            headers.put(header, List.of(headerValue + "-" + UUID.randomUUID()));
         }
         return headers;
     }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -46,7 +46,6 @@ import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Literal;
 import org.apache.commons.rdf.api.RDF;
-import org.apache.http.Header;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.*;
@@ -174,10 +173,10 @@ public class ApplicationRequestMetadataScenarios {
 
         final URI resourceUri = URI.create(resourceName);
 
-        var headers = fillHeaders("aaaaaa");
+        final var headers = fillHeaders("aaaaaa");
 
         // Create a new resource and check response headers
-        Request.Builder reqBuilder = Request.newBuilder(resourceUri)
+        final Request.Builder reqBuilder = Request.newBuilder(resourceUri)
                 .header(Utils.CONTENT_TYPE, Utils.TEXT_TURTLE)
                 .PUT(Request.BodyPublishers.noBody());
 
@@ -207,7 +206,7 @@ public class ApplicationRequestMetadataScenarios {
         LOGGER.info("Integration Test - High level async client -" +
                 " Request and response headers match for a successful authenticated request");
 
-        var headers = fillHeaders("bbbbbb");
+        final var headers = fillHeaders("bbbbbb");
         headers.put("someblabla", List.of("bbbbbb-2454-4501-8110-ecc082aa975f"));
 
         final SolidClient authClient = SolidClient.getClientBuilder()
@@ -246,7 +245,7 @@ public class ApplicationRequestMetadataScenarios {
         LOGGER.info("Integration Test - High level sync client -" +
                 " Request and response headers match for a successful authenticated request");
 
-        var headers = fillHeaders("ccccc");
+        final var headers = fillHeaders("ccccc");
         headers.put("someblabla", List.of("ccccc-2454-4501-8110-ecc082aa975f"));
 
         final SolidSyncClient authClient = SolidSyncClient.getClientBuilder()
@@ -294,7 +293,7 @@ public class ApplicationRequestMetadataScenarios {
     }
 
     private Map<String, List<String>> fillHeaders(final String headerValue) {
-        var headers = new HashMap<String, List<String>>();
+        final var headers = new HashMap<String, List<String>>();
         for (String value: REQUEST_METADATA_HEADERS_THAT_PROPAGATE) {
             headers.put(value, List.of(headerValue + "-" + UUID.randomUUID()));
         }

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -73,7 +73,8 @@ public class ApplicationRequestMetadataScenarios {
             .orElse("false");
 
     private static final String[] REQUEST_METADATA_HEADERS_THAT_PROPAGATE = config
-            .getValue("inrupt.test.request-metadata-headers-that-propagate", String[].class);
+            .getOptionalValue("inrupt.test.request-metadata-headers-that-propagate", String[].class)
+            .orElse(new String[]{""});
 
     private static final String AUTH_METHOD = config
             .getOptionalValue("inrupt.test.auth-method", String.class)
@@ -145,9 +146,8 @@ public class ApplicationRequestMetadataScenarios {
 
     @ParameterizedTest
     @MethodSource("provideSessions")
-    @DisplayName(" " +
-            "Request and response headers match for a successful authenticated request")
-    void requestResponseMatchOnAuthRequestLowLevelClientTest(final Session session) {
+    @DisplayName("Request and response headers match for a successful authenticated request")
+    void matchOnAuthRequestSyncLowLevelClientTest(final Session session) {
         assumeTrue(featureIsActive());
 
         LOGGER.info("Integration Test - Low level sync client - " +
@@ -194,16 +194,15 @@ public class ApplicationRequestMetadataScenarios {
 
     @ParameterizedTest
     @MethodSource("provideSessions")
-    @DisplayName(" " +
-            "Request and response headers match for a successful authenticated request")
-    void requestResponseMatchOnAuthRequestAsyncHighLevelClientTest(final Session session) {
+    @DisplayName("Request and response headers match for a successful authenticated request")
+    void matchOnAuthRequestAsyncHighLevelClientTest(final Session session) {
         assumeTrue(featureIsActive());
 
         LOGGER.info("Integration Test - High level async client -" +
                 " Request and response headers match for a successful authenticated request");
 
         final var headers = fillHeaders("bbbbbb");
-        headers.put("someblabla", List.of("bbbbbb-2454-4501-8110-ecc082aa975f"));
+        headers.put("someheader", List.of("bbbbbb-2454-4501-8110-ecc082aa975f"));
 
         final SolidClient authClient = SolidClient.getClientBuilder()
                         .headers(Headers.of(headers)).build()
@@ -227,22 +226,21 @@ public class ApplicationRequestMetadataScenarios {
             for (String value: REQUEST_METADATA_HEADERS_THAT_PROPAGATE) {
                 assertEquals(headers.get(value), response.getHeaders().allValues(value));
             }
-            assertTrue(response.getHeaders().allValues("someblabla").isEmpty());
+            assertTrue(response.getHeaders().allValues("someheader").isEmpty());
         });
     }
 
     @ParameterizedTest
     @MethodSource("provideSessions")
-    @DisplayName(" " +
-            "Request and response headers match for a successful authenticated request")
-    void requestResponseMatchOnAuthRequestHighLevelSyncClientTest(final Session session) {
+    @DisplayName("Request and response headers match for a successful authenticated request")
+    void matchOnAuthRequestSyncHighLevelClientTest(final Session session) {
         assumeTrue(featureIsActive());
 
         LOGGER.info("Integration Test - High level sync client -" +
                 " Request and response headers match for a successful authenticated request");
 
         final var headers = fillHeaders("ccccc");
-        headers.put("someblabla", List.of("ccccc-2454-4501-8110-ecc082aa975f"));
+        headers.put("someheader", List.of("ccccc-2454-4501-8110-ecc082aa975f"));
 
         final SolidSyncClient authClient = SolidSyncClient.getClientBuilder()
                 .headers(Headers.of(headers)).build()
@@ -266,7 +264,7 @@ public class ApplicationRequestMetadataScenarios {
             for (String header: REQUEST_METADATA_HEADERS_THAT_PROPAGATE) {
                 assertEquals(headers.get(header), resource.getHeaders().allValues(header));
             }
-            assertTrue(resource.getHeaders().allValues("someblabla").isEmpty());
+            assertTrue(resource.getHeaders().allValues("someheader").isEmpty());
         }
     }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -121,14 +121,14 @@ public class ApplicationRequestMetadataScenarios {
         }
 
         publicContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path("public-domain-test-" + UUID.randomUUID() + FOLDER_SEPARATOR)
-                .build();
+            .path("public-domain-test-" + UUID.randomUUID() + FOLDER_SEPARATOR)
+            .build();
 
         Utils.createPublicContainer(authenticatedClient, publicContainerURI);
 
         privateContainerURI = URIBuilder.newBuilder(URI.create(podUrl))
-                .path(State.PRIVATE_RESOURCE_PATH + "-auth-test-" + UUID.randomUUID() + "/")
-                .build();
+            .path(State.PRIVATE_RESOURCE_PATH + "-auth-test-" + UUID.randomUUID() + "/")
+            .build();
 
         Utils.createContainer(authenticatedClient, privateContainerURI);
 
@@ -156,12 +156,12 @@ public class ApplicationRequestMetadataScenarios {
         LOGGER.info("Integration Test - Request and response headers match for a successful authenticated request");
 
         final Headers applicationHeaders = Headers.of(
-                Map.of("someblabla", List.of("a6d87d0e-2454-4501-8110-ecc082aa975f"))
+            Map.of("someblabla", List.of("a6d87d0e-2454-4501-8110-ecc082aa975f"))
         );
 
         final SolidClient authClient = SolidClient.getClientBuilder()
-                .headers(applicationHeaders).build()
-                .session(session);
+                        .headers(applicationHeaders).build()
+                        .session(session);
 
         final String resourceName = privateContainerURI + "e2e-test-application-metadata1";
         final String predicateName = "https://example.example/predicate";
@@ -178,10 +178,10 @@ public class ApplicationRequestMetadataScenarios {
         // Create a new resource and check response
         final URI resourceUri = URI.create(resourceName);
         authClient.create(
-                new SolidRDFSource(resourceUri, dataset)).thenAccept(response -> {
+            new SolidRDFSource(resourceUri, dataset)).thenAccept(response -> {
 
             assertEquals("0d1e63a3-b635-4d50-ba7f-34b7176defdf",
-                    response.getHeaders().allValues("somecid").get(0));
+                response.getHeaders().allValues("somecid").get(0));
         });
     }
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -182,7 +182,7 @@ public class DomainModulesResource {
             assertDoesNotThrow(() -> client.update(resource));
         }
 
-        // Re-fetch the resource, ensuring that that it has been updated
+        // Re-fetch the resource, ensuring that it has been updated
         try (final SolidRDFSource resource = client.read(resourceUri, SolidRDFSource.class)) {
             // Assert that the returned resource contains the expected data
             assertEquals(resourceUri, resource.getIdentifier());

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdApplicationMetadataTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdApplicationMetadataTest.java
@@ -1,0 +1,7 @@
+package com.inrupt.client.integration.openid;
+
+import com.inrupt.client.integration.base.ApplicationRequestMetadataScenarios;
+
+public class OpenIdApplicationMetadataTest extends ApplicationRequestMetadataScenarios {
+
+}

--- a/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdApplicationMetadataTest.java
+++ b/integration/openid/src/test/java/com/inrupt/client/integration/openid/OpenIdApplicationMetadataTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.inrupt.client.integration.openid;
 
 import com.inrupt.client.integration.base.ApplicationRequestMetadataScenarios;

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaApplicationRequestMetadataTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaApplicationRequestMetadataTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.inrupt.client.integration.uma;
 
 import com.inrupt.client.integration.base.ApplicationRequestMetadataScenarios;

--- a/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaApplicationRequestMetadataTest.java
+++ b/integration/uma/src/test/java/com/inrupt/client/integration/uma/UmaApplicationRequestMetadataTest.java
@@ -1,0 +1,7 @@
+package com.inrupt.client.integration.uma;
+
+import com.inrupt.client.integration.base.ApplicationRequestMetadataScenarios;
+
+public class UmaApplicationRequestMetadataTest extends ApplicationRequestMetadataScenarios {
+
+}


### PR DESCRIPTION
Introduced 2 new configuration options:
* `inrupt.test.request-metadata.feature` can be `true` or `false`  (default is false) to signal if a env (prod or dev) should run the tests related to the feature.
* `inrupt.test.request-metadata-headers-that-propagate` is a list of strings such as `somecid, x-request-id` which are the headers active to propagate on the servers.

This PR activates the application request metadata tests only on dev2.2 - see CI config.
We only added some very basic tests, to be able to setup the config. More relevant tests will be added in a follow up PR: