### PR TITLE
Turn off javadoc generation for non-deployed artifacts

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -139,6 +139,13 @@
           <verbose>false</verbose>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -200,6 +200,13 @@
           <verbose>false</verbose>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
For modules that are not deployed, there is no need to generate javadocs; they only fill the CI output with warnings.