### PR TITLE
Use cached NVD API data

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -109,5 +109,16 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
-      - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+      - name: Generate Cache Name
+        shell: bash
+        run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
+
+      - name: Restore NVD data cache
+        uses: actions/cache@v3
+        with:
+          key: nvd-data-${{ env.CACHE_NAME }}
+          restore-keys: nvd-data-
+          path: ./data/cache
+
+      - name: Verify dependencies
+        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.datafeed="file:${GITHUB_WORKSPACE}/data/cache/nvdcve-{0}.json.gz"

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <dependency-check.skip>true</dependency-check.skip>
     <archetype.test.skip>true</archetype.test.skip>
     <nvd.api.key/>
+    <nvd.api.datafeed/>
 
     <!-- sonar -->
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/reports/target/site/jacoco-merged/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -628,6 +629,7 @@
               ./build-tools/owasp/suppressions.xml
           </suppressionFile>
           <nvdApiKey>${nvd.api.key}</nvdApiKey>
+          <nvdDatafeedUrl>${nvd.api.datafeed}</nvdDatafeedUrl>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Backport of #879 using the cached NVD API data for dependency checks