### PR TITLE
JCL-444: Improve support for RFC 9207

### DIFF
--- a/openid/src/main/java/com/inrupt/client/openid/Metadata.java
+++ b/openid/src/main/java/com/inrupt/client/openid/Metadata.java
@@ -112,4 +112,9 @@ public class Metadata {
      * A list of DPoP signing algorithm values supported by the given OpenID Connect provider.
      */
     public List<String> dpopSigningAlgValuesSupported;
+
+    /**
+     * Indication of whether the OpenID Connect provider supports RFC-9207.
+     */
+    public boolean authorizationResponseIssParameterSupported;
 }

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
@@ -211,6 +211,13 @@ public class OpenIdProvider {
     }
 
     private Request tokenRequest(final Metadata metadata, final TokenRequest request) {
+        if (request.getIssuer() != null) {
+            if (!request.getIssuer().equals(metadata.issuer)) {
+                throw new OpenIdException("Issuer mismatch. " +
+                        "Please verify that the designated OpenID issuer is correct");
+            }
+        }
+
         if (!metadata.grantTypesSupported.contains(request.getGrantType())) {
             throw new OpenIdException("Grant type [" + request.getGrantType() + "] is not supported by this provider.");
         }

--- a/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
+++ b/openid/src/main/java/com/inrupt/client/openid/OpenIdProvider.java
@@ -211,8 +211,10 @@ public class OpenIdProvider {
     }
 
     private Request tokenRequest(final Metadata metadata, final TokenRequest request) {
-        if (request.getIssuer() != null) {
-            if (!request.getIssuer().equals(metadata.issuer)) {
+        // RFC 9207 describes this behavior as a SHOULD but recognizes use cases that vary;
+        // this would be good to consider when adding broader configuration support to the libraries.
+        if (metadata.authorizationResponseIssParameterSupported) {
+            if (!Objects.equals(request.getIssuer(), metadata.issuer)) {
                 throw new OpenIdException("Issuer mismatch. " +
                         "Please verify that the designated OpenID issuer is correct");
             }

--- a/openid/src/main/java/com/inrupt/client/openid/TokenRequest.java
+++ b/openid/src/main/java/com/inrupt/client/openid/TokenRequest.java
@@ -38,6 +38,7 @@ public final class TokenRequest {
     private final String clientSecret;
     private final String authMethod;
     private final URI redirectUri;
+    private final URI issuer;
     private final List<String> scopes;
 
     /**
@@ -56,6 +57,15 @@ public final class TokenRequest {
      */
     public List<String> getScopes() {
         return scopes;
+    }
+
+    /**
+     * Get the issuer.
+     *
+     * @return the issuer, may be {@code null}
+     */
+    public URI getIssuer() {
+        return issuer;
     }
 
     /**
@@ -123,7 +133,8 @@ public final class TokenRequest {
 
     /* package-private */
     TokenRequest(final String clientId, final String clientSecret, final URI redirectUri, final String grantType,
-            final String authMethod, final String code, final String codeVerifier, final List<String> scopes) {
+            final String authMethod, final String code, final String codeVerifier, final URI issuer,
+            final List<String> scopes) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.redirectUri = redirectUri;
@@ -132,6 +143,7 @@ public final class TokenRequest {
         this.code = code;
         this.codeVerifier = codeVerifier;
         this.scopes = scopes;
+        this.issuer = issuer;
     }
 
     /**
@@ -146,6 +158,7 @@ public final class TokenRequest {
         private String builderCode;
         private String builderCodeVerifier;
         private URI builderRedirectUri;
+        private URI builderIssuer;
         private List<String> builderScopes = new ArrayList<>();
 
         /**
@@ -178,6 +191,17 @@ public final class TokenRequest {
          */
         public Builder scopes(final String... scopes) {
             Collections.addAll(builderScopes, scopes);
+            return this;
+        }
+
+        /**
+         * Set the issuer URI.
+         *
+         * @param issuer the issuer value
+         * @return this builder
+         */
+        public Builder issuer(final URI issuer) {
+            builderIssuer = issuer;
             return this;
         }
 
@@ -240,7 +264,7 @@ public final class TokenRequest {
             }
 
             return new TokenRequest(clientId, builderClientSecret, builderRedirectUri, grant, builderAuthMethod,
-                    builderCode, builderCodeVerifier, builderScopes);
+                    builderCode, builderCodeVerifier, builderIssuer, builderScopes);
         }
     }
 }

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
@@ -80,14 +80,14 @@ class OpenIdMockHttpService {
                                         "/oauth/oauth20/token",
                                         wireMockServer.baseUrl() + "/oauth/oauth20/token"))));
 
-        wireMockServer.stubFor(post(urlPathMatching("/oauth/oauth20/token"))
+        wireMockServer.stubFor(post(urlPathMatching("/token"))
                     .withHeader("Content-Type", containing("application/x-www-form-urlencoded"))
                     .withRequestBody(containing("myCodeverifier"))
                     .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
                         .withBody(getTokenResponseJSON())));
-        wireMockServer.stubFor(post(urlPathMatching("/oauth/oauth20/token"))
+        wireMockServer.stubFor(post(urlPathMatching("/token"))
                 .withHeader("Content-Type", containing("application/x-www-form-urlencoded"))
                     .atPriority(1)
                     .withRequestBody(containing("code=none"))
@@ -96,7 +96,7 @@ class OpenIdMockHttpService {
                         .withHeader("Content-Type", "application/json")
                         .withBodyFile("token-error.json")));
 
-        wireMockServer.stubFor(post(urlPathMatching("/oauth/oauth20/token"))
+        wireMockServer.stubFor(post(urlPathMatching("/token"))
                 .withHeader("Content-Type", containing("application/x-www-form-urlencoded"))
                     .atPriority(2)
                     .withRequestBody(containing("grant_type=client_credentials"))
@@ -108,7 +108,8 @@ class OpenIdMockHttpService {
 
     private String getMetadataJSON() {
         try (final InputStream res = OpenIdMockHttpService.class.getResourceAsStream("/metadata.json")) {
-            return new String(IOUtils.toByteArray(res), UTF_8);
+            return new String(IOUtils.toByteArray(res), UTF_8)
+                .replace("http://example.test", wireMockServer.baseUrl());
         } catch (final IOException ex) {
             throw new UncheckedIOException("Could not read class resource", ex);
         }
@@ -129,9 +130,6 @@ class OpenIdMockHttpService {
             "\"expires_in\": 300" +
             "}";
     }
-
-
-
 
     public String start() {
         wireMockServer.start();

--- a/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
+++ b/openid/src/test/java/com/inrupt/client/openid/OpenIdMockHttpService.java
@@ -75,10 +75,7 @@ class OpenIdMockHttpService {
                     .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "application/json")
-                        .withBody(getMetadataJSON()
-                                    .replace(
-                                        "/oauth/oauth20/token",
-                                        wireMockServer.baseUrl() + "/oauth/oauth20/token"))));
+                        .withBody(getMetadataJSON())));
 
         wireMockServer.stubFor(post(urlPathMatching("/token"))
                     .withHeader("Content-Type", containing("application/x-www-form-urlencoded"))

--- a/openid/src/test/resources/metadata.json
+++ b/openid/src/test/resources/metadata.json
@@ -1,34 +1,20 @@
 {
     "issuer":"http://example.test",
-    "token_endpoint":"/oauth/oauth20/token",
+    "token_endpoint":"http://example.test/token",
     "end_session_endpoint":"http://example.test/endSession",
-    "userinfo_endpoint":"http://example.test/oauth/userinfo",
-    "jwks_uri":"http://example.test/oauth/jwks",
+    "userinfo_endpoint":"http://example.test/userinfo",
+    "jwks_uri":"http://example.test/jwks",
     "authorization_endpoint":"http://example.test/auth",
     "scopes_supported":[
-        "READ",
-        "WRITE",
-        "DELETE",
         "openid",
-        "scope",
         "profile",
-        "email",
-        "address",
-        "phone"
+        "email"
     ],
     "response_types_supported":[
-        "code",
-        "code id_token",
-        "code token",
-        "code id_token token",
-        "token",
-        "id_token",
-        "id_token token"
+        "code"
     ],
     "grant_types_supported":[
         "authorization_code",
-        "implicit",
-        "password",
         "client_credentials",
         "urn:ietf:params:oauth:grant-type:jwt-bearer"
     ],
@@ -36,30 +22,8 @@
         "public"
     ],
     "id_token_signing_alg_values_supported":[
-        "HS256",
-        "HS384",
-        "HS512",
         "RS256",
-        "RS384",
-        "RS512",
-        "ES256",
-        "ES384",
-        "ES512",
-        "PS256",
-        "PS384",
-        "PS512"
-    ],
-    "id_token_encryption_alg_values_supported":[
-        "RSA1_5",
-        "RSA-OAEP",
-        "RSA-OAEP-256",
-        "A128KW",
-        "A192KW",
-        "A256KW",
-        "A128GCMKW",
-        "A192GCMKW",
-        "A256GCMKW",
-        "dir"
+        "ES256"
     ],
     "token_endpoint_auth_methods_supported":[
         "client_secret_post",

--- a/openid/src/test/resources/metadata.json
+++ b/openid/src/test/resources/metadata.json
@@ -69,5 +69,6 @@
     ],
     "dpop_signing_alg_values_supported":[
         "RS256", "ES256"
-    ]
+    ],
+    "authorization_response_iss_parameter_supported": true
 }


### PR DESCRIPTION
This improves support for RFC 9270 for anyone building an authorization code flow client with the JCL API.