### PR TITLE
Clean up BOM definitions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -126,11 +126,6 @@
 
       <!-- transitive dependencies -->
       <dependency>
-        <groupId>com.squareup.okhttp3</groupId>
-        <artifactId>okhttp</artifactId>
-        <version>${okhttp.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.antlr</groupId>
         <artifactId>antlr4-runtime</artifactId>
         <version>${antlr.version}</version>


### PR DESCRIPTION
The BOM previously included okhttp (since Quarkus' BOM included a much older version of that), but that is generally not needed any longer, and it is better to avoid listing too many transitive dependencies, since BOMs are often layered