### PR TITLE
Include missing wiremock stubs

### DIFF
--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
@@ -67,6 +67,11 @@ class MockUMAAuthorizationServer {
                         .withBody(
                                 "{\"access_token\":\"token-67890\",\"token_type\":\"Bearer\",\"expires_in\":\"3600\"}"
                         )));
+        wireMockServer.stubFor(post(urlPathMatching("/" + Utils.UMA_TOKEN_ENDPOINT))
+                .withRequestBody(WireMock.notContaining("claim_token"))
+                .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
+                .willReturn(aResponse()
+                        .withStatus(403)));
     }
 
     public void start() {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockWebIdService.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockWebIdService.java
@@ -62,6 +62,11 @@ class MockWebIdService {
                                 wireMockServer.baseUrl() + "/" + this.username,
                                 storageUrl,
                                 issuerUrl))));
+
+        wireMockServer.stubFor(get(urlPathMatching("/([a-z]+)/([a-f0-9-]+)"))
+                .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
+                .willReturn(aResponse()
+                        .withStatus(404)));
     }
 
     public void start() {


### PR DESCRIPTION
The integration tests make use of some currently missing wiremock stubs. This PR adds those stubs