### PR TITLE
JCL-402: Low-level client throws enriched exceptions

### DIFF
--- a/api/src/main/java/com/inrupt/client/ProblemDetails.java
+++ b/api/src/main/java/com/inrupt/client/ProblemDetails.java
@@ -35,11 +35,11 @@ import java.util.Optional;
  */
 public class ProblemDetails {
     /**
-     * The <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a> default MIME type
+     * The <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a> default MIME type.
      */
     public static final String MIME_TYPE = "application/problem+json";
     /**
-     * The <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a> default problem type
+     * The <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a> default problem type.
      */
     public static final String DEFAULT_TYPE = "about:blank";
     private final URI type;

--- a/api/src/main/java/com/inrupt/client/ProblemDetails.java
+++ b/api/src/main/java/com/inrupt/client/ProblemDetails.java
@@ -35,11 +35,11 @@ import java.util.Optional;
  */
 public class ProblemDetails {
     /**
-     * {@link <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>} default MIME type
+     * The <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a> default MIME type
      */
     public static final String MIME_TYPE = "application/problem+json";
     /**
-     * {@link <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>} default problem type
+     * The <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a> default problem type
      */
     public static final String DEFAULT_TYPE = "about:blank";
     private final URI type;
@@ -117,10 +117,25 @@ public class ProblemDetails {
      * This inner class is only ever used for JSON deserialization. Please do not use in any other context.
      */
     public static class Data {
+        /**
+         * The problem type.
+         */
         public URI type;
+        /**
+         * The problem title.
+         */
         public String title;
+        /**
+         * The problem details.
+         */
         public String details;
+        /**
+         * The problem status code.
+         */
         public int status;
+        /**
+         * The problem instance.
+         */
         public URI instance;
     }
 

--- a/api/src/main/java/com/inrupt/client/ProblemDetails.java
+++ b/api/src/main/java/com/inrupt/client/ProblemDetails.java
@@ -52,7 +52,7 @@ public class ProblemDetails {
 
     /**
      * Build a ProblemDetails instance providing the expected fields as described in
-     * {@link <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>}.
+     * <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>.
      * @param type the problem type
      * @param title the problem title
      * @param details the problem details

--- a/api/src/main/java/com/inrupt/client/ProblemDetails.java
+++ b/api/src/main/java/com/inrupt/client/ProblemDetails.java
@@ -34,7 +34,13 @@ import java.util.Optional;
  * @see <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC 9457 Problem Details for HTTP APIs</a>
  */
 public class ProblemDetails {
+    /**
+     * {@link <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>} default MIME type
+     */
     public static final String MIME_TYPE = "application/problem+json";
+    /**
+     * {@link <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>} default problem type
+     */
     public static final String DEFAULT_TYPE = "about:blank";
     private final URI type;
     private final String title;
@@ -44,6 +50,15 @@ public class ProblemDetails {
     private static JsonService jsonService;
     private static boolean isJsonServiceInitialized;
 
+    /**
+     * Build a ProblemDetails instance providing the expected fields as described in
+     * {@link <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>}.
+     * @param type the problem type
+     * @param title the problem title
+     * @param details the problem details
+     * @param status the error response status code
+     * @param instance the problem instance
+     */
     public ProblemDetails(
         final URI type,
         final String title,
@@ -58,22 +73,42 @@ public class ProblemDetails {
         this.instance = instance;
     }
 
+    /**
+     * The problem type.
+     * @return the type
+     */
     public URI getType() {
         return this.type;
     };
 
+    /**
+     * The problem title.
+     * @return the title
+     */
     public String getTitle() {
         return this.title;
     };
 
+    /**
+     * The problem details.
+     * @return the details
+     */
     public String getDetails() {
         return this.details;
     };
 
+    /**
+     * The problem status code.
+     * @return the status code
+     */
     public int getStatus() {
         return this.status;
     };
 
+    /**
+     * The problem instance.
+     * @return the instance
+     */
     public URI getInstance() {
         return this.instance;
     };
@@ -104,6 +139,13 @@ public class ProblemDetails {
         return ProblemDetails.jsonService;
     }
 
+    /**
+     * Builds a {@link ProblemDetails} instance from an HTTP error response.
+     * @param statusCode the HTTP error response status code
+     * @param headers the HTTP error response headers
+     * @param body the HTTP error response body
+     * @return a {@link ProblemDetails} instance
+     */
     public static ProblemDetails fromErrorResponse(
             final int statusCode,
             final Headers headers,

--- a/api/src/main/java/com/inrupt/client/Response.java
+++ b/api/src/main/java/com/inrupt/client/Response.java
@@ -97,6 +97,11 @@ public interface Response<T> {
         ByteBuffer body();
     }
 
+    /**
+     * Indicates whether a status code reflects a successful HTTP response.
+     * @param statusCode the HTTP response status code
+     * @return true if the status code is in the success range, namely [200, 299].
+     */
     static boolean isSuccess(final int statusCode) {
         return statusCode >= 200 && statusCode < 300;
     }

--- a/api/src/main/java/com/inrupt/client/Response.java
+++ b/api/src/main/java/com/inrupt/client/Response.java
@@ -163,49 +163,6 @@ public interface Response<T> {
             return responseInfo -> null;
         }
 
-        /**
-         * Throws on HTTP error using the provided mapper, or apply the provided body handler.
-         * @param handler the body handler to apply on non-error HTTP responses
-         * @param isSuccess a callback determining error cases
-         * @param exceptionMapper the exception mapper
-         * @return the body handler
-         * @param <T> the type of the body handler
-         */
-        public static <T> Response.BodyHandler<T> throwOnError(
-                final Response.BodyHandler<T> handler,
-                final Function<Response.ResponseInfo, Boolean> isSuccess,
-                final Function<Response.ResponseInfo, ClientHttpException> exceptionMapper
-        ) {
-            return responseinfo -> {
-                if (!isSuccess.apply(responseinfo)) {
-                    throw exceptionMapper.apply(responseinfo);
-                }
-                return handler.apply(responseinfo);
-            };
-        }
-
-        /**
-         * Throws on HTTP error, or apply the provided body handler.
-         * @param handler the body handler to apply on non-error HTTP responses
-         * @param isSuccess a callback determining error cases
-         * @return the body handler
-         * @param <T> the type of the body handler
-         */
-        public static <T> Response.BodyHandler<T> throwOnError(
-                final Response.BodyHandler<T> handler,
-                final Function<Response.ResponseInfo, Boolean> isSuccess
-        ) {
-            final Function<Response.ResponseInfo, ClientHttpException> defaultMapper = responseInfo ->
-                new ClientHttpException(
-                    "An HTTP error has been returned, with status code " + responseInfo.statusCode(),
-                    responseInfo.uri(),
-                    responseInfo.statusCode(),
-                    responseInfo.headers(),
-                    new String(responseInfo.body().array(), StandardCharsets.UTF_8)
-                );
-            return throwOnError(handler, isSuccess, defaultMapper);
-        }
-
         private BodyHandlers() {
             // Prevent instantiation
         }

--- a/api/src/main/java/com/inrupt/client/Response.java
+++ b/api/src/main/java/com/inrupt/client/Response.java
@@ -26,8 +26,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.function.Function;
 
 /**
  * An HTTP Response.

--- a/api/src/main/java/com/inrupt/client/Response.java
+++ b/api/src/main/java/com/inrupt/client/Response.java
@@ -97,6 +97,10 @@ public interface Response<T> {
         ByteBuffer body();
     }
 
+    static boolean isSuccess(final int statusCode) {
+        return statusCode >= 200 && statusCode < 300;
+    }
+
     /**
      * An interface for mapping an HTTP response into a specific Java type.
      * @param <T> the body type
@@ -196,8 +200,6 @@ public interface Response<T> {
                 );
             return throwOnError(handler, isSuccess, defaultMapper);
         }
-
-
 
         private BodyHandlers() {
             // Prevent instantiation

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -22,14 +22,11 @@ package com.inrupt.client.solid;
 
 import com.inrupt.client.*;
 import com.inrupt.client.auth.Session;
-import com.inrupt.client.spi.JsonService;
-import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -127,7 +124,10 @@ public class SolidClient {
         final Request request = builder.build();
         return client.send(
                 request,
-                Response.BodyHandlers.throwOnError(Response.BodyHandlers.ofByteArray(), (r) -> isSuccess(r.statusCode()))
+                Response.BodyHandlers.throwOnError(
+                    Response.BodyHandlers.ofByteArray(),
+                    (r) -> isSuccess(r.statusCode())
+                )
             ).thenApply(response -> {
                 final String contentType = response.headers().firstValue(CONTENT_TYPE)
                     .orElse("application/octet-stream");
@@ -157,7 +157,7 @@ public class SolidClient {
                 if (exception instanceof ClientHttpException) {
                     throw SolidClientException.handle((ClientHttpException) exception);
                 }
-                throw new RuntimeException("Something went wrong reading "+request.uri(), exception);
+                throw new RuntimeException("Something went wrong reading " + request.uri(), exception);
             });
     }
 
@@ -277,18 +277,18 @@ public class SolidClient {
         headers.firstValue(USER_AGENT).ifPresent(agent -> builder.setHeader(USER_AGENT, agent));
 
         return client.send(
-                builder.build(),
-                Response.BodyHandlers.throwOnError(
-                    Response.BodyHandlers.ofByteArray(),
-                    (r) -> isSuccess(r.statusCode())
-                )
-            ).exceptionally(exception -> {
+            builder.build(),
+            Response.BodyHandlers.throwOnError(
+                Response.BodyHandlers.ofByteArray(),
+                (r) -> isSuccess(r.statusCode())
+            )
+        ).exceptionally(exception -> {
             if (exception instanceof ClientHttpException) {
                 throw SolidClientException.handle((ClientHttpException) exception);
             }
-            throw new RuntimeException("Something went wrong reading "+resource.getIdentifier(), exception);
+            throw new RuntimeException("Something went wrong reading " + resource.getIdentifier(), exception);
             // FIXME I don't understand why the following is required.
-        }).thenAccept(o -> {});
+        }).thenAccept(o -> { /* no-op */ });
     }
 
     /**

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -382,7 +382,7 @@ public class SolidClient {
                     resource.getIdentifier(),
                     res.statusCode(),
                     res.headers(),
-                    new String(res.body())
+                    new String(res.body(), StandardCharsets.UTF_8)
                 );
             }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -140,7 +140,7 @@ public class SolidClient {
                 Response.BodyHandlers.throwOnError(
                     Response.BodyHandlers.ofByteArray(),
                     (r) -> Response.isSuccess(r.statusCode()),
-                    httpExceptionMapper("Reading resource " + request.uri() + " failed.")
+                    httpExceptionMapper("Reading resource failed.")
                 )
             ).thenApply(response -> {
                 final String contentType = response.headers().firstValue(CONTENT_TYPE)

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -139,7 +139,7 @@ public class SolidClient {
                 request,
                 Response.BodyHandlers.throwOnError(
                     Response.BodyHandlers.ofByteArray(),
-                    (r) -> isSuccess(r.statusCode()),
+                    (r) -> Response.isSuccess(r.statusCode()),
                     httpExceptionMapper("Reading resource " + request.uri() + " failed.")
                 )
             ).thenApply(response -> {
@@ -289,7 +289,7 @@ public class SolidClient {
             builder.build(),
             Response.BodyHandlers.throwOnError(
                 Response.BodyHandlers.ofByteArray(),
-                (r) -> isSuccess(r.statusCode()),
+                (r) -> Response.isSuccess(r.statusCode()),
                 httpExceptionMapper("Unable to delete resource.")
             )
         )
@@ -376,7 +376,7 @@ public class SolidClient {
     <T extends Resource> Function<Response<byte[]>, CompletionStage<T>> handleResponse(final T resource,
             final Headers headers, final String message) {
         return res -> {
-            if (!isSuccess(res.statusCode())) {
+            if (!Response.isSuccess(res.statusCode())) {
                 throw SolidClientException.handle(
                     message,
                     resource.getIdentifier(),
@@ -453,10 +453,6 @@ public class SolidClient {
                 builder.header(entry.getKey(), item);
             }
         }
-    }
-
-    static boolean isSuccess(final int statusCode) {
-        return statusCode >= 200 && statusCode < 300;
     }
 
     static Request.BodyPublisher cast(final Resource resource) {

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -287,7 +288,7 @@ public class SolidClient {
                     resource.getIdentifier(),
                     res.statusCode(),
                     res.headers(),
-                    new String(res.body())
+                    new String(res.body(), StandardCharsets.UTF_8)
                 );
             }
         });

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -292,7 +292,7 @@ public class SolidClient {
                 (r) -> isSuccess(r.statusCode()),
                 httpExceptionMapper("Deleting resource " + resource.getIdentifier() + " failed.")
             )
-        )// FIXME I don't understand why the following is required.
+        )
         .thenAccept(o -> { /* no-op */ });
     }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClient.java
@@ -290,7 +290,7 @@ public class SolidClient {
             Response.BodyHandlers.throwOnError(
                 Response.BodyHandlers.ofByteArray(),
                 (r) -> isSuccess(r.statusCode()),
-                httpExceptionMapper("Deleting resource " + resource.getIdentifier() + " failed.")
+                httpExceptionMapper("Unable to delete resource.")
             )
         )
         .thenAccept(o -> { /* no-op */ });

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
@@ -91,7 +91,7 @@ public class SolidClientException extends ClientHttpException {
         }
     }
 
-    public static SolidClientException handle(final ClientHttpException exception){
+    public static SolidClientException handle(final ClientHttpException exception) {
         switch (exception.getStatusCode()) {
             case BadRequestException.STATUS_CODE:
                 return (BadRequestException) exception;

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
@@ -90,5 +90,36 @@ public class SolidClientException extends ClientHttpException {
                 return new SolidClientException(message, uri, statusCode, headers, body);
         }
     }
+
+    public static SolidClientException handle(final ClientHttpException exception){
+        switch (exception.getStatusCode()) {
+            case BadRequestException.STATUS_CODE:
+                return (BadRequestException) exception;
+            case UnauthorizedException.STATUS_CODE:
+                return (UnauthorizedException) exception;
+            case ForbiddenException.STATUS_CODE:
+                return (ForbiddenException) exception;
+            case NotFoundException.STATUS_CODE:
+                return (NotFoundException) exception;
+            case MethodNotAllowedException.STATUS_CODE:
+                return (MethodNotAllowedException) exception;
+            case NotAcceptableException.STATUS_CODE:
+                return (NotAcceptableException) exception;
+            case ConflictException.STATUS_CODE:
+                return (ConflictException) exception;
+            case GoneException.STATUS_CODE:
+                return (GoneException) exception;
+            case PreconditionFailedException.STATUS_CODE:
+                return (PreconditionFailedException) exception;
+            case UnsupportedMediaTypeException.STATUS_CODE:
+                return (UnsupportedMediaTypeException) exception;
+            case TooManyRequestsException.STATUS_CODE:
+                return (TooManyRequestsException) exception;
+            case InternalServerErrorException.STATUS_CODE:
+                return (InternalServerErrorException) exception;
+            default:
+                return (SolidClientException) exception;
+        }
+    }
 }
 

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
@@ -90,36 +90,5 @@ public class SolidClientException extends ClientHttpException {
                 return new SolidClientException(message, uri, statusCode, headers, body);
         }
     }
-
-    public static SolidClientException handle(final ClientHttpException exception) {
-        switch (exception.getStatusCode()) {
-            case BadRequestException.STATUS_CODE:
-                return (BadRequestException) exception;
-            case UnauthorizedException.STATUS_CODE:
-                return (UnauthorizedException) exception;
-            case ForbiddenException.STATUS_CODE:
-                return (ForbiddenException) exception;
-            case NotFoundException.STATUS_CODE:
-                return (NotFoundException) exception;
-            case MethodNotAllowedException.STATUS_CODE:
-                return (MethodNotAllowedException) exception;
-            case NotAcceptableException.STATUS_CODE:
-                return (NotAcceptableException) exception;
-            case ConflictException.STATUS_CODE:
-                return (ConflictException) exception;
-            case GoneException.STATUS_CODE:
-                return (GoneException) exception;
-            case PreconditionFailedException.STATUS_CODE:
-                return (PreconditionFailedException) exception;
-            case UnsupportedMediaTypeException.STATUS_CODE:
-                return (UnsupportedMediaTypeException) exception;
-            case TooManyRequestsException.STATUS_CODE:
-                return (TooManyRequestsException) exception;
-            case InternalServerErrorException.STATUS_CODE:
-                return (InternalServerErrorException) exception;
-            default:
-                return (SolidClientException) exception;
-        }
-    }
 }
 

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -22,6 +22,7 @@ package com.inrupt.client.solid;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.inrupt.client.*;
 import com.inrupt.client.auth.Session;
@@ -367,15 +368,22 @@ class SolidClientTest {
 
     private static Stream<Arguments> testExceptionalResources() {
         return Stream.of(
-                Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/unauthorized"), 401,
-                        UnauthorizedException.class),
-                Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/forbidden"), 403,
-                        ForbiddenException.class),
-                Arguments.of(
-                    URI.create(config.get("solid_resource_uri") + "/missing"), 404,
-                        NotFoundException.class));
+            arguments(
+                URI.create(config.get("solid_resource_uri") + "/unauthorized"),
+                401,
+                UnauthorizedException.class
+            ),
+            arguments(
+                URI.create(config.get("solid_resource_uri") + "/forbidden"),
+                403,
+                ForbiddenException.class
+            ),
+            arguments(
+                URI.create(config.get("solid_resource_uri") + "/missing"),
+                404,
+                NotFoundException.class
+            )
+        );
     }
 
     @ParameterizedTest
@@ -425,21 +433,21 @@ class SolidClientTest {
 
     private static Stream<Arguments> testLegacyExceptions() {
         return Stream.of(
-            Arguments.of(BadRequestException.class, 400),
-            Arguments.of(UnauthorizedException.class, 401),
-            Arguments.of(ForbiddenException.class, 403),
-            Arguments.of(NotFoundException.class, 404),
-            Arguments.of(MethodNotAllowedException.class, 405),
-            Arguments.of(NotAcceptableException.class, 406),
-            Arguments.of(ConflictException.class, 409),
-            Arguments.of(GoneException.class, 410),
-            Arguments.of(PreconditionFailedException.class, 412),
-            Arguments.of(UnsupportedMediaTypeException.class, 415),
-            Arguments.of(TooManyRequestsException.class, 429),
-            Arguments.of(InternalServerErrorException.class, 500),
-            Arguments.of(SolidClientException.class, 418),
-            Arguments.of(SolidClientException.class,599),
-            Arguments.of(SolidClientException.class,600)
+            arguments(BadRequestException.class, 400),
+            arguments(UnauthorizedException.class, 401),
+            arguments(ForbiddenException.class, 403),
+            arguments(NotFoundException.class, 404),
+            arguments(MethodNotAllowedException.class, 405),
+            arguments(NotAcceptableException.class, 406),
+            arguments(ConflictException.class, 409),
+            arguments(GoneException.class, 410),
+            arguments(PreconditionFailedException.class, 412),
+            arguments(UnsupportedMediaTypeException.class, 415),
+            arguments(TooManyRequestsException.class, 429),
+            arguments(InternalServerErrorException.class, 500),
+            arguments(SolidClientException.class, 418),
+            arguments(SolidClientException.class,599),
+            arguments(SolidClientException.class,600)
         );
     }
 
@@ -498,7 +506,7 @@ class SolidClientTest {
 
     private static Stream<Arguments> testRfc9457Exceptions() {
         return Stream.of(
-                Arguments.of(
+                arguments(
                         BadRequestException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -507,7 +515,7 @@ class SolidClientTest {
                                 400,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         UnauthorizedException.class,
                         new ProblemDetails(
                             URI.create("https://example.org/type"),
@@ -516,7 +524,7 @@ class SolidClientTest {
                             401,
                             URI.create("https://example.org/instance")
                     )
-                ), Arguments.of(
+                ), arguments(
                         ForbiddenException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -525,7 +533,7 @@ class SolidClientTest {
                                 403,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         NotFoundException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -534,7 +542,7 @@ class SolidClientTest {
                                 404,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         MethodNotAllowedException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -543,7 +551,7 @@ class SolidClientTest {
                                 405,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         NotAcceptableException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -552,7 +560,7 @@ class SolidClientTest {
                                 406,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         ConflictException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -561,7 +569,7 @@ class SolidClientTest {
                                 409,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         GoneException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -570,7 +578,7 @@ class SolidClientTest {
                                 410,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         PreconditionFailedException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -579,7 +587,7 @@ class SolidClientTest {
                                 412,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         UnsupportedMediaTypeException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -588,7 +596,7 @@ class SolidClientTest {
                                 415,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         TooManyRequestsException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -597,7 +605,7 @@ class SolidClientTest {
                                 429,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         InternalServerErrorException.class,
                         new ProblemDetails(
                                 URI.create("https://example.org/type"),
@@ -606,7 +614,7 @@ class SolidClientTest {
                                 500,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         // Custom errors that do not map to a predefined Exception class
                         // default to the generic SolidClientException
                         SolidClientException.class,
@@ -617,7 +625,7 @@ class SolidClientTest {
                                 418,
                                 URI.create("https://example.org/instance")
                         )
-                ), Arguments.of(
+                ), arguments(
                         // Custom errors that do not map to a predefined Exception class
                         // default to the generic SolidClientException.
                         SolidClientException.class,

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -455,13 +455,12 @@ class SolidClientTest {
                         .apply(new Response<byte[]>() {
                             @Override
                             public byte[] body() {
-                                final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                                try {
+                                try (ByteArrayOutputStream bos = new ByteArrayOutputStream()){
                                     jsonService.toJson(problemDetails, bos);
+                                    return bos.toByteArray();
                                 } catch (IOException e) {
                                     throw new RuntimeException(e);
                                 }
-                                return bos.toByteArray();
                             }
 
                             @Override

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -455,7 +455,7 @@ class SolidClientTest {
                         .apply(new Response<byte[]>() {
                             @Override
                             public byte[] body() {
-                                try (ByteArrayOutputStream bos = new ByteArrayOutputStream()){
+                                try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
                                     jsonService.toJson(problemDetails, bos);
                                     return bos.toByteArray();
                                 } catch (IOException e) {

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -493,76 +493,75 @@ class SolidClientTest {
     }
 
     private static ProblemDetails mockProblemDetails(final String title, final String details, final int status) {
-        return new ProblemDetails(
-                URI.create("https://example.org/type"),
-                title,
-                details,
-                status,
-                URI.create("https://example.org/instance")
+        return new ProblemDetails(URI.create("https://example.org/type"),
+            title,
+            details,
+            status,
+            URI.create("https://example.org/instance")
         );
     }
 
     private static Stream<Arguments> testRfc9457Exceptions() {
         return Stream.of(
                 arguments(
-                        BadRequestException.class,
-                        mockProblemDetails("Bad Request", "Some details", 400)
+                    BadRequestException.class,
+                    mockProblemDetails("Bad Request", "Some details", 400)
                 ),
                 arguments(
-                        UnauthorizedException.class,
-                        mockProblemDetails("Unauthorized", "Some details", 401)
+                    UnauthorizedException.class,
+                    mockProblemDetails("Unauthorized", "Some details", 401)
                 ),
                 arguments(
-                        ForbiddenException.class,
-                        mockProblemDetails("Forbidden", "Some details", 403)
+                    ForbiddenException.class,
+                    mockProblemDetails("Forbidden", "Some details", 403)
                 ),
                 arguments(
-                        NotFoundException.class,
-                        mockProblemDetails("Not Found", "Some details", 404)
+                    NotFoundException.class,
+                    mockProblemDetails("Not Found", "Some details", 404)
                 ),
                 arguments(
-                        MethodNotAllowedException.class,
-                        mockProblemDetails("Method Not Allowed", "Some details", 405)
+                    MethodNotAllowedException.class,
+                    mockProblemDetails("Method Not Allowed", "Some details", 405)
                 ),
                 arguments(
-                        NotAcceptableException.class,
-                        mockProblemDetails("Not Acceptable", "Some details", 406)
+                    NotAcceptableException.class,
+                    mockProblemDetails("Not Acceptable", "Some details", 406)
                 ),
                 arguments(
-                        ConflictException.class,
-                        mockProblemDetails("Conflict", "Some details", 409)
+                    ConflictException.class,
+                    mockProblemDetails("Conflict", "Some details", 409)
                 ),
                 arguments(
-                        GoneException.class,
-                        mockProblemDetails("Gone", "Some details", 410)
+                    GoneException.class,
+                    mockProblemDetails("Gone", "Some details", 410)
                 ),
                 arguments(
-                        PreconditionFailedException.class,
-                        mockProblemDetails("Precondition Failed", "Some details", 412)
+                    PreconditionFailedException.class,
+                    mockProblemDetails("Precondition Failed", "Some details", 412)
                 ),
                 arguments(
-                        UnsupportedMediaTypeException.class,
-                        mockProblemDetails("Unsupported Media Type", "Some details", 415)
+                    UnsupportedMediaTypeException.class,
+                    mockProblemDetails("Unsupported Media Type", "Some details", 415)
                 ),
                 arguments(
-                        TooManyRequestsException.class,
-                        mockProblemDetails("Too Many Requests", "Some details", 429)
+                    TooManyRequestsException.class,
+                    mockProblemDetails("Too Many Requests", "Some details", 429)
                 ),
                 arguments(
-                        InternalServerErrorException.class,
-                        mockProblemDetails("Internal Server Error", "Some details", 500)
+                    InternalServerErrorException.class,
+                    mockProblemDetails("Internal Server Error", "Some details", 500)
                 ),
                 arguments(
-                        // Custom errors that do not map to a predefined Exception class
-                        // default to the generic SolidClientException
-                        SolidClientException.class,
-                        mockProblemDetails("I'm a Teapot", "Some details", 418)
+                    // Custom errors that do not map to a predefined Exception class
+                    // default to the generic SolidClientException
+                    SolidClientException.class,
+                    mockProblemDetails("I'm a Teapot", "Some details", 418)
                 ),
                 arguments(
-                        // Custom errors that do not map to a predefined Exception class
-                        // default to the generic SolidClientException.
-                        SolidClientException.class,
-                        mockProblemDetails("Custom server error", "Some details", 599)
+                    // Custom errors that do not map to a predefined Exception class
+                    // default to the generic SolidClientException.
+                    SolidClientException.class,
+                    mockProblemDetails("Custom server error", "Some details", 599)
                 )
         );
     }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -368,21 +368,9 @@ class SolidClientTest {
 
     private static Stream<Arguments> testExceptionalResources() {
         return Stream.of(
-            arguments(
-                URI.create(config.get("solid_resource_uri") + "/unauthorized"),
-                401,
-                UnauthorizedException.class
-            ),
-            arguments(
-                URI.create(config.get("solid_resource_uri") + "/forbidden"),
-                403,
-                ForbiddenException.class
-            ),
-            arguments(
-                URI.create(config.get("solid_resource_uri") + "/missing"),
-                404,
-                NotFoundException.class
-            )
+            arguments(URI.create(config.get("solid_resource_uri") + "/unauthorized"), 401, UnauthorizedException.class),
+            arguments(URI.create(config.get("solid_resource_uri") + "/forbidden"), 403, ForbiddenException.class),
+            arguments(URI.create(config.get("solid_resource_uri") + "/missing"), 404, NotFoundException.class)
         );
     }
 
@@ -504,138 +492,77 @@ class SolidClientTest {
         assertEquals(problemDetails.getInstance(), exception.getProblemDetails().getInstance());
     }
 
+    private static ProblemDetails mockProblemDetails(final String title, final String details, final int status) {
+        return new ProblemDetails(
+                URI.create("https://example.org/type"),
+                title,
+                details,
+                status,
+                URI.create("https://example.org/instance")
+        );
+    }
+
     private static Stream<Arguments> testRfc9457Exceptions() {
         return Stream.of(
                 arguments(
                         BadRequestException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Bad Request",
-                                "Some details",
-                                400,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Bad Request", "Some details", 400)
+                ),
+                arguments(
                         UnauthorizedException.class,
-                        new ProblemDetails(
-                            URI.create("https://example.org/type"),
-                            "Unauthorized",
-                            "Some details",
-                            401,
-                            URI.create("https://example.org/instance")
-                    )
-                ), arguments(
+                        mockProblemDetails("Unauthorized", "Some details", 401)
+                ),
+                arguments(
                         ForbiddenException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Forbidden",
-                                "Some details",
-                                403,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Forbidden", "Some details", 403)
+                ),
+                arguments(
                         NotFoundException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Not Found",
-                                "Some details",
-                                404,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Not Found", "Some details", 404)
+                ),
+                arguments(
                         MethodNotAllowedException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Method Not Allowed",
-                                "Some details",
-                                405,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Method Not Allowed", "Some details", 405)
+                ),
+                arguments(
                         NotAcceptableException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Not Acceptable",
-                                "Some details",
-                                406,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Not Acceptable", "Some details", 406)
+                ),
+                arguments(
                         ConflictException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Conflict",
-                                "Some details",
-                                409,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Conflict", "Some details", 409)
+                ),
+                arguments(
                         GoneException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Gone",
-                                "Some details",
-                                410,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Gone", "Some details", 410)
+                ),
+                arguments(
                         PreconditionFailedException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Precondition Failed",
-                                "Some details",
-                                412,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Precondition Failed", "Some details", 412)
+                ),
+                arguments(
                         UnsupportedMediaTypeException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Unsupported Media Type",
-                                "Some details",
-                                415,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Unsupported Media Type", "Some details", 415)
+                ),
+                arguments(
                         TooManyRequestsException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Too Many Requests",
-                                "Some details",
-                                429,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Too Many Requests", "Some details", 429)
+                ),
+                arguments(
                         InternalServerErrorException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Internal Server Error",
-                                "Some details",
-                                500,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("Internal Server Error", "Some details", 500)
+                ),
+                arguments(
                         // Custom errors that do not map to a predefined Exception class
                         // default to the generic SolidClientException
                         SolidClientException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "I'm a Teapot",
-                                "Some details",
-                                418,
-                                URI.create("https://example.org/instance")
-                        )
-                ), arguments(
+                        mockProblemDetails("I'm a Teapot", "Some details", 418)
+                ),
+                arguments(
                         // Custom errors that do not map to a predefined Exception class
                         // default to the generic SolidClientException.
                         SolidClientException.class,
-                        new ProblemDetails(
-                                URI.create("https://example.org/type"),
-                                "Custom server error",
-                                "Some details",
-                                599,
-                                URI.create("https://example.org/instance")
-                        )
+                        mockProblemDetails("Custom server error", "Some details", 599)
                 )
         );
     }


### PR DESCRIPTION
This is based on #1160, which should be reviewed first.

The `SolidClient` now uses the `throwOnError` body mapper to handle error responses, and provides a custom exception mapper to throw the appropriate specialized exception.