### PR TITLE
JCL-402: RDF4J body handlers http error handling

### DIFF
--- a/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
+++ b/jena/src/main/java/com/inrupt/client/jena/JenaBodyHandlers.java
@@ -49,7 +49,7 @@ public final class JenaBodyHandlers {
     private static void throwOnError(final Response.ResponseInfo responseInfo) {
         if (!Response.isSuccess(responseInfo.statusCode())) {
             throw new ClientHttpException(
-                    "Could not map to a Jena entity.",
+                    "An HTTP error was encountered mapping to a Jena entity.",
                     responseInfo.uri(),
                     responseInfo.statusCode(),
                     responseInfo.headers(),

--- a/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
+++ b/jena/src/test/java/com/inrupt/client/jena/JenaBodyHandlersTest.java
@@ -79,6 +79,31 @@ class JenaBodyHandlersTest {
         );
     }
 
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofModel function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfModelHandler() throws IOException,
+            InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .GET()
+                .build();
+
+        final var response = client.send(request, JenaBodyHandlers.ofModel())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final var responseBody = response.body();
+        assertEquals(1, responseBody.size());
+        assertTrue(responseBody.contains(
+                null,
+                null,
+                ResourceFactory.createResource("http://example.test/o"))
+        );
+    }
+
     @Test
     void testOfJenaModelHandlerAsync() throws IOException,
             InterruptedException, ExecutionException {
@@ -102,6 +127,33 @@ class JenaBodyHandlersTest {
         );
     }
 
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofModel function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfModelHandlerAsync() throws IOException,
+            InterruptedException, ExecutionException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .header("Accept", "text/turtle")
+                .GET()
+                .build();
+
+        final var asyncResponse = client.send(request, JenaBodyHandlers.ofModel());
+
+        final int statusCode = asyncResponse.thenApply(Response::statusCode).toCompletableFuture().join();
+        assertEquals(200, statusCode);
+
+        final var responseBody = asyncResponse.thenApply(Response::body).toCompletableFuture().join();
+        assertEquals(1, responseBody.size());
+        assertTrue(responseBody.contains(
+                null,
+                null,
+                ResourceFactory.createResource("http://example.test/o"))
+        );
+    }
+
     @Test
     void testOfJenaModelHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
@@ -118,6 +170,29 @@ class JenaBodyHandlersTest {
         assertTrue(responseBody.contains(
             null,
             ResourceFactory.createProperty("http://www.w3.org/ns/pim/space#preferencesFile"))
+        );
+    }
+
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofModel function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfModelHandlerWithURL() throws IOException, InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/example"))
+                .GET()
+                .build();
+
+        final var response = client.send(request, JenaBodyHandlers.ofModel())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final var responseBody = response.body();
+        assertEquals(7, responseBody.size());
+        assertTrue(responseBody.contains(
+                null,
+                ResourceFactory.createProperty("http://www.w3.org/ns/pim/space#preferencesFile"))
         );
     }
 
@@ -152,16 +227,42 @@ class JenaBodyHandlersTest {
                 .build();
 
         final var response = client.send(request, JenaBodyHandlers.ofJenaDataset())
-            .toCompletableFuture().join();
+                .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
         final var responseBody = response.body();
         assertEquals(1, responseBody.asDatasetGraph().stream().count());
         assertTrue(responseBody.asDatasetGraph().contains(
-            null,
-            NodeFactory.createURI("http://example.test/s"),
-            null,
-            null)
+                null,
+                NodeFactory.createURI("http://example.test/s"),
+                null,
+                null)
+        );
+    }
+
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofDataset function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfDatasetHandler() throws IOException,
+            InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .GET()
+                .build();
+
+        final var response = client.send(request, JenaBodyHandlers.ofDataset())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final var responseBody = response.body();
+        assertEquals(1, responseBody.asDatasetGraph().stream().count());
+        assertTrue(responseBody.asDatasetGraph().contains(
+                null,
+                NodeFactory.createURI("http://example.test/s"),
+                null,
+                null)
         );
     }
 
@@ -183,6 +284,31 @@ class JenaBodyHandlersTest {
             null,
             NodeFactory.createURI("http://www.w3.org/ns/pim/space#preferencesFile"),
             null)
+        );
+    }
+
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofDataset function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfDatasetHandlerWithURL() throws IOException, InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/example"))
+                .GET()
+                .build();
+
+        final var response = client.send(request, JenaBodyHandlers.ofDataset())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final var responseBody = response.body();
+        assertEquals(7, responseBody.asDatasetGraph().stream().count());
+        assertTrue(responseBody.asDatasetGraph().contains(
+                null,
+                null,
+                NodeFactory.createURI("http://www.w3.org/ns/pim/space#preferencesFile"),
+                null)
         );
     }
 
@@ -231,6 +357,33 @@ class JenaBodyHandlersTest {
         );
     }
 
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofGraph function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfGraphHandlerAsync() throws IOException,
+            InterruptedException, ExecutionException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .header("Accept", "text/turtle")
+                .GET()
+                .build();
+
+        final var asyncResponse = client.send(request, JenaBodyHandlers.ofGraph());
+
+        final int statusCode = asyncResponse.thenApply(Response::statusCode).toCompletableFuture().join();
+        assertEquals(200, statusCode);
+
+        final var responseBody = asyncResponse.thenApply(Response::body).toCompletableFuture().join();
+        assertEquals(1, responseBody.size());
+        assertTrue(responseBody.contains(
+                NodeFactory.createURI("http://example.test/s"),
+                null,
+                null)
+        );
+    }
+
     @Test
     void testOfJenaGraphHandler() throws IOException,
             InterruptedException {
@@ -252,6 +405,31 @@ class JenaBodyHandlersTest {
         );
     }
 
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofGraph function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfGraphHandler() throws IOException,
+            InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .GET()
+                .build();
+
+        final var response = client.send(request, JenaBodyHandlers.ofGraph())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final var responseBody = response.body();
+        assertEquals(1, responseBody.size());
+        assertTrue(responseBody.contains(
+                NodeFactory.createURI("http://example.test/s"),
+                null,
+                null)
+        );
+    }
+
     @Test
     void testOfJenaGraphHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
@@ -269,6 +447,30 @@ class JenaBodyHandlersTest {
             null,
             NodeFactory.createURI("http://www.w3.org/ns/pim/space#preferencesFile"),
             null)
+        );
+    }
+
+    /**
+     * @deprecated covers the deprecated JenaBodyHandlers::ofGraph function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfGraphHandlerWithURL() throws IOException, InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/example"))
+                .GET()
+                .build();
+
+        final var response = client.send(request, JenaBodyHandlers.ofGraph())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final var responseBody = response.body();
+        assertEquals(7, responseBody.size());
+        assertTrue(responseBody.contains(
+                null,
+                NodeFactory.createURI("http://www.w3.org/ns/pim/space#preferencesFile"),
+                null)
         );
     }
 

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -41,10 +41,6 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
  */
 public final class RDF4JBodyHandlers {
 
-    private static Boolean isSuccess(final Response.ResponseInfo responseInfo) {
-        return responseInfo.statusCode() < 300;
-    }
-
     private static Model responseToModel(final Response.ResponseInfo responseInfo) {
         return responseInfo.headers().firstValue("Content-Type")
                 .map(RDF4JBodyHandlers::toRDF4JFormat).map(format -> {
@@ -76,7 +72,7 @@ public final class RDF4JBodyHandlers {
     public static Response.BodyHandler<Model> ofRDF4JModel() {
         return Response.BodyHandlers.throwOnError(
                 RDF4JBodyHandlers::responseToModel,
-                RDF4JBodyHandlers::isSuccess
+                (r) -> Response.isSuccess(r.statusCode())
         );
     }
 
@@ -114,7 +110,7 @@ public final class RDF4JBodyHandlers {
     public static Response.BodyHandler<Repository> ofRDF4JRepository() {
         return Response.BodyHandlers.throwOnError(
                 RDF4JBodyHandlers::responseToRepository,
-                RDF4JBodyHandlers::isSuccess
+                (r) -> Response.isSuccess(r.statusCode())
         );
     }
 

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -20,7 +20,11 @@
  */
 package com.inrupt.client.rdf4j;
 
+import com.inrupt.client.ClientHttpException;
+import com.inrupt.client.ProblemDetails;
 import com.inrupt.client.Response;
+import com.inrupt.client.spi.JsonService;
+import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -41,22 +45,95 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
  */
 public final class RDF4JBodyHandlers {
 
+    private static JsonService jsonService;
+    private static boolean isJsonServiceInitialized = false;
+
+    private static JsonService getJsonService() {
+        if (RDF4JBodyHandlers.isJsonServiceInitialized) {
+            return RDF4JBodyHandlers.jsonService;
+        }
+        // It is acceptable for a JenaBodyHandlers instance to be in a classpath without any implementation for
+        // JsonService, in which case the ProblemDetails exceptions will fallback to default and not be parsed.
+        JsonService js;
+        try {
+            js = ServiceProvider.getJsonService();
+        } catch (IllegalStateException e) {
+            js = null;
+        }
+        RDF4JBodyHandlers.jsonService = js;
+        RDF4JBodyHandlers.isJsonServiceInitialized = true;
+        return RDF4JBodyHandlers.jsonService;
+    }
+
+    private static Model responseToModel(final Response.ResponseInfo responseInfo) {
+        return responseInfo.headers().firstValue("Content-Type")
+                .map(RDF4JBodyHandlers::toRDF4JFormat).map(format -> {
+                    try (final InputStream stream = new ByteArrayInputStream(responseInfo.body().array())) {
+                        return Rio.parse(stream, responseInfo.uri().toString(), format);
+                    } catch (final IOException ex) {
+                        throw new UncheckedIOException(
+                                "An I/O error occurred while data was read from the InputStream", ex);
+                    }
+                })
+                .orElseGet(() -> new DynamicModelFactory().createEmptyModel());
+    }
+
+    /**
+     * Populate a RDF4J {@link Model} with an HTTP response.
+     *
+     * @return an HTTP body handler
+     * @deprecated
+     */
+    public static Response.BodyHandler<Model> ofModel() {
+        return RDF4JBodyHandlers::responseToModel;
+    }
+
     /**
      * Populate a RDF4J {@link Model} with an HTTP response.
      *
      * @return an HTTP body handler
      */
-    public static Response.BodyHandler<Model> ofModel() {
-        return responseInfo -> responseInfo.headers().firstValue("Content-Type")
+    public static Response.BodyHandler<Model> ofRDF4JModel() {
+        return responseInfo -> {
+            if (responseInfo.statusCode() >= 300) {
+                throw new ClientHttpException(
+                    ProblemDetails.fromErrorResponse(
+                        responseInfo.statusCode(),
+                        responseInfo.headers(),
+                        responseInfo.body().array(),
+                        getJsonService()
+                    ),
+                    "Deserializing the RDF from " + responseInfo.uri() + " failed"
+                );
+            }
+            return responseToModel(responseInfo);
+        };
+    }
+
+    private static Repository responseToRepository(final Response.ResponseInfo responseInfo) {
+        return responseInfo.headers().firstValue("Content-Type")
             .map(RDF4JBodyHandlers::toRDF4JFormat).map(format -> {
-                try (final InputStream stream = new ByteArrayInputStream(responseInfo.body().array())) {
-                    return Rio.parse(stream, responseInfo.uri().toString(), format);
+                final Repository repository = new SailRepository(new MemoryStore());
+                try (final InputStream stream = new ByteArrayInputStream(responseInfo.body().array());
+                     final RepositoryConnection conn = repository.getConnection()) {
+                    conn.add(stream, responseInfo.uri().toString(), format);
                 } catch (final IOException ex) {
                     throw new UncheckedIOException(
-                        "An I/O error occurred while data was read from the InputStream", ex);
+                            "An I/O error occurred while data was read from the InputStream", ex);
                 }
+                return repository;
             })
-            .orElseGet(() -> new DynamicModelFactory().createEmptyModel());
+            .orElseGet(() -> new SailRepository(new MemoryStore()));
+    }
+
+    /**
+     * Populate a RDF4J {@link Repository} with an HTTP response.
+     *
+     * @return an HTTP body handler
+     * @deprecated
+     */
+    public static Response.BodyHandler<Repository> ofRepository() {
+        return RDF4JBodyHandlers::responseToRepository;
     }
 
     /**
@@ -64,20 +141,21 @@ public final class RDF4JBodyHandlers {
      *
      * @return an HTTP body handler
      */
-    public static Response.BodyHandler<Repository> ofRepository() {
-        return responseInfo -> responseInfo.headers().firstValue("Content-Type")
-            .map(RDF4JBodyHandlers::toRDF4JFormat).map(format -> {
-                final Repository repository = new SailRepository(new MemoryStore());
-                try (final InputStream stream = new ByteArrayInputStream(responseInfo.body().array());
-                        final RepositoryConnection conn = repository.getConnection()) {
-                    conn.add(stream, responseInfo.uri().toString(), format);
-                } catch (final IOException ex) {
-                    throw new UncheckedIOException(
-                        "An I/O error occurred while data was read from the InputStream", ex);
-                }
-                return repository;
-            })
-            .orElseGet(() -> new SailRepository(new MemoryStore()));
+    public static Response.BodyHandler<Repository> ofRDF4JRepository() {
+        return responseInfo -> {
+            if (responseInfo.statusCode() >= 300) {
+                throw new ClientHttpException(
+                    ProblemDetails.fromErrorResponse(
+                        responseInfo.statusCode(),
+                        responseInfo.headers(),
+                        responseInfo.body().array(),
+                        getJsonService()
+                    ),
+                    "Deserializing the RDF from " + responseInfo.uri() + " failed"
+                );
+            }
+            return responseToRepository(responseInfo);
+        };
     }
 
     static RDFFormat toRDF4JFormat(final String mediaType) {

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -46,7 +46,7 @@ public final class RDF4JBodyHandlers {
     private static void throwOnError(final Response.ResponseInfo responseInfo) {
         if (!Response.isSuccess(responseInfo.statusCode())) {
             throw new ClientHttpException(
-                    "Could not map to an RDF4J entity.",
+                    "An HTTP error was encountered mapping to an RDF4J entity.",
                     responseInfo.uri(),
                     responseInfo.statusCode(),
                     responseInfo.headers(),

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -20,11 +20,7 @@
  */
 package com.inrupt.client.rdf4j;
 
-import com.inrupt.client.ClientHttpException;
-import com.inrupt.client.ProblemDetails;
 import com.inrupt.client.Response;
-import com.inrupt.client.spi.JsonService;
-import com.inrupt.client.spi.ServiceProvider;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -46,7 +46,7 @@ public final class RDF4JBodyHandlers {
     private static void throwOnError(final Response.ResponseInfo responseInfo) {
         if (!Response.isSuccess(responseInfo.statusCode())) {
             throw new ClientHttpException(
-                    "Could not map to a Jena entity.",
+                    "Could not map to an RDF4J entity.",
                     responseInfo.uri(),
                     responseInfo.statusCode(),
                     responseInfo.headers(),

--- a/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
+++ b/rdf4j/src/main/java/com/inrupt/client/rdf4j/RDF4JBodyHandlers.java
@@ -72,7 +72,7 @@ public final class RDF4JBodyHandlers {
      * Populate a RDF4J {@link Model} with an HTTP response.
      *
      * @return an HTTP body handler
-     * @deprecated
+     * @deprecated Use {@link RDF4JBodyHandlers#ofRDF4JModel} instead for consistent HTTP error handling.
      */
     public static Response.BodyHandler<Model> ofModel() {
         return RDF4JBodyHandlers::responseToModel;
@@ -110,7 +110,7 @@ public final class RDF4JBodyHandlers {
      * Populate a RDF4J {@link Repository} with an HTTP response.
      *
      * @return an HTTP body handler
-     * @deprecated
+     * @deprecated Use {@link RDF4JBodyHandlers#ofRDF4JRepository} instead for consistent HTTP error handling.
      */
     public static Response.BodyHandler<Repository> ofRepository() {
         return RDF4JBodyHandlers::responseToRepository;

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
@@ -384,12 +384,12 @@ class RDF4JBodyHandlersTest {
         final Repository responseBody = response.body();
         try (final RepositoryConnection conn = responseBody.getConnection()) {
             assertTrue(conn.hasStatement(
-                            null,
-                            SimpleValueFactory.getInstance().createIRI("http://www.w3.org/ns/pim/space#preferencesFile"),
-                            null,
-                            false,
-                            (Resource)null
-                    )
+                    null,
+                    SimpleValueFactory.getInstance().createIRI("http://www.w3.org/ns/pim/space#preferencesFile"),
+                    null,
+                    false,
+                    (Resource)null
+                )
             );
         }
     }

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
@@ -85,6 +85,33 @@ class RDF4JBodyHandlersTest {
         );
     }
 
+    /**
+     * @deprecated covers the deprecated RDF4JBodyHandlers::ofModel function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfModelHandlerAsync() throws IOException,
+            InterruptedException, ExecutionException, TimeoutException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .GET()
+                .build();
+
+        final Response<Model> res = client.send(request, RDF4JBodyHandlers.ofModel()).toCompletableFuture().join();
+
+        final int statusCode = res.statusCode();
+        final Model responseBody = res.body();
+
+        assertEquals(200, statusCode);
+        assertEquals(1, responseBody.size());
+        assertTrue(responseBody.contains(
+                (Resource)SimpleValueFactory.getInstance().createIRI("http://example.test/s"),
+                null,
+                null,
+                (Resource)null)
+        );
+    }
+
     @Test
     void testOfRDF4JModelHandler() throws IOException,
             InterruptedException, ExecutionException, TimeoutException {
@@ -107,6 +134,32 @@ class RDF4JBodyHandlersTest {
         );
     }
 
+    /**
+     * @deprecated covers the deprecated RDF4JBodyHandlers::ofModel function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfModelHandler() throws IOException,
+            InterruptedException, ExecutionException, TimeoutException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .GET()
+                .build();
+
+        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofModel())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final Model responseBody = response.body();
+        assertEquals(1, responseBody.size());
+        assertTrue(responseBody.contains(
+                (Resource)SimpleValueFactory.getInstance().createIRI("http://example.test/s"),
+                null,
+                null,
+                (Resource)null)
+        );
+    }
+
     @Test
     void testOfRDF4JModelHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
@@ -125,6 +178,32 @@ class RDF4JBodyHandlersTest {
                 SimpleValueFactory.getInstance().createIRI("http://www.w3.org/ns/pim/space#preferencesFile"),
                 null,
                 (Resource)null
+                )
+        );
+    }
+
+    /**
+     * @deprecated covers the deprecated RDF4JBodyHandlers::ofModel function. To be removed when removing the function
+     *  from the API.
+     */
+    @Test
+    void testOfModelHandlerWithURL() throws IOException, InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/example"))
+                .GET()
+                .build();
+
+        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofModel())
+                .toCompletableFuture().join();
+
+        assertEquals(200, response.statusCode());
+        final Model responseBody = response.body();
+        assertEquals(7, responseBody.size());
+        assertTrue(responseBody.contains(
+                        null,
+                        SimpleValueFactory.getInstance().createIRI("http://www.w3.org/ns/pim/space#preferencesFile"),
+                        null,
+                        (Resource)null
                 )
         );
     }
@@ -160,7 +239,7 @@ class RDF4JBodyHandlersTest {
                 .build();
 
         final Response<Repository> res = client.send(request, RDF4JBodyHandlers.ofRDF4JRepository())
-            .toCompletableFuture().join();
+                .toCompletableFuture().join();
 
         final int statusCode = res.statusCode();
         assertEquals(200, statusCode);
@@ -168,12 +247,43 @@ class RDF4JBodyHandlersTest {
         final Repository responseBody = res.body();
         try (final RepositoryConnection conn = responseBody.getConnection()) {
             assertTrue(conn.hasStatement(
-                (Resource)SimpleValueFactory.getInstance().createIRI("http://example.test/s"),
-                null,
-                null,
-                false,
-                (Resource)null
-            )
+                            (Resource)SimpleValueFactory.getInstance().createIRI("http://example.test/s"),
+                            null,
+                            null,
+                            false,
+                            (Resource)null
+                    )
+            );
+        }
+    }
+
+    /**
+     * @deprecated covers the deprecated RDF4JBodyHandlers::ofRepository function.
+     *   To be removed when removing the function from the API.
+     */
+    @Test
+    void testOfRepositoryHandlerAsync() throws IOException,
+            InterruptedException, ExecutionException, TimeoutException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .GET()
+                .build();
+
+        final Response<Repository> res = client.send(request, RDF4JBodyHandlers.ofRepository())
+                .toCompletableFuture().join();
+
+        final int statusCode = res.statusCode();
+        assertEquals(200, statusCode);
+
+        final Repository responseBody = res.body();
+        try (final RepositoryConnection conn = responseBody.getConnection()) {
+            assertTrue(conn.hasStatement(
+                            (Resource)SimpleValueFactory.getInstance().createIRI("http://example.test/s"),
+                            null,
+                            null,
+                            false,
+                            (Resource)null
+                    )
             );
         }
     }
@@ -203,6 +313,35 @@ class RDF4JBodyHandlersTest {
         }
     }
 
+    /**
+     * @deprecated covers the deprecated RDF4JBodyHandlers::ofRepository function.
+     *   To be removed when removing the function from the API.
+     */
+    @Test
+    void testOfRepositoryHandler() throws IOException,
+            InterruptedException, ExecutionException, TimeoutException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
+                .GET()
+                .build();
+
+        final Response<Repository> response = client.send(request, RDF4JBodyHandlers.ofRepository())
+                .toCompletableFuture().join();
+        assertEquals(200, response.statusCode());
+
+        final Repository responseBody = response.body();
+        try (final RepositoryConnection conn = responseBody.getConnection()) {
+            assertTrue(conn.hasStatement(
+                            (Resource)SimpleValueFactory.getInstance().createIRI("http://example.test/s"),
+                            null,
+                            null,
+                            false,
+                            (Resource)null
+                    )
+            );
+        }
+    }
+
     @Test
     void testOfRDF4JRepositoryHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
@@ -223,6 +362,34 @@ class RDF4JBodyHandlersTest {
                 false,
                 (Resource)null
             )
+            );
+        }
+    }
+
+    /**
+     * @deprecated covers the deprecated RDF4JBodyHandlers::ofRepository function.
+     *   To be removed when removing the function from the API.
+     */
+    @Test
+    void testOfRepositoryHandlerWithURL() throws IOException, InterruptedException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/example"))
+                .GET()
+                .build();
+
+        final Response<Repository> response = client.send(request, RDF4JBodyHandlers.ofRepository())
+                .toCompletableFuture().join();
+        assertEquals(200, response.statusCode());
+
+        final Repository responseBody = response.body();
+        try (final RepositoryConnection conn = responseBody.getConnection()) {
+            assertTrue(conn.hasStatement(
+                            null,
+                            SimpleValueFactory.getInstance().createIRI("http://www.w3.org/ns/pim/space#preferencesFile"),
+                            null,
+                            false,
+                            (Resource)null
+                    )
             );
         }
     }

--- a/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
+++ b/rdf4j/src/test/java/com/inrupt/client/rdf4j/RDF4JBodyHandlersTest.java
@@ -22,6 +22,7 @@ package com.inrupt.client.rdf4j;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.inrupt.client.ClientHttpException;
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.spi.HttpService;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -61,14 +63,14 @@ class RDF4JBodyHandlersTest {
     }
 
     @Test
-    void testOfModelHandlerAsync() throws IOException,
+    void testOfRDF4JModelHandlerAsync() throws IOException,
             InterruptedException, ExecutionException, TimeoutException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
                 .GET()
                 .build();
 
-        final Response<Model> res = client.send(request, RDF4JBodyHandlers.ofModel()).toCompletableFuture().join();
+        final Response<Model> res = client.send(request, RDF4JBodyHandlers.ofRDF4JModel()).toCompletableFuture().join();
 
         final int statusCode = res.statusCode();
         final Model responseBody = res.body();
@@ -84,14 +86,14 @@ class RDF4JBodyHandlersTest {
     }
 
     @Test
-    void testOfModelHandler() throws IOException,
+    void testOfRDF4JModelHandler() throws IOException,
             InterruptedException, ExecutionException, TimeoutException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
                 .GET()
                 .build();
 
-        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofModel())
+        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofRDF4JModel())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -106,13 +108,13 @@ class RDF4JBodyHandlersTest {
     }
 
     @Test
-    void testOfModelHandlerWithURL() throws IOException, InterruptedException {
+    void testOfRDF4JModelHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/example"))
                 .GET()
                 .build();
 
-        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofModel())
+        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofRDF4JModel())
             .toCompletableFuture().join();
 
         assertEquals(200, response.statusCode());
@@ -128,14 +130,36 @@ class RDF4JBodyHandlersTest {
     }
 
     @Test
-    void testOfRepositoryHandlerAsync() throws IOException,
+    void testOfRDF4JModelHandlerError() throws IOException,
+            InterruptedException, ExecutionException, TimeoutException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/error"))
+                .GET()
+                .build();
+
+        final CompletionException completionException = assertThrows(
+                CompletionException.class,
+                () -> client.send(request, RDF4JBodyHandlers.ofRDF4JModel()).toCompletableFuture().join()
+        );
+
+        final ClientHttpException httpException = (ClientHttpException) completionException.getCause();
+
+        assertEquals(429, httpException.getProblemDetails().getStatus());
+        assertEquals("Too Many Requests", httpException.getProblemDetails().getTitle());
+        assertEquals("Some details", httpException.getProblemDetails().getDetails());
+        assertEquals("https://example.org/type", httpException.getProblemDetails().getType().toString());
+        assertEquals("https://example.org/instance", httpException.getProblemDetails().getInstance().toString());
+    }
+
+    @Test
+    void testOfRDF4JRepositoryHandlerAsync() throws IOException,
             InterruptedException, ExecutionException, TimeoutException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
                 .GET()
                 .build();
 
-        final Response<Repository> res = client.send(request, RDF4JBodyHandlers.ofRepository())
+        final Response<Repository> res = client.send(request, RDF4JBodyHandlers.ofRDF4JRepository())
             .toCompletableFuture().join();
 
         final int statusCode = res.statusCode();
@@ -155,14 +179,14 @@ class RDF4JBodyHandlersTest {
     }
 
     @Test
-    void testOfRepositoryHandler() throws IOException,
+    void testOfRDF4JRepositoryHandler() throws IOException,
             InterruptedException, ExecutionException, TimeoutException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/oneTriple"))
                 .GET()
                 .build();
 
-        final Response<Repository> response = client.send(request, RDF4JBodyHandlers.ofRepository())
+        final Response<Repository> response = client.send(request, RDF4JBodyHandlers.ofRDF4JRepository())
             .toCompletableFuture().join();
         assertEquals(200, response.statusCode());
 
@@ -180,13 +204,13 @@ class RDF4JBodyHandlersTest {
     }
 
     @Test
-    void testOfRepositoryHandlerWithURL() throws IOException, InterruptedException {
+    void testOfRDF4JRepositoryHandlerWithURL() throws IOException, InterruptedException {
         final Request request = Request.newBuilder()
                 .uri(URI.create(config.get("rdf_uri") + "/example"))
                 .GET()
                 .build();
 
-        final Response<Repository> response = client.send(request, RDF4JBodyHandlers.ofRepository())
+        final Response<Repository> response = client.send(request, RDF4JBodyHandlers.ofRDF4JRepository())
             .toCompletableFuture().join();
         assertEquals(200, response.statusCode());
 
@@ -201,5 +225,27 @@ class RDF4JBodyHandlersTest {
             )
             );
         }
+    }
+
+    @Test
+    void testOfRDF4JRepositoryHandlerError() throws IOException,
+            InterruptedException, ExecutionException, TimeoutException {
+        final Request request = Request.newBuilder()
+                .uri(URI.create(config.get("rdf_uri") + "/error"))
+                .GET()
+                .build();
+
+        final CompletionException completionException = assertThrows(
+                CompletionException.class,
+                () -> client.send(request, RDF4JBodyHandlers.ofRDF4JRepository()).toCompletableFuture().join()
+        );
+
+        final ClientHttpException httpException = (ClientHttpException) completionException.getCause();
+
+        assertEquals(429, httpException.getProblemDetails().getStatus());
+        assertEquals("Too Many Requests", httpException.getProblemDetails().getTitle());
+        assertEquals("Some details", httpException.getProblemDetails().getDetails());
+        assertEquals("https://example.org/type", httpException.getProblemDetails().getType().toString());
+        assertEquals("https://example.org/instance", httpException.getProblemDetails().getInstance().toString());
     }
 }


### PR DESCRIPTION
This is based on #1159 , which should be reviewed first. (The only dependency between the two is in the mocks)

This deprecates the current methods in `RDF4JBodyHandlers`, and replaces them with similar method throwing an appropriate exception with error details on HTTP error instead of returning an empty dataset. This makes use of the composable throwing body handler now exposed by the `Response` interface of the `api` module. The new method now have `RDF4J` in their name for this not to be a breaking change: `ofModel` becomes `ofRDF4JModel`, etc.