### PR TITLE
Bump spring security version for Java 11 testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <quarkus.version>3.11.3</quarkus.version>
     <slf4j.version>2.0.13</slf4j.version>
     <!-- pinning to Spring 5.x for Java 11 support -->
-    <spring.security.version>5.8.12</spring.security.version>
+    <spring.security.version>5.8.13</spring.security.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
     <inrupt.rdf.wrapping.version>1.1.1</inrupt.rdf.wrapping.version>
 


### PR DESCRIPTION
For Java 11 test runs, Spring security is pinned to the latest 5.x version, but that isn't managed by dependabot, so it needs to be manually updated.