### PR TITLE
Support protected resources with RDF body handlers

### DIFF
--- a/core/src/main/java/com/inrupt/client/core/DefaultClient.java
+++ b/core/src/main/java/com/inrupt/client/core/DefaultClient.java
@@ -105,7 +105,6 @@ public final class DefaultClient implements Client {
                 }));
     }
 
-
     Request upgradeRequest(final Request request, final Credential token) {
         final Request.Builder builder = Request.newBuilder()
             .uri(request.uri())

--- a/core/src/main/java/com/inrupt/client/core/NoBodyResponse.java
+++ b/core/src/main/java/com/inrupt/client/core/NoBodyResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.inrupt.client.core;
+
+import com.inrupt.client.Headers;
+import com.inrupt.client.Response;
+
+import java.net.URI;
+
+class NoBodyResponse<T> implements Response<T> {
+
+    private final Headers responseHeaders;
+    private final int responseStatusCode;
+    private final URI responseUri;
+
+    public NoBodyResponse(final URI uri, final int statusCode, final Headers headers) {
+        this.responseHeaders = headers;
+        this.responseStatusCode = statusCode;
+        this.responseUri = uri;
+    }
+
+    @Override
+    public Headers headers() {
+        return responseHeaders;
+    }
+
+    @Override
+    public URI uri() {
+        return responseUri;
+    }
+
+    @Override
+    public int statusCode() {
+        return responseStatusCode;
+    }
+
+    @Override
+    public T body() {
+        return (T) null;
+    }
+}

--- a/core/src/test/java/com/inrupt/client/core/DefaultClientRdfJenaTest.java
+++ b/core/src/test/java/com/inrupt/client/core/DefaultClientRdfJenaTest.java
@@ -85,7 +85,7 @@ class DefaultClientRdfJenaTest {
                 .GET()
                 .build();
 
-        final Response<Model> response = client.send(request, JenaBodyHandlers.ofModel())
+        final Response<Model> response = client.send(request, JenaBodyHandlers.ofJenaModel())
             .toCompletableFuture().join();
         assertEquals(200, response.statusCode());
 

--- a/core/src/test/java/com/inrupt/client/core/DefaultClientRdfRDF4JTest.java
+++ b/core/src/test/java/com/inrupt/client/core/DefaultClientRdfRDF4JTest.java
@@ -86,7 +86,7 @@ class DefaultClientRdfRDF4JTest {
                 .GET()
                 .build();
 
-        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofModel())
+        final Response<Model> response = client.send(request, RDF4JBodyHandlers.ofRDF4JModel())
             .toCompletableFuture().join();
         assertEquals(200, response.statusCode());
 


### PR DESCRIPTION
With the current code, it is not possible to use the `ofJenaModel` (and similar) method on protected resources, because the code will throw an exception at the first 401, interfering with the reactive style of the JCL