### PR TITLE
Bump Spring security version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.version>3.10.0</quarkus.version>
     <slf4j.version>2.0.13</slf4j.version>
     <!-- pinning to Spring 5.x for Java 11 support -->
-    <spring.security.version>5.8.8</spring.security.version>
+    <spring.security.version>5.8.12</spring.security.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
     <inrupt.rdf.wrapping.version>1.1.1</inrupt.rdf.wrapping.version>
 


### PR DESCRIPTION
This updates the Java 11-compatible version of Spring, which dependabot (apparently) does not update.