### PR TITLE
Upgrade the vulnz version to 6.0.0

### DIFF
--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         repository: jeremylong/Open-Vulnerability-Project
         path: ovp
-        ref: v5.1.1
+        ref: v6.0.0
 
     - name: Set up JDK 17
       uses: actions/setup-java@v4


### PR DESCRIPTION
[Version 6.0.0](https://github.com/jeremylong/Open-Vulnerability-Project/releases/tag/v6.0.0) of the Open Vulnerability Project was released a few weeks ago. This updates our use of that project.