### PR TITLE
JCL-476: Adjust ProblemDetails API

### DIFF
--- a/access-grant/pom.xml
+++ b/access-grant/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/api/src/main/java/com/inrupt/client/ProblemDetails.java
+++ b/api/src/main/java/com/inrupt/client/ProblemDetails.java
@@ -52,10 +52,10 @@ public interface ProblemDetails {
     String getTitle();
 
     /**
-     * The problem details.
-     * @return the details
+     * The problem detail.
+     * @return the detail
      */
-    String getDetails();
+    String getDetail();
 
     /**
      * The problem status code.

--- a/api/src/main/java/com/inrupt/client/ProblemDetails.java
+++ b/api/src/main/java/com/inrupt/client/ProblemDetails.java
@@ -37,7 +37,7 @@ public interface ProblemDetails {
     /**
      * The <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a> default problem type.
      */
-    String DEFAULT_TYPE = "about:blank";
+    URI DEFAULT_TYPE = URI.create("about:blank");
 
     /**
      * The problem type.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencyManagement>

--- a/examples/cli/pom.xml
+++ b/examples/cli/pom.xml
@@ -16,8 +16,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
 
     <quarkus.version>3.12.0</quarkus.version>
   </properties>

--- a/examples/spring-web/pom.xml
+++ b/examples/spring-web/pom.xml
@@ -16,8 +16,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
     <springboot.version>3.3.1</springboot.version>
   </properties>
 

--- a/examples/springboot/pom.xml
+++ b/examples/springboot/pom.xml
@@ -16,8 +16,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
     <springboot.version>3.3.1</springboot.version>
   </properties>
 

--- a/examples/webapp/pom.xml
+++ b/examples/webapp/pom.xml
@@ -16,8 +16,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>17</maven.compiler.target>
-    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.release>17</maven.compiler.release>
 
     <quarkus.version>3.12.0</quarkus.version>
   </properties>

--- a/okhttp/pom.xml
+++ b/okhttp/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/openid/pom.xml
+++ b/openid/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/parser/pom.xml
+++ b/parser/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
 
   <properties>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>11</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 

--- a/quarkus/pom.xml
+++ b/quarkus/pom.xml
@@ -13,11 +13,6 @@
       Integration utilities for Quarkus support.
   </description>
 
-  <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/rdf-legacy/pom.xml
+++ b/rdf-legacy/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
 
     <!-- version management -->
     <commons.text.version>1.12.0</commons.text.version>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
     <rdf4j.version>5.0.0</rdf4j.version>
   </properties>
 

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>inrupt-client-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
 
     <!-- test dependencies -->
     <dependency>
@@ -82,12 +87,6 @@
       <groupId>com.inrupt.client</groupId>
       <artifactId>inrupt-client-jackson</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/solid/pom.xml
+++ b/solid/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>

--- a/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidClientException.java
@@ -97,7 +97,7 @@ public class SolidClientException extends InruptClientException {
      * @return the problem details object
      */
     public ProblemDetails getProblemDetails() {
-        return SolidProblemDetails.fromErrorResponse(statusCode, headers, body.getBytes());
+        return SolidProblemDetails.fromErrorResponse(uri, statusCode, headers, body.getBytes());
     }
 
     /**

--- a/solid/src/main/java/com/inrupt/client/solid/SolidProblemDetails.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidProblemDetails.java
@@ -154,9 +154,10 @@ public class SolidProblemDetails implements ProblemDetails {
                 final URI type = Optional.ofNullable(pdData.type)
                     .map(uri::resolve)
                     .orElse(ProblemDetails.DEFAULT_TYPE);
+                final URI instance = pdData.instance != null ? uri.resolve(pdData.instance) : null;
                 // JSON mappers map invalid integers to 0, which is an invalid value in our case anyway.
                 final int status = Optional.of(pdData.status).filter(s -> s != 0).orElse(statusCode);
-                return new SolidProblemDetails(type, pdData.title, pdData.detail, status, pdData.instance);
+                return new SolidProblemDetails(type, pdData.title, pdData.detail, status, instance);
             } catch (IOException e) {
                 LOGGER.debug("Unable to parse ProblemDetails response from server", e);
             }

--- a/solid/src/main/java/com/inrupt/client/solid/SolidProblemDetails.java
+++ b/solid/src/main/java/com/inrupt/client/solid/SolidProblemDetails.java
@@ -36,7 +36,7 @@ public class SolidProblemDetails implements ProblemDetails {
 
     private final URI type;
     private final String title;
-    private final String details;
+    private final String detail;
     private final int status;
     private final URI instance;
     private static JsonService jsonService;
@@ -47,20 +47,20 @@ public class SolidProblemDetails implements ProblemDetails {
      * <a href="https://www.rfc-editor.org/rfc/rfc9457">RFC9457</a>.
      * @param type the problem type
      * @param title the problem title
-     * @param details the problem details
+     * @param detail the problem details
      * @param status the error response status code
      * @param instance the problem instance
      */
     public SolidProblemDetails(
         final URI type,
         final String title,
-        final String details,
+        final String detail,
         final int status,
         final URI instance
     ) {
         this.type = type;
         this.title = title;
-        this.details = details;
+        this.detail = detail;
         this.status = status;
         this.instance = instance;
     }
@@ -76,8 +76,8 @@ public class SolidProblemDetails implements ProblemDetails {
     }
 
     @Override
-    public String getDetails() {
-        return this.details;
+    public String getDetail() {
+        return this.detail;
     }
 
     @Override
@@ -103,9 +103,9 @@ public class SolidProblemDetails implements ProblemDetails {
          */
         public String title;
         /**
-         * The problem details.
+         * The problem detail.
          */
-        public String details;
+        public String detail;
         /**
          * The problem status code.
          */
@@ -133,12 +133,14 @@ public class SolidProblemDetails implements ProblemDetails {
 
     /**
      * Builds a {@link ProblemDetails} instance from an HTTP error response.
+     * @param uri the original URI
      * @param statusCode the HTTP error response status code
      * @param headers the HTTP error response headers
      * @param body the HTTP error response body
      * @return a {@link ProblemDetails} instance
      */
-    public static SolidProblemDetails fromErrorResponse(
+    static SolidProblemDetails fromErrorResponse(
+            final URI uri,
             final int statusCode,
             final Headers headers,
             final byte[] body
@@ -160,13 +162,14 @@ public class SolidProblemDetails implements ProblemDetails {
                     Data.class
             );
             final URI type = Optional.ofNullable(pdData.type)
+                .map(uri::resolve)
                 .orElse(URI.create(ProblemDetails.DEFAULT_TYPE));
             // JSON mappers map invalid integers to 0, which is an invalid value in our case anyway.
             final int status = Optional.of(pdData.status).filter(s -> s != 0).orElse(statusCode);
             return new SolidProblemDetails(
                     type,
                     pdData.title,
-                    pdData.details,
+                    pdData.detail,
                     status,
                     pdData.instance
             );

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -412,7 +412,7 @@ class SolidClientTest {
         assertEquals(statusCode, exception.getStatusCode());
         // The following assertions check that in absence of an RFC9457 compliant response, we properly initialize the
         // default values for the attached Problem Details.
-        assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType().toString());
+        assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType());
         assertEquals(statusCode, exception.getProblemDetails().getStatus());
         assertNull(exception.getProblemDetails().getTitle());
         assertNull(exception.getProblemDetails().getDetail());
@@ -606,7 +606,7 @@ class SolidClientTest {
         );
         assertEquals(statusCode, exception.getStatusCode());
         // On malformed response, the ProblemDetails should fall back to defaults.
-        assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType().toString());
+        assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType());
         assertNull(exception.getProblemDetails().getTitle());
         assertEquals(statusCode, exception.getProblemDetails().getStatus());
         assertNull(exception.getProblemDetails().getDetail());
@@ -653,7 +653,7 @@ class SolidClientTest {
         );
         assertEquals(statusCode, exception.getStatusCode());
         // On malformed response, the ProblemDetails should fall back to defaults.
-        assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType().toString());
+        assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType());
         assertNull(exception.getProblemDetails().getTitle());
         assertEquals(statusCode, exception.getProblemDetails().getStatus());
         assertNull(exception.getProblemDetails().getDetail());

--- a/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidClientTest.java
@@ -415,7 +415,7 @@ class SolidClientTest {
         assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType().toString());
         assertEquals(statusCode, exception.getProblemDetails().getStatus());
         assertNull(exception.getProblemDetails().getTitle());
-        assertNull(exception.getProblemDetails().getDetails());
+        assertNull(exception.getProblemDetails().getDetail());
         assertNull(exception.getProblemDetails().getInstance());
     }
 
@@ -487,7 +487,7 @@ class SolidClientTest {
         assertEquals(problemDetails.getType(), exception.getProblemDetails().getType());
         assertEquals(problemDetails.getTitle(), exception.getProblemDetails().getTitle());
         assertEquals(problemDetails.getStatus(), exception.getProblemDetails().getStatus());
-        assertEquals(problemDetails.getDetails(), exception.getProblemDetails().getDetails());
+        assertEquals(problemDetails.getDetail(), exception.getProblemDetails().getDetail());
         assertEquals(problemDetails.getInstance(), exception.getProblemDetails().getInstance());
     }
 
@@ -609,7 +609,7 @@ class SolidClientTest {
         assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType().toString());
         assertNull(exception.getProblemDetails().getTitle());
         assertEquals(statusCode, exception.getProblemDetails().getStatus());
-        assertNull(exception.getProblemDetails().getDetails());
+        assertNull(exception.getProblemDetails().getDetail());
         assertNull(exception.getProblemDetails().getInstance());
     }
 
@@ -656,7 +656,7 @@ class SolidClientTest {
         assertEquals(ProblemDetails.DEFAULT_TYPE, exception.getProblemDetails().getType().toString());
         assertNull(exception.getProblemDetails().getTitle());
         assertEquals(statusCode, exception.getProblemDetails().getStatus());
-        assertNull(exception.getProblemDetails().getDetails());
+        assertNull(exception.getProblemDetails().getDetail());
         assertNull(exception.getProblemDetails().getInstance());
     }
 }

--- a/solid/src/test/java/com/inrupt/client/solid/SolidProblemDetailsTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidProblemDetailsTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -67,6 +68,7 @@ class SolidProblemDetailsTest {
     @Test
     void testRelativeUriProblemDetails() {
         final int statusCode = 400;
+        final UUID instance = UUID.randomUUID();
         final ProblemDetails pd = SolidProblemDetails.fromErrorResponse(
                 POD,
                 statusCode,
@@ -75,7 +77,7 @@ class SolidProblemDetailsTest {
                     "\"title\":\"Some title\"," +
                     "\"status\":400," +
                     "\"detail\":\"Some details\"," +
-                    "\"instance\":\"https://example.org/instance\"," +
+                    "\"instance\":\"Instance" + instance + "\"," +
                     "\"type\":\"SomeType\"" +
                 "}").getBytes()
         );
@@ -83,13 +85,13 @@ class SolidProblemDetailsTest {
         assertEquals(statusCode, pd.getStatus());
         Assertions.assertEquals("Some title", pd.getTitle());
         assertEquals("Some details", pd.getDetail());
-        assertEquals("https://example.org/instance", pd.getInstance().toString());
+        assertEquals("https://storage.test/pod/Instance" + instance, pd.getInstance().toString());
     }
-
 
     @Test
     void testCompleteProblemDetails() {
         final int statusCode = 400;
+        final UUID instance = UUID.randomUUID();
         final ProblemDetails pd = SolidProblemDetails.fromErrorResponse(
                 POD,
                 statusCode,
@@ -98,7 +100,7 @@ class SolidProblemDetailsTest {
                     "\"title\":\"Some title\"," +
                     "\"status\":400," +
                     "\"detail\":\"Some details\"," +
-                    "\"instance\":\"https://example.org/instance\"," +
+                    "\"instance\":\"urn:uuid:" + instance + "\"," +
                     "\"type\":\"https://example.org/type\"" +
                 "}").getBytes()
         );
@@ -106,7 +108,7 @@ class SolidProblemDetailsTest {
         assertEquals(statusCode, pd.getStatus());
         Assertions.assertEquals("Some title", pd.getTitle());
         assertEquals("Some details", pd.getDetail());
-        assertEquals("https://example.org/instance", pd.getInstance().toString());
+        assertEquals("urn:uuid:" + instance, pd.getInstance().toString());
     }
 
     @Test

--- a/solid/src/test/java/com/inrupt/client/solid/SolidProblemDetailsTest.java
+++ b/solid/src/test/java/com/inrupt/client/solid/SolidProblemDetailsTest.java
@@ -57,7 +57,7 @@ class SolidProblemDetailsTest {
                 mockProblemDetailsHeader(),
                 "{}".getBytes()
         );
-        assertEquals(ProblemDetails.DEFAULT_TYPE, pd.getType().toString());
+        assertEquals(ProblemDetails.DEFAULT_TYPE, pd.getType());
         assertEquals(statusCode, pd.getStatus());
         assertNull(pd.getTitle());
         assertNull(pd.getDetail());
@@ -170,7 +170,7 @@ class SolidProblemDetailsTest {
                     "\"type\":\"Some invalid type\"" +
                 "}").getBytes()
         );
-        assertEquals(ProblemDetails.DEFAULT_TYPE, pd.getType().toString());
+        assertEquals(ProblemDetails.DEFAULT_TYPE, pd.getType());
     }
 
     @Test
@@ -195,7 +195,7 @@ class SolidProblemDetailsTest {
                 mockProblemDetailsHeader(),
                 "Not valid application/problem+json".getBytes()
         );
-        assertEquals(ProblemDetails.DEFAULT_TYPE, pd.getType().toString());
+        assertEquals(ProblemDetails.DEFAULT_TYPE, pd.getType());
         assertEquals(statusCode, pd.getStatus());
         assertNull(pd.getTitle());
         assertNull(pd.getDetail());

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -13,11 +13,6 @@
       Integration utilities for Spring support.
   </description>
 
-  <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/uma/pom.xml
+++ b/uma/pom.xml
@@ -14,8 +14,7 @@
   </description>
 
   <properties>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.release>8</maven.compiler.release>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
There are three significant changes to the ProblemsDetails API in this PR:

* `ProblemDetails::getDetails` becomes `ProblemDetails::getDetail`. This aligns the implementation with the RFC
* The `ProblemDetails.DEFAULT_TYPE` value is now a `URI` (instead of a `String`)
* `SolidClientException::fromErrorResponse` has been refactored.
  * The autocloseable `InputStream` is now handled in a try-with-resources block to prevent resource leakage
  * The method accepts a response `URI` so that any relative `URI`s in the `ProblemDetails` body can be resolved correctly
  * The method is made package-private, since it is not used outside of the package and I don't see a reason to make it part of the public API
  * The logic has been reworked to remove duplication and simplify the flow considerably

In addition, the compiler arguments are changed from the old-style `maven.compiler.source` / `maven.compiler.target` to the new approach `maven.compiler.release`. This eliminates a troublesome compiler warning.