### PR TITLE
JCL-448: added a new test suite documentation

### DIFF
--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -274,6 +274,42 @@ public class ApplicationRequestMetadataScenarios {
         }
     }
 
+    @ParameterizedTest
+    @EnabledIf("featureIsActive")
+    @MethodSource("provideSessions")
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/unAuthClientCreateResourceWithHeaders " +
+            "Request and response headers match for a successful unauthenticated request")
+    void matchOnUnAuthRequestSyncHighLevelClientTest(final Session session) {
+
+        LOGGER.info("Integration Test - High level sync client -" +
+                " Request and response headers match for a successful unauthenticated request");
+
+    }
+
+    @ParameterizedTest
+    @EnabledIf("featureIsActive")
+    @MethodSource("provideSessions")
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCannotCreateResourceWithHeaders " +
+            "Request and response headers match for a failed authenticated request")
+    void matchOnAuthFailedRequestSyncHighLevelClientTest(final Session session) {
+
+        LOGGER.info("Integration Test - High level sync client -" +
+                " Request and response headers match for a failed authenticated request");
+
+    }
+
+    @ParameterizedTest
+    @EnabledIf("featureIsActive")
+    @MethodSource("provideSessions")
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/unClientCannotCreateResourceWithHeaders " +
+            "Request and response headers match for a failed unauthenticated request")
+    void matchOnUnAuthFailedRequestSyncHighLevelClientTest(final Session session) {
+
+        LOGGER.info("Integration Test - High level sync client -" +
+                " Request and response headers match for a failed unauthenticated request");
+
+    }
+
     private static Stream<Arguments> provideSessions() throws SolidClientException {
         final Session session = OpenIdSession.ofClientCredentials(
                 URI.create(issuer), //Client credentials

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -150,7 +150,8 @@ public class ApplicationRequestMetadataScenarios {
     @ParameterizedTest
     @EnabledIf("featureIsActive")
     @MethodSource("provideSessions")
-    @DisplayName("Request and response headers match for a successful authenticated request")
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders" +
+            "Request and response headers match for a successful authenticated request")
     void matchOnAuthRequestSyncLowLevelClientTest(final Session session) {
 
         LOGGER.info("Integration Test - Low level sync client - " +
@@ -198,7 +199,8 @@ public class ApplicationRequestMetadataScenarios {
     @ParameterizedTest
     @EnabledIf("featureIsActive")
     @MethodSource("provideSessions")
-    @DisplayName("Request and response headers match for a successful authenticated request")
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders" +
+            "Request and response headers match for a successful authenticated request")
     void matchOnAuthRequestAsyncHighLevelClientTest(final Session session) {
 
         LOGGER.info("Integration Test - High level async client -" +
@@ -236,7 +238,8 @@ public class ApplicationRequestMetadataScenarios {
     @ParameterizedTest
     @EnabledIf("featureIsActive")
     @MethodSource("provideSessions")
-    @DisplayName("Request and response headers match for a successful authenticated request")
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders" +
+            "Request and response headers match for a successful authenticated request")
     void matchOnAuthRequestSyncHighLevelClientTest(final Session session) {
 
         LOGGER.info("Integration Test - High level sync client -" +

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -150,7 +150,7 @@ public class ApplicationRequestMetadataScenarios {
     @ParameterizedTest
     @EnabledIf("featureIsActive")
     @MethodSource("provideSessions")
-    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders" +
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders " +
             "Request and response headers match for a successful authenticated request")
     void matchOnAuthRequestSyncLowLevelClientTest(final Session session) {
 
@@ -199,7 +199,7 @@ public class ApplicationRequestMetadataScenarios {
     @ParameterizedTest
     @EnabledIf("featureIsActive")
     @MethodSource("provideSessions")
-    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders" +
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders " +
             "Request and response headers match for a successful authenticated request")
     void matchOnAuthRequestAsyncHighLevelClientTest(final Session session) {
 
@@ -238,7 +238,7 @@ public class ApplicationRequestMetadataScenarios {
     @ParameterizedTest
     @EnabledIf("featureIsActive")
     @MethodSource("provideSessions")
-    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders" +
+    @DisplayName("https://w3id.org/inrupt/qa/manifest/solid-client-java/authClientCreateResourceWithHeaders " +
             "Request and response headers match for a successful authenticated request")
     void matchOnAuthRequestSyncHighLevelClientTest(final Session session) {
 

--- a/src/site/resources/qa/manifest/integrationTestScenarios.ttl
+++ b/src/site/resources/qa/manifest/integrationTestScenarios.ttl
@@ -17,7 +17,7 @@
   doap:developer <https://github.com/inrupt/solid-client-java/graphs/contributors>;
   doap:homepage <https://docs.inrupt.com/developer-tools/java/client-libraries/> ;
   doap:homepage <https://github.com/inrupt/solid-client-java> ;
-  inrupt:testSuite :resourceTestSuite, :authenticationTestSuite, :vcTestSuite. 
+  inrupt:testSuite :resourceTestSuite, :authenticationTestSuite, :vcTestSuite, :applicationMetadataRequestSuite.
 
 :resourceTestSuite dcterms:hasPart
   #new tests specific for Java SDK - based on the core modules layer of Java SDK
@@ -176,78 +176,89 @@
   td:reviewStatus td:approved.
 
 :accessGrantOverride a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Access Grant with request overrides"@en;
   dcterms:description "An authenticated requestor issues an access request, and the authenticated resource owner overrides the grant duration approving it."@en;
   td:expectedResults "A valid Access Grant with the overridden duration is issued."@en;
   td:reviewStatus td:approved.
 
 :accessGrantNoACRchange a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Issue an access grant that does not change ACR"@en;
   dcterms:description "An authenticated requestor can issue an access request, grant access to a resource, but will not update the ACR if the updateAcr flag is set to false."@en;
   td:expectedResults "A valid Access Grant without ACR change is issued."@en;
   td:reviewStatus td:onhold.
 
 :accessGrantQueryByRequestor a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Lookup Access Grants by requestor"@en;
   dcterms:description "An authenticated resource owner having previously issued Access Grants sends a request to list the Grants they have issued to a given requestor."@en;
   td:expectedResults "The list of the Access Grants they have issued to the given requestor is returned."@en;
   td:reviewStatus td:approved.
 
 :accessGrantQueryByResource a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Lookup Access Grants by resource"@en;
   dcterms:description "An authenticated resource owner having previously issued Access Grants sends a request to list the Grants they have issued for a given resource."@en;
   td:expectedResults "The list of the Access Grants they have issued for the given resource is returned."@en;
   td:reviewStatus td:approved.
 
 :accessGrantQueryByPurpose a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Lookup Access Grants by purpose"@en;
   dcterms:description "An authenticated resource owner having previously issued Access Grants sends a request to list the Grants they have issued for a given purpose."@en;
   td:expectedResults "The list of the Access Grants they have issued for the given purpose is returned."@en;
   td:reviewStatus td:approved.
 
 :accessGrantGetRdf a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Fetching RDF using an Access Grant"@en;
   dcterms:description "An authenticated user having previously been issued a valid Access Grant uses it to read an existing RDF resource."@en;
   td:expectedResults "The RDF resource is returned successfully."@en;
   td:reviewStatus td:approved.
 
 :accessGrantSetRdf a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Appending RDF using Access Grant"@en;
   dcterms:description "An authenticated user having previously been issued a valid Access Grant uses it to append to an existing RDF resource."@en;
   td:expectedResults "The RDF resource is updated successfully."@en;
   td:reviewStatus td:approved.
 
 :accessGrantCreateRdf a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Creating RDF using Access Grant"@en;
   dcterms:description "An authenticated user having previously been issued a valid Access Grant uses it to create a new RDF resource."@en;
   td:expectedResults "The RDF resource is created successfully."@en;
   td:reviewStatus td:approved.
 
 :accessGrantGetNonRdf a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Fetching non-RDF using Access Grant"@en;
   dcterms:description "An authenticated user having previously been issued a valid Access Grant uses it to read an existing non-RDF resource."@en;
   td:expectedResults "The resource is returned successfully."@en;
   td:reviewStatus td:approved.
 
 :accessGrantSetNonRdf a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Overwriting non-RDF using Access Grant"@en;
   dcterms:description "An authenticated user having previously been issued a valid Access Grant uses it to overwrite an existing non-RDF resource."@en;
   td:expectedResults "The non-RDF resource is updated successfully."@en;
   td:reviewStatus td:approved.
 
 :accessGrantCreateNonRdf a td:TestCase ;
-  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;;
+  inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
   dcterms:title "Creating non-RDF using Access Grant"@en;
   dcterms:description "An authenticated user having previously been issued a valid Access Grant uses it to create a new non-RDF resource."@en;
   td:expectedResults "The RDF resource is created successfully."@en;
   td:reviewStatus td:approved.
+
+ :applicationMetadataRequestSuite dcterms:hasPart
+    :authClientCreateResourceWithHeaders;
+    inrupt:targetEnvironment <https://docs.oracle.com/en/java/javase/11/docs/api/>.
+
+ :authClientCreateResourceWithHeaders a td:TestCase ;
+   inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
+   dcterms:title "Request and response headers match for a successful authenticated request"@en;
+   dcterms:description "An authenticated user having previously set some application request headers to create a new RDF resource can see the same headers on the response."@en;
+   td:expectedResults "The RDF resource is created successfully and the response contains only the expected application headers."@en;
+   td:reviewStatus td:approved.

--- a/src/site/resources/qa/manifest/integrationTestScenarios.ttl
+++ b/src/site/resources/qa/manifest/integrationTestScenarios.ttl
@@ -253,7 +253,10 @@
   td:reviewStatus td:approved.
 
  :applicationMetadataRequestSuite dcterms:hasPart
-    :authClientCreateResourceWithHeaders;
+    :authClientCreateResourceWithHeaders,
+    :unAuthClientCreateResourceWithHeaders,
+    :authClientCannotCreateResourceWithHeaders,
+    :unClientCannotCreateResourceWithHeaders;
     inrupt:targetEnvironment <https://docs.oracle.com/en/java/javase/11/docs/api/>.
 
  :authClientCreateResourceWithHeaders a td:TestCase ;
@@ -261,4 +264,25 @@
    dcterms:title "Request and response headers match for a successful authenticated request"@en;
    dcterms:description "An authenticated user having previously set some application request headers to create a new RDF resource can see the same headers on the response."@en;
    td:expectedResults "The RDF resource is created successfully and the response contains only the expected application headers."@en;
+   td:reviewStatus td:approved.
+
+ :unAuthClientCreateResourceWithHeaders a td:TestCase ;
+   inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
+   dcterms:title "Request and response headers match for a successful unauthenticated request"@en;
+   dcterms:description "An unauthenticated user having previously set some application request headers to create a new RDF resource can see the same headers on the response."@en;
+   td:expectedResults "The RDF resource is created successfully and the response contains only the expected application headers."@en;
+   td:reviewStatus td:approved.
+
+ :authClientCannotCreateResourceWithHeaders a td:TestCase ;
+   inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
+   dcterms:title "Request and response headers match for a failed authenticated request"@en;
+   dcterms:description "An authenticated user having previously set some application request headers to create a new RDF resource can see the same headers on the response."@en;
+   td:expectedResults "The RDF resource is not created and the response contains only the expected application headers."@en;
+   td:reviewStatus td:approved.
+
+ :unClientCannotCreateResourceWithHeaders a td:TestCase ;
+   inrupt:appliesTo <https://dev-2-2.inrupt.com/>, <https://start.inrupt.com>;
+   dcterms:title "Request and response headers match for a failed unauthenticated request"@en;
+   dcterms:description "An unauthenticated user having previously set some application request headers to create a new RDF resource can see the same headers on the response."@en;
+   td:expectedResults "The RDF resource is not created and the response contains only the expected application headers."@en;
    td:reviewStatus td:approved.


### PR DESCRIPTION
We start to document, in RDF, the new application request metadata test scenarios