### PR TITLE
JCL-445: Add header support to the SolidContainer class

### DIFF
--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -202,7 +202,7 @@ public class DomainModulesResource {
 
         final String containerURL = publicContainerURI + "newContainer-" + UUID.randomUUID() + "/";
 
-        final SolidContainer newContainer = new SolidContainer(URI.create(containerURL), null, null);
+        final SolidContainer newContainer = new SolidContainer(URI.create(containerURL));
         assertDoesNotThrow(() -> client.create(newContainer));
 
         assertDoesNotThrow(() -> client.delete(newContainer));

--- a/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
@@ -72,7 +72,7 @@ public class SolidContainer extends SolidRDFSource {
      * @param identifier the container's unique identifier
      * @param dataset the dataset for this container, may be {@code null}
      * @param metadata the container's metadata, may be {@code null}
-     * @deprecated use {@link #SolidRDFSource(URI, Dataset, Headers)} instead
+     * @deprecated use {@link #SolidContainer(URI, Dataset, Headers)} instead
      */
     @Deprecated
     public SolidContainer(final URI identifier, final Dataset dataset, final Metadata metadata) {

--- a/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidContainer.java
@@ -20,6 +20,7 @@
  */
 package com.inrupt.client.solid;
 
+import com.inrupt.client.Headers;
 import com.inrupt.client.ValidationResult;
 import com.inrupt.client.vocabulary.LDP;
 import com.inrupt.client.vocabulary.RDF;
@@ -62,7 +63,7 @@ public class SolidContainer extends SolidRDFSource {
      * @param dataset the dataset for this container, may be {@code null}
      */
     public SolidContainer(final URI identifier, final Dataset dataset) {
-        this(identifier, dataset, null);
+        this(identifier, dataset, (Headers) null);
     }
 
     /**
@@ -71,9 +72,22 @@ public class SolidContainer extends SolidRDFSource {
      * @param identifier the container's unique identifier
      * @param dataset the dataset for this container, may be {@code null}
      * @param metadata the container's metadata, may be {@code null}
+     * @deprecated use {@link #SolidRDFSource(URI, Dataset, Headers)} instead
      */
+    @Deprecated
     public SolidContainer(final URI identifier, final Dataset dataset, final Metadata metadata) {
         super(identifier, dataset, metadata);
+    }
+
+    /**
+     * Create a new SolidContainer.
+     *
+     * @param identifier the container's unique identifier
+     * @param dataset the dataset for this container, may be {@code null}
+     * @param headers headers associated with this resource, may be {@code null}
+     */
+    public SolidContainer(final URI identifier, final Dataset dataset, final Headers headers) {
+        super(identifier, dataset, headers);
     }
 
     /**

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -183,6 +183,13 @@ class SolidClientTest {
                 assertEquals(2, c.stream(Optional.empty(), rdf.createIRI(uri.toString()),
                             rdf.createIRI("https://example.com/song"), null).count());
 
+                assertEquals(Optional.of("user=\"read write\",public=\"read\""),
+                        c.getHeaders().firstValue("WAC-Allow"));
+                assertEquals(Optional.of("user=\"read write\",public=\"read\""),
+                        c.getHeaders().firstValue("wac-allow"));
+                assertTrue(c.getHeaders().allValues("Link")
+                        .contains("<http://storage.example/>; rel=\"" + PIM.storage + "\""));
+
                 assertDoesNotThrow(client.update(c).toCompletableFuture()::join);
                 assertDoesNotThrow(client.create(c).toCompletableFuture()::join);
                 assertDoesNotThrow(client.delete(c).toCompletableFuture()::join);
@@ -378,7 +385,7 @@ class SolidClientTest {
     ) {
         final Headers headers = Headers.of(Collections.singletonMap("x-key", Arrays.asList("value")));
         final SolidClient solidClient = new SolidClient(ClientProvider.getClient(), headers, false);
-        final SolidContainer resource = new SolidContainer(URI.create("http://example.com"), null, null);
+        final SolidContainer resource = new SolidContainer(URI.create("http://example.com"));
 
         final SolidClientException exception = assertThrows(
                 clazz,


### PR DESCRIPTION
When header support was added to the high level SolidClient, the `SolidContainer` class was missed. This adds header support for that class.