### PR TITLE
JCL-476: problem details integration tests

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -39,6 +39,7 @@ jobs:
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_SECRET }}
           INRUPT_TEST_REQUEST_METADATA_FEATURE: false
           INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_PROD_HEADERS_THAT_PROPAGATE }}
+          INRUPT_TEST_ERROR_DESCRIPTION_FEATURE: false
 
       - name: Dev Integration tests
         if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 11 }}
@@ -54,6 +55,7 @@ jobs:
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_DEV_REQUESTER_CLIENT_SECRET }}
           INRUPT_TEST_REQUEST_METADATA_FEATURE: true
           INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_DEV_HEADERS_THAT_PROPAGATE }}
+          INRUPT_TEST_ERROR_DESCRIPTION_FEATURE: true
 
   performance:
     name: Performance Tests

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -253,6 +253,11 @@ public class AccessGrantScenarios {
         final var err = assertThrows(UnauthorizedException.class,
                 () -> requesterClient.read(sharedTextFileURI, SolidNonRDFSource.class));
         assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+        Utils.checkProblemDetails(err).ifPresent(problemDetails -> {
+            assertEquals("Unauthorized", problemDetails.getTitle());
+            assertNotNull(problemDetails.getDetail());
+            assertNotNull(problemDetails.getInstance());
+        });
 
         //authorized request test
         final Session accessSession = AccessGrantSession.ofAccessGrant(requesterSession, grant);
@@ -271,10 +276,13 @@ public class AccessGrantScenarios {
         // Once revoked, the Access Grant should no longer grant access to the resource. The previously issued access
         // token may still be valid, so cache is cleared for the test.
         accessSession.reset();
-        assertThrows(
-                UnauthorizedException.class,
-                () -> requesterAuthClient.read(sharedTextFileURI, SolidNonRDFSource.class)
-        );
+        final var err2 = assertThrows(UnauthorizedException.class,
+                () -> requesterAuthClient.read(sharedTextFileURI, SolidNonRDFSource.class));
+        Utils.checkProblemDetails(err2).ifPresent(problemDetails -> {
+            assertEquals("Unauthorized", problemDetails.getTitle());
+            assertNotNull(problemDetails.getDetail());
+            assertNotNull(problemDetails.getInstance());
+        });
     }
 
     @ParameterizedTest

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -93,6 +93,9 @@ public class AccessGrantScenarios {
         .getOptionalValue("inrupt.test.auth-method", String.class)
         .orElse("client_secret_basic");
 
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
+            config.getValue("inrupt.test.error-description.feature", Boolean.class);
+
     protected static String ACCESS_GRANT_PROVIDER;
     protected static final String GRANT_MODE_READ = "Read";
     private static final String GRANT_MODE_APPEND = "Append";
@@ -253,6 +256,7 @@ public class AccessGrantScenarios {
         final var err = assertThrows(UnauthorizedException.class,
                 () -> requesterClient.read(sharedTextFileURI, SolidNonRDFSource.class));
         assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+        assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
         Utils.checkProblemDetails(err).ifPresent(problemDetails -> {
             assertEquals("Unauthorized", problemDetails.getTitle());
             assertNotNull(problemDetails.getDetail());
@@ -278,6 +282,7 @@ public class AccessGrantScenarios {
         accessSession.reset();
         final var err2 = assertThrows(UnauthorizedException.class,
                 () -> requesterAuthClient.read(sharedTextFileURI, SolidNonRDFSource.class));
+        assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err2).isPresent());
         Utils.checkProblemDetails(err2).ifPresent(problemDetails -> {
             assertEquals("Unauthorized", problemDetails.getTitle());
             assertNotNull(problemDetails.getDetail());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -93,8 +93,9 @@ public class AccessGrantScenarios {
         .getOptionalValue("inrupt.test.auth-method", String.class)
         .orElse("client_secret_basic");
 
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
-            config.getValue("inrupt.test.error-description.feature", Boolean.class);
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
+        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
+        .orElse(false);
 
     protected static String ACCESS_GRANT_PROVIDER;
     protected static final String GRANT_MODE_READ = "Read";

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -322,6 +322,11 @@ public class ApplicationRequestMetadataScenarios {
             final var exception = assertThrows(BadRequestException.class, ()-> client.create(testResource));
 
             matchHeaders(requestHeaders, exception.getHeaders());
+            Utils.checkProblemDetails(exception).ifPresent(problemDetails -> {
+                assertEquals("Bad Request", problemDetails.getTitle());
+                assertNotNull(problemDetails.getInstance());
+                assertNotNull(problemDetails.getDetail());
+            });
         }
     }
 
@@ -345,8 +350,12 @@ public class ApplicationRequestMetadataScenarios {
             final var exception = assertThrows(UnauthorizedException.class, ()-> client.create(testResource));
 
             matchHeaders(requestHeaders, exception.getHeaders());
+            Utils.checkProblemDetails(exception).ifPresent(problemDetails -> {
+                assertEquals("Unauthorized", problemDetails.getTitle());
+                assertNotNull(problemDetails.getInstance());
+                assertNotNull(problemDetails.getDetail());
+            });
         }
-
     }
 
     @SuppressWarnings("unchecked")

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -84,8 +84,9 @@ public class ApplicationRequestMetadataScenarios {
             .orElse("client_secret_basic");
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
-            config.getValue("inrupt.test.error-description.feature", Boolean.class);
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
+        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
+        .orElse(false);
 
 
     private static final String FOLDER_SEPARATOR = "/";

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -84,6 +84,9 @@ public class ApplicationRequestMetadataScenarios {
             .orElse("client_secret_basic");
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
+            config.getValue("inrupt.test.error-description.feature", Boolean.class);
+
 
     private static final String FOLDER_SEPARATOR = "/";
 
@@ -322,6 +325,7 @@ public class ApplicationRequestMetadataScenarios {
             final var exception = assertThrows(BadRequestException.class, ()-> client.create(testResource));
 
             matchHeaders(requestHeaders, exception.getHeaders());
+            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(exception).isPresent());
             Utils.checkProblemDetails(exception).ifPresent(problemDetails -> {
                 assertEquals("Bad Request", problemDetails.getTitle());
                 assertNotNull(problemDetails.getInstance());
@@ -350,6 +354,7 @@ public class ApplicationRequestMetadataScenarios {
             final var exception = assertThrows(UnauthorizedException.class, ()-> client.create(testResource));
 
             matchHeaders(requestHeaders, exception.getHeaders());
+            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(exception).isPresent());
             Utils.checkProblemDetails(exception).ifPresent(problemDetails -> {
                 assertEquals("Unauthorized", problemDetails.getTitle());
                 assertNotNull(problemDetails.getInstance());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -76,8 +76,9 @@ public class AuthenticationScenarios {
             .getOptionalValue("inrupt.test.auth-method", String.class)
             .orElse("client_secret_basic");
 
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
-            config.getValue("inrupt.test.error-description.feature", Boolean.class);
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
+        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
+        .orElse(false);
     private static SolidSyncClient localAuthClient;
 
     @BeforeAll

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -190,6 +190,7 @@ public class AuthenticationScenarios {
             final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURI, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+            Utils.checkProblemDetails(err);
 
             assertDoesNotThrow(() -> authClient.delete(testResource));
         }
@@ -245,6 +246,7 @@ public class AuthenticationScenarios {
             final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURI, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+            Utils.checkProblemDetails(err);
 
             final SolidSyncClient authClient2 = client.session(session);
             assertDoesNotThrow(() -> authClient2.read(privateResourceURI, SolidRDFSource.class));
@@ -281,6 +283,7 @@ public class AuthenticationScenarios {
                 final var err = assertThrows(UnauthorizedException.class,
                         () -> client.read(privateResourceURI, SolidRDFSource.class));
                 assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+                Utils.checkProblemDetails(err);
 
                 //delete both resources with whichever client
                 assertDoesNotThrow(() -> authClient1.delete(testResource2));

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -75,6 +75,9 @@ public class AuthenticationScenarios {
     private static final String AUTH_METHOD = config
             .getOptionalValue("inrupt.test.auth-method", String.class)
             .orElse("client_secret_basic");
+
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
+            config.getValue("inrupt.test.error-description.feature", Boolean.class);
     private static SolidSyncClient localAuthClient;
 
     @BeforeAll
@@ -190,6 +193,7 @@ public class AuthenticationScenarios {
             final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURI, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
             Utils.checkProblemDetails(err);
 
             assertDoesNotThrow(() -> authClient.delete(testResource));
@@ -246,7 +250,9 @@ public class AuthenticationScenarios {
             final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURI, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
             Utils.checkProblemDetails(err);
+
 
             final SolidSyncClient authClient2 = client.session(session);
             assertDoesNotThrow(() -> authClient2.read(privateResourceURI, SolidRDFSource.class));
@@ -283,6 +289,7 @@ public class AuthenticationScenarios {
                 final var err = assertThrows(UnauthorizedException.class,
                         () -> client.read(privateResourceURI, SolidRDFSource.class));
                 assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
+                assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
                 Utils.checkProblemDetails(err);
 
                 //delete both resources with whichever client

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -76,8 +76,9 @@ public class DomainModulesResource {
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
     private static final String FOLDER_SEPARATOR = "/";
     private static URI publicContainerURI;
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
-            config.getValue("inrupt.test.error-description.feature", Boolean.class);
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
+        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
+        .orElse(false);
 
     private static SolidSyncClient localAuthClient;
 

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -275,6 +275,9 @@ public class DomainModulesResource {
         final var err = assertThrows(NotFoundException.class, () -> client.read(missingWebId, WebIdProfile.class));
         assertEquals(404, err.getStatusCode());
         assertEquals(missingWebId, err.getUri());
+
+        final var problemDetails = err.getProblemDetails();
+        assertEquals(err.getStatusCode(), problemDetails.getStatus());
     }
 
     @Test

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -22,9 +22,7 @@ package com.inrupt.client.integration.base;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.inrupt.client.Headers;
-import com.inrupt.client.Request;
-import com.inrupt.client.Response;
+import com.inrupt.client.*;
 import com.inrupt.client.auth.Session;
 import com.inrupt.client.openid.OpenIdSession;
 import com.inrupt.client.solid.*;
@@ -73,6 +71,7 @@ public class DomainModulesResource {
     private static final String AUTH_METHOD = config
             .getOptionalValue("inrupt.test.auth-method", String.class)
             .orElse("client_secret_basic");
+    private static final String CONTENT_TYPE = "Content-Type";
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
     private static final String FOLDER_SEPARATOR = "/";
@@ -276,8 +275,11 @@ public class DomainModulesResource {
         assertEquals(404, err.getStatusCode());
         assertEquals(missingWebId, err.getUri());
 
-        final var problemDetails = err.getProblemDetails();
-        assertEquals(err.getStatusCode(), problemDetails.getStatus());
+        Utils.checkProblemDetails(err).ifPresent(problemDetails -> {
+            assertEquals("Not Found", problemDetails.getTitle());
+            assertNotNull(problemDetails.getInstance());
+            assertNotNull(problemDetails.getDetail());
+        });
     }
 
     @Test

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -76,6 +76,8 @@ public class DomainModulesResource {
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
     private static final String FOLDER_SEPARATOR = "/";
     private static URI publicContainerURI;
+    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE =
+            config.getValue("inrupt.test.error-description.feature", Boolean.class);
 
     private static SolidSyncClient localAuthClient;
 
@@ -275,6 +277,7 @@ public class DomainModulesResource {
         assertEquals(404, err.getStatusCode());
         assertEquals(missingWebId, err.getUri());
 
+        assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
         Utils.checkProblemDetails(err).ifPresent(problemDetails -> {
             assertEquals("Not Found", problemDetails.getTitle());
             assertNotNull(problemDetails.getInstance());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/MockUMAAuthorizationServer.java
@@ -26,6 +26,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.inrupt.client.ProblemDetails;
 import com.inrupt.client.Request;
 
 import java.io.IOException;
@@ -71,7 +72,12 @@ class MockUMAAuthorizationServer {
                 .withRequestBody(WireMock.notContaining("claim_token"))
                 .withHeader(USER_AGENT_HEADER, equalTo(USER_AGENT))
                 .willReturn(aResponse()
-                        .withStatus(403)));
+                        .withStatus(403)
+                        .withHeader(Utils.CONTENT_TYPE, ProblemDetails.MIME_TYPE)
+                        .withBody("{" +
+                                "\"status\":403, \"title\": \"Forbidden\"," +
+                                "\"description\": \"The client does not have access to this resource.\"," +
+                                "\"instance\": \"urn:uuid:8dfa92c4-f56b-4f01-93a0-983484cfbb26\"}")));
     }
 
     public void start() {

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/Utils.java
@@ -22,9 +22,10 @@ package com.inrupt.client.integration.base;
 
 import static com.inrupt.client.vocabulary.RDF.type;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.inrupt.client.Headers;
+import com.inrupt.client.ProblemDetails;
 import com.inrupt.client.Request;
 import com.inrupt.client.Response;
 import com.inrupt.client.solid.*;
@@ -116,6 +117,18 @@ public final class Utils {
                 RDFDataMgr.write(output, model, Lang.TURTLE);
                 return output.toByteArray();
             }
+        }
+    }
+
+    public static Optional<ProblemDetails> checkProblemDetails(final SolidClientException err) {
+        final ProblemDetails problemDetails = err.getProblemDetails();
+        assertEquals(err.getStatusCode(), problemDetails.getStatus());
+        if (err.getHeaders().firstValue(CONTENT_TYPE).equals(Optional.of(ProblemDetails.MIME_TYPE))) {
+            assertNotNull(problemDetails.getType(), "Type field should not be null!");
+            return Optional.of(problemDetails);
+        } else {
+            assertEquals(ProblemDetails.DEFAULT_TYPE, problemDetails.getType());
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
This adds the ProblemDetails checks to the integration testing framework.

The challenge is that, when testing against a live ESS server, there are some versions that already support ProblemDetails responses and others that don't. So this code needs to be able to check based on the capability of the server.