### PR TITLE
Upgrade Nimbus JWT library in SpringBoot example

### DIFF
--- a/examples/springboot/pom.xml
+++ b/examples/springboot/pom.xml
@@ -108,6 +108,14 @@
       <artifactId>spring-boot-devtools</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <!-- transitive dependencies -->
+    <!-- addresses CVE-2023-52428 via Spring Boot 3.2.x -->
+    <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>9.37.3</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
The SpringBoot example code brings in a vulnerable version of `com.nimbusds:nimbus-jose-jwt` via `org.springframework.security/spring-security-oauth2-jose@6.2.3`.

This upgrades to the latest version of `nimbus-jose-jwt`