### PR TITLE
Fix site build failures

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,6 +31,13 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
The CD task that builds the javadoc site fails because the Spring boot examples use newer Java 17 constructs (SpringBoot 3 requires Java 17). Since the example code doesn't need to be included in the generated site, this PR just excludes everything in the `/examples` directory