### PR TITLE
Upgrade commons-compress for CVE-2024-25710

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
           <artifactId>guava</artifactId>
           <version>${guava.version}</version>
         </dependency>
+        <!-- transitive dependency update for CVE-2024-25710 -->
+        <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-compress</artifactId>
+          <version>1.26.0</version>
+        </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This upgrades commons-compress to address CVE-2024-25710