### PR TITLE
Clean up maven configuration

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -132,6 +132,13 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <verbose>false</verbose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -193,6 +193,13 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <verbose>false</verbose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -592,18 +592,22 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <header>./build-tools/license/HEADER.txt</header>
           <mapping>
             <java>SLASHSTAR_STYLE</java>
           </mapping>
-          <excludes>
-            <exclude>**/src/main/resources/**</exclude>
-            <exclude>**/src/test/resources/**</exclude>
-          </excludes>
-          <includes>
-            <include>**/src/main/java/**</include>
-            <include>**/src/test/java/**</include>
-          </includes>
+          <licenseSets>
+            <licenseSet>
+              <header>./build-tools/license/HEADER.txt</header>
+              <excludes>
+                <exclude>**/src/main/resources/**</exclude>
+                <exclude>**/src/test/resources/**</exclude>
+              </excludes>
+              <includes>
+                <include>**/src/main/java/**</include>
+                <include>**/src/test/java/**</include>
+              </includes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The maven configuration could be cleaned up a bit, including using the non-deprecated license plugin structure as well as being consistent with our use of PMD (i.e. turning off warnings for test code)