### PR TITLE
JCL-402: HTTP error handling in JenaBodyHandlers

### DIFF
--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -68,6 +68,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.inrupt.client</groupId>
+      <artifactId>inrupt-client-jackson</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>

--- a/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
@@ -63,7 +63,7 @@ public final class JenaBodyHandlers {
      * Populate a Jena {@link Model} with an HTTP response body.
      *
      * @return an HTTP body handler
-     * @deprecated Use ofJenaModel instead for consistent HTTP error handling.
+     * @deprecated Use {@link JenaBodyHandlers#ofJenaModel()} instead for consistent HTTP error handling.
      */
     public static Response.BodyHandler<Model> ofModel() {
         return JenaBodyHandlers::responseToModel;
@@ -100,7 +100,7 @@ public final class JenaBodyHandlers {
      * Populate a Jena {@link Graph} with an HTTP response.
      *
      * @return an HTTP body handler
-     * @deprecated Use ofJenaGraph instead for consistent HTTP error handling.
+     * @deprecated Use {@link JenaBodyHandlers#ofJenaGraph} instead for consistent HTTP error handling.
      */
     public static Response.BodyHandler<Graph> ofGraph() {
         return JenaBodyHandlers::responseToGraph;
@@ -137,7 +137,7 @@ public final class JenaBodyHandlers {
      * Populate a Jena {@link Dataset} with an HTTP response.
      *
      * @return an HTTP body handler
-     * @deprecated Use ofJenaDataset instead for consistent HTTP error handling.
+     * @deprecated Use {@link JenaBodyHandlers#ofJenaDataset} instead for consistent HTTP error handling.
      */
     public static Response.BodyHandler<Dataset> ofDataset() {
         return JenaBodyHandlers::responseToDataset;

--- a/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
@@ -44,10 +44,6 @@ public final class JenaBodyHandlers {
 
     private static final String CONTENT_TYPE = "Content-Type";
 
-    private static Boolean isSuccess(final Response.ResponseInfo responseInfo) {
-        return responseInfo.statusCode() < 300;
-    }
-
     private static Model responseToModel(final Response.ResponseInfo responseInfo) {
         return responseInfo.headers().firstValue(CONTENT_TYPE)
             .map(JenaBodyHandlers::toJenaLang).map(lang -> {
@@ -81,7 +77,7 @@ public final class JenaBodyHandlers {
     public static Response.BodyHandler<Model> ofJenaModel() {
         return Response.BodyHandlers.throwOnError(
                 JenaBodyHandlers::responseToModel,
-                JenaBodyHandlers::isSuccess
+                (r) -> Response.isSuccess(r.statusCode())
         );
     }
 
@@ -118,7 +114,7 @@ public final class JenaBodyHandlers {
     public static Response.BodyHandler<Graph> ofJenaGraph() {
         return Response.BodyHandlers.throwOnError(
                 JenaBodyHandlers::responseToGraph,
-                JenaBodyHandlers::isSuccess
+                (r) -> Response.isSuccess(r.statusCode())
         );
     }
 
@@ -155,7 +151,7 @@ public final class JenaBodyHandlers {
     public static Response.BodyHandler<Dataset> ofJenaDataset() {
         return Response.BodyHandlers.throwOnError(
                 JenaBodyHandlers::responseToDataset,
-                JenaBodyHandlers::isSuccess
+                (r) -> Response.isSuccess(r.statusCode())
         );
     }
 

--- a/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
@@ -22,6 +22,7 @@ package com.inrupt.client.jena;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.inrupt.client.ClientHttpException;
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.spi.HttpService;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.jena.graph.NodeFactory;
@@ -57,14 +59,14 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfModelHandler() throws IOException,
+    void testOfJenaModelHandler() throws IOException,
             InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
                 .GET()
                 .build();
 
-        final var response = client.send(request, JenaBodyHandlers.ofModel())
+        final var response = client.send(request, JenaBodyHandlers.ofJenaModel())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -78,7 +80,7 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfModelHandlerAsync() throws IOException,
+    void testOfJenaModelHandlerAsync() throws IOException,
             InterruptedException, ExecutionException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
@@ -86,7 +88,7 @@ class JenaBodyHandlersTest {
                 .GET()
                 .build();
 
-        final var asyncResponse = client.send(request, JenaBodyHandlers.ofModel());
+        final var asyncResponse = client.send(request, JenaBodyHandlers.ofJenaModel());
 
         final int statusCode = asyncResponse.thenApply(Response::statusCode).toCompletableFuture().join();
         assertEquals(200, statusCode);
@@ -101,13 +103,13 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfModelHandlerWithURL() throws IOException, InterruptedException {
+    void testOfJenaModelHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/example"))
                 .GET()
                 .build();
 
-        final var response = client.send(request, JenaBodyHandlers.ofModel())
+        final var response = client.send(request, JenaBodyHandlers.ofJenaModel())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -120,14 +122,36 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfDatasetHandler() throws IOException,
+    void testOfJenaModelHandlerError() throws IOException,
+            InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/error"))
+                .GET()
+                .build();
+
+        final CompletionException completionException = assertThrows(
+                CompletionException.class,
+                () -> client.send(request, JenaBodyHandlers.ofJenaModel()).toCompletableFuture().join()
+        );
+
+        final ClientHttpException httpException = (ClientHttpException) completionException.getCause();
+
+        assertEquals(429, httpException.getProblemDetails().getStatus());
+        assertEquals("Too Many Requests", httpException.getProblemDetails().getTitle());
+        assertEquals("Some details", httpException.getProblemDetails().getDetails());
+        assertEquals("https://example.org/type", httpException.getProblemDetails().getType().toString());
+        assertEquals("https://example.org/instance", httpException.getProblemDetails().getInstance().toString());
+    }
+
+    @Test
+    void testOfJenaDatasetHandler() throws IOException,
             InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
                 .GET()
                 .build();
 
-        final var response = client.send(request, JenaBodyHandlers.ofDataset())
+        final var response = client.send(request, JenaBodyHandlers.ofJenaDataset())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -142,13 +166,13 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfDatasetHandlerWithURL() throws IOException, InterruptedException {
+    void testOfJenaDatasetHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/example"))
                 .GET()
                 .build();
 
-        final var response = client.send(request, JenaBodyHandlers.ofDataset())
+        final var response = client.send(request, JenaBodyHandlers.ofJenaDataset())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -163,7 +187,29 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfGraphHandlerAsync() throws IOException,
+    void testOfJenaDatasetHandlerError() throws IOException,
+            InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/error"))
+                .GET()
+                .build();
+
+        final CompletionException completionException = assertThrows(
+                CompletionException.class,
+                () -> client.send(request, JenaBodyHandlers.ofJenaDataset()).toCompletableFuture().join()
+        );
+
+        final ClientHttpException httpException = (ClientHttpException) completionException.getCause();
+
+        assertEquals(429, httpException.getProblemDetails().getStatus());
+        assertEquals("Too Many Requests", httpException.getProblemDetails().getTitle());
+        assertEquals("Some details", httpException.getProblemDetails().getDetails());
+        assertEquals("https://example.org/type", httpException.getProblemDetails().getType().toString());
+        assertEquals("https://example.org/instance", httpException.getProblemDetails().getInstance().toString());
+    }
+
+    @Test
+    void testOfJenaGraphHandlerAsync() throws IOException,
             InterruptedException, ExecutionException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
@@ -171,7 +217,7 @@ class JenaBodyHandlersTest {
                 .GET()
                 .build();
 
-        final var asyncResponse = client.send(request, JenaBodyHandlers.ofGraph());
+        final var asyncResponse = client.send(request, JenaBodyHandlers.ofJenaGraph());
 
         final int statusCode = asyncResponse.thenApply(Response::statusCode).toCompletableFuture().join();
         assertEquals(200, statusCode);
@@ -186,14 +232,14 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfGraphHandler() throws IOException,
+    void testOfJenaGraphHandler() throws IOException,
             InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
                 .GET()
                 .build();
 
-        final var response = client.send(request, JenaBodyHandlers.ofGraph())
+        final var response = client.send(request, JenaBodyHandlers.ofJenaGraph())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -207,13 +253,13 @@ class JenaBodyHandlersTest {
     }
 
     @Test
-    void testOfGraphHandlerWithURL() throws IOException, InterruptedException {
+    void testOfJenaGraphHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/example"))
                 .GET()
                 .build();
 
-        final var response = client.send(request, JenaBodyHandlers.ofGraph())
+        final var response = client.send(request, JenaBodyHandlers.ofJenaGraph())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -224,5 +270,27 @@ class JenaBodyHandlersTest {
             NodeFactory.createURI("http://www.w3.org/ns/pim/space#preferencesFile"),
             null)
         );
+    }
+
+    @Test
+    void testOfJenaGraphHandlerError() throws IOException,
+            InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/error"))
+                .GET()
+                .build();
+
+        final CompletionException completionException = assertThrows(
+                CompletionException.class,
+                () -> client.send(request, JenaBodyHandlers.ofJenaGraph()).toCompletableFuture().join()
+        );
+
+        final ClientHttpException httpException = (ClientHttpException) completionException.getCause();
+
+        assertEquals(429, httpException.getProblemDetails().getStatus());
+        assertEquals("Too Many Requests", httpException.getProblemDetails().getTitle());
+        assertEquals("Some details", httpException.getProblemDetails().getDetails());
+        assertEquals("https://example.org/type", httpException.getProblemDetails().getType().toString());
+        assertEquals("https://example.org/instance", httpException.getProblemDetails().getInstance().toString());
     }
 }

--- a/test/src/main/java/com/inrupt/client/test/RdfMockService.java
+++ b/test/src/main/java/com/inrupt/client/test/RdfMockService.java
@@ -24,6 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.*;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.inrupt.client.ProblemDetails;
 
 import java.util.Collections;
 import java.util.Map;
@@ -32,6 +33,8 @@ import java.util.Map;
  * A {@link WireMockServer} based HTTP service used for testing RDF services.
  */
 public class RdfMockService {
+
+    private static final String CONTENT_TYPE = "Content-Type";
 
     private final WireMockServer wireMockServer;
 
@@ -49,30 +52,41 @@ public class RdfMockService {
         wireMockServer.stubFor(get(urlEqualTo("/oneTriple"))
                     .willReturn(aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/turtle")
+                        .withHeader(CONTENT_TYPE, "text/turtle")
                         .withBody("<http://example.test/s> <http://example.test/p> <http://example.test/o> .")));
 
         wireMockServer.stubFor(post(urlEqualTo("/postOneTriple"))
                     .withRequestBody(matching(
                             ".*<http://example.test/subject>\\s+" +
                             "<http://example.test/predicate>\\s+\"object\"\\s+\\..*"))
-                    .withHeader("Content-Type", containing("text/turtle"))
+                    .withHeader(CONTENT_TYPE, containing("text/turtle"))
                     .willReturn(aResponse()
                         .withStatus(204)));
 
         wireMockServer.stubFor(get(urlEqualTo("/example"))
                     .willReturn(aResponse()
                         .withStatus(200)
-                        .withHeader("Content-Type", "text/turtle")
+                        .withHeader(CONTENT_TYPE, "text/turtle")
                         .withBody(getExampleTTL())));
 
         wireMockServer.stubFor(patch(urlEqualTo("/sparqlUpdate"))
-                    .withHeader("Content-Type", containing("application/sparql-update"))
+                    .withHeader(CONTENT_TYPE, containing("application/sparql-update"))
                     .withRequestBody(matching(
                             "INSERT DATA\\s+\\{\\s*<http://example.test/s1>\\s+" +
                             "<http://example.test/p1>\\s+<http://example.test/o1>\\s*\\.\\s*\\}\\s*"))
                     .willReturn(aResponse()
                         .withStatus(204)));
+
+        wireMockServer.stubFor(get(urlEqualTo("/error"))
+                .willReturn(aResponse()
+                        .withStatus(429)
+                        .withHeader(CONTENT_TYPE, ProblemDetails.MIME_TYPE)
+                        .withBody("{" +
+                                "\"title\":\"Too Many Requests\"," +
+                                "\"status\":429," +
+                                "\"details\":\"Some details\"," +
+                                "\"instance\":\"https://example.org/instance\"," +
+                                "\"type\":\"https://example.org/type\"}")));
     }
 
     private String getExampleTTL() {


### PR DESCRIPTION
This is based on #1160, which should be reviewed first.

This deprecates the current methods in `JenaBodyHandlers`, and replaces them with similar method throwing an appropriate exception with error details on HTTP error instead of returning an empty dataset. This makes use of the composable throwing body handler now exposed by the `Response` interface of the `api` module. The new method now have `Jena` in their name for this not to be a breaking change: `ofModel` becomes `ofJenaModel`, etc.