### PR TITLE
JCL-451: Serialize AccessGrant query requests

### DIFF
--- a/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientService.java
+++ b/httpclient/src/main/java/com/inrupt/client/httpclient/HttpClientService.java
@@ -68,6 +68,7 @@ public class HttpClientService implements HttpService {
             .orElseGet(HttpRequest.BodyPublishers::noBody);
 
         builder.method(request.method(), publisher);
+        request.timeout().ifPresent(timeout -> builder.timeout(timeout));
 
         for (final Map.Entry<String, List<String>> entry : request.headers().asMap().entrySet()) {
             for (final String value : entry.getValue()) {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -97,10 +97,10 @@ public class AccessGrantScenarios {
     protected static final String GRANT_MODE_READ = "Read";
     private static final String GRANT_MODE_APPEND = "Append";
     private static final String GRANT_MODE_WRITE = "Write";
-    private static final URI PURPOSE1 = URI.create("https://purpose.example/212efdf4-e1a4-4dcd-9d3b-d6eb92e0205f");
-    private static final URI PURPOSE2 = URI.create("https://purpose.example/de605b08-76c7-4f04-9cec-a438810b0c03");
-    protected static final Set<URI> PURPOSES = new HashSet<>(Arrays.asList(PURPOSE1, PURPOSE2));
-    protected static final String GRANT_EXPIRATION = Instant.now().plus(1, ChronoUnit.HOURS)
+    private static URI PURPOSE1;
+    private static URI PURPOSE2;
+    protected static final Set<URI> PURPOSES = new HashSet<>();
+    protected static final String GRANT_EXPIRATION = Instant.now().plus(20, ChronoUnit.MINUTES)
         .truncatedTo(ChronoUnit.SECONDS).toString();
     private static final String sharedTextFileName = "sharedFile.txt";
     protected static URI sharedTextFileURI;
@@ -111,6 +111,11 @@ public class AccessGrantScenarios {
     @BeforeAll
     static void setup() throws IOException {
         LOGGER.info("Setup AccessGrantScenarios test");
+        PURPOSE1 = URI.create("https://purpose.example/" + UUID.randomUUID());
+        PURPOSE2 = URI.create("https://purpose.example/" + UUID.randomUUID());
+        PURPOSES.clear();
+        PURPOSES.add(PURPOSE1);
+        PURPOSES.add(PURPOSE2);
         if (config.getOptionalValue("inrupt.test.webid", String.class).isPresent()) {
             LOGGER.info("Running AccessGrantScenarios on live server");
             webidUrl = config.getOptionalValue("inrupt.test.webid", String.class).get();
@@ -177,7 +182,8 @@ public class AccessGrantScenarios {
                     URI.create(webidUrl),
                     URI.create(requesterWebidUrl),
                     sharedTextFileURI,
-                    authServer.getMockServerUrl()
+                    authServer.getMockServerUrl(),
+                    PURPOSE1
             );
             accessGrantServer.start();
             ACCESS_GRANT_PROVIDER = accessGrantServer.getMockServerUrl();

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockAccessGrantServer.java
@@ -60,6 +60,7 @@ class MockAccessGrantServer {
     private final String ownerWebId;
     private final String requesterWebId;
     private final String sharedResource;
+    private final URI purpose;
 
     private final String authorisationServerUrl;
 
@@ -67,12 +68,14 @@ class MockAccessGrantServer {
             final URI ownerWebId,
             final URI requesterWebId,
             final URI sharedResource,
-            final String authorisationServerUrl
+            final String authorisationServerUrl,
+            final URI purpose
     ) {
         this.ownerWebId = ownerWebId.toString();
         this.requesterWebId = requesterWebId.toString();
         this.sharedResource = sharedResource.toString();
         this.authorisationServerUrl = authorisationServerUrl;
+        this.purpose = purpose;
         wireMockServer = new WireMockServer(WireMockConfiguration.options()
                 .httpDisabled(true)
                 .dynamicHttpsPort());
@@ -227,7 +230,7 @@ class MockAccessGrantServer {
                 .atPriority(1)
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
                 .withRequestBody(containing("\"Append\""))
-                .withRequestBody(containing("\"https://purpose.example/212efdf4-e1a4-4dcd-9d3b-d6eb92e0205f\""))
+                .withRequestBody(containing("\"" + purpose + "\""))
                 .withRequestBody(containing("\"" + this.sharedResource + "\""))
                 .withRequestBody(containing("SolidAccessGrant"))
                 .willReturn(aResponse()

--- a/integration/customokhttp/src/main/java/com/inrupt/client/integration/customokhttp/CustomOkHttpService.java
+++ b/integration/customokhttp/src/main/java/com/inrupt/client/integration/customokhttp/CustomOkHttpService.java
@@ -29,6 +29,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -191,6 +192,7 @@ public class CustomOkHttpService implements HttpService {
         final OkHttpClient.Builder newBuilder = new OkHttpClient.Builder();
         newBuilder.sslSocketFactory(sslContext.getSocketFactory(), (X509TrustManager) trustAllCerts[0]);
         newBuilder.hostnameVerifier((hostname, session) -> true);
+        newBuilder.callTimeout(Duration.ofSeconds(30));
 
         return newBuilder.build();
     }


### PR DESCRIPTION
This appears to fix the flaky integration tests. It does it by changing the (questionable?) parallelization in the `AccessGrantClient::query` code. We previously had some issues with this in terms of the parallel processing of `InputStream` data.

In addition, as part of the investigation, I found that the HTTP client implementations do not properly respect `timeout` values set in a `Request` object. Setting a longer timeout did not, on its own, resolve this issue, but I kept that fix in this PR. If it would be preferred to pull that out into a separate PR, I can do that.