### PR TITLE
Use generated NVD cache

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -124,5 +124,8 @@ jobs:
           restore-keys: nvd-data-
           path: ./data/cache
 
+      - name: Debug
+        run: find . -name cache
+
       - name: Verify dependencies
         run: mvn -B -ntp verify -Pdependencies -Dnvd.api.datafeed="file:${GITHUB_WORKSPACE}/data/cache/nvdcve-{0}.json.gz"

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -113,5 +113,16 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
-      - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+      - name: Generate Cache Name
+        shell: bash
+        run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
+
+      - name: Restore NVD data cache
+        uses: actions/cache@v3
+        with:
+          key: nvd-data-${{ env.CACHE_NAME }}
+          restore-keys: nvd-data-
+          path: ./data/cache
+
+      - name: Verify dependencies
+        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.datafeed="file:${GITHUB_WORKSPACE}/data/cache/nvdcve-{0}.json.gz"

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -124,8 +124,5 @@ jobs:
           restore-keys: nvd-data-
           path: ./data/cache
 
-      - name: Debug
-        run: find . -name cache
-
       - name: Verify dependencies
         run: mvn -B -ntp verify -Pdependencies -Dnvd.api.datafeed="file:${GITHUB_WORKSPACE}/data/cache/nvdcve-{0}.json.gz"

--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -3,6 +3,7 @@ name: NVD Data Workflow Schedule
 on:
   schedule:
     - cron: '0 5 * * 1,2,3,4,5'
+  workflow_dispatch: { }
 
 jobs:
   build:

--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -1,4 +1,4 @@
-name: NVD Data Workflow CD
+name: NVD Data Workflow Schedule
 
 on:
   schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <dependency-check.skip>true</dependency-check.skip>
     <archetype.test.skip>true</archetype.test.skip>
     <nvd.api.key/>
+    <nvd.api.datafeed />
 
     <!-- sonar -->
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/reports/target/site/jacoco-merged/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -628,6 +629,7 @@
               ./build-tools/owasp/suppressions.xml
           </suppressionFile>
           <nvdApiKey>${nvd.api.key}</nvdApiKey>
+          <nvdDatafeedUrl>${nvd.api.datafeed}</nvdDatafeedUrl>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This makes use of the cached NVD data during the `dependencies` workflow