### PR TITLE
Revert feature detection configuration

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -39,7 +39,6 @@ jobs:
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_PROD_REQUESTER_CLIENT_SECRET }}
           INRUPT_TEST_REQUEST_METADATA_FEATURE: false
           INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_PROD_HEADERS_THAT_PROPAGATE }}
-          INRUPT_TEST_ERROR_DESCRIPTION_FEATURE: false
 
       - name: Dev Integration tests
         if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 11 }}
@@ -55,7 +54,6 @@ jobs:
           INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_DEV_REQUESTER_CLIENT_SECRET }}
           INRUPT_TEST_REQUEST_METADATA_FEATURE: true
           INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_DEV_HEADERS_THAT_PROPAGATE }}
-          INRUPT_TEST_ERROR_DESCRIPTION_FEATURE: true
 
   performance:
     name: Performance Tests

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AccessGrantScenarios.java
@@ -93,10 +93,6 @@ public class AccessGrantScenarios {
         .getOptionalValue("inrupt.test.auth-method", String.class)
         .orElse("client_secret_basic");
 
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
-        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
-        .orElse(true);
-
     protected static String ACCESS_GRANT_PROVIDER;
     protected static final String GRANT_MODE_READ = "Read";
     private static final String GRANT_MODE_APPEND = "Append";
@@ -257,7 +253,6 @@ public class AccessGrantScenarios {
         final var err = assertThrows(UnauthorizedException.class,
                 () -> requesterClient.read(sharedTextFileURI, SolidNonRDFSource.class));
         assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
-        assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
         Utils.checkProblemDetails(err).ifPresent(problemDetails -> {
             assertEquals("Unauthorized", problemDetails.getTitle());
             assertNotNull(problemDetails.getDetail());
@@ -283,7 +278,6 @@ public class AccessGrantScenarios {
         accessSession.reset();
         final var err2 = assertThrows(UnauthorizedException.class,
                 () -> requesterAuthClient.read(sharedTextFileURI, SolidNonRDFSource.class));
-        assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err2).isPresent());
         Utils.checkProblemDetails(err2).ifPresent(problemDetails -> {
             assertEquals("Unauthorized", problemDetails.getTitle());
             assertNotNull(problemDetails.getDetail());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/ApplicationRequestMetadataScenarios.java
@@ -84,9 +84,6 @@ public class ApplicationRequestMetadataScenarios {
             .orElse("client_secret_basic");
     private static final String CLIENT_ID = config.getValue("inrupt.test.client-id", String.class);
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
-        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
-        .orElse(true);
 
 
     private static final String FOLDER_SEPARATOR = "/";
@@ -326,7 +323,6 @@ public class ApplicationRequestMetadataScenarios {
             final var exception = assertThrows(BadRequestException.class, ()-> client.create(testResource));
 
             matchHeaders(requestHeaders, exception.getHeaders());
-            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(exception).isPresent());
             Utils.checkProblemDetails(exception).ifPresent(problemDetails -> {
                 assertEquals("Bad Request", problemDetails.getTitle());
                 assertNotNull(problemDetails.getInstance());
@@ -355,7 +351,6 @@ public class ApplicationRequestMetadataScenarios {
             final var exception = assertThrows(UnauthorizedException.class, ()-> client.create(testResource));
 
             matchHeaders(requestHeaders, exception.getHeaders());
-            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(exception).isPresent());
             Utils.checkProblemDetails(exception).ifPresent(problemDetails -> {
                 assertEquals("Unauthorized", problemDetails.getTitle());
                 assertNotNull(problemDetails.getInstance());

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/AuthenticationScenarios.java
@@ -76,9 +76,6 @@ public class AuthenticationScenarios {
             .getOptionalValue("inrupt.test.auth-method", String.class)
             .orElse("client_secret_basic");
 
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
-        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
-        .orElse(true);
     private static SolidSyncClient localAuthClient;
 
     @BeforeAll
@@ -194,7 +191,6 @@ public class AuthenticationScenarios {
             final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURI, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
-            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
             Utils.checkProblemDetails(err);
 
             assertDoesNotThrow(() -> authClient.delete(testResource));
@@ -251,9 +247,7 @@ public class AuthenticationScenarios {
             final var err = assertThrows(UnauthorizedException.class,
                     () -> client.read(privateResourceURI, SolidRDFSource.class));
             assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
-            assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
             Utils.checkProblemDetails(err);
-
 
             final SolidSyncClient authClient2 = client.session(session);
             assertDoesNotThrow(() -> authClient2.read(privateResourceURI, SolidRDFSource.class));
@@ -290,7 +284,6 @@ public class AuthenticationScenarios {
                 final var err = assertThrows(UnauthorizedException.class,
                         () -> client.read(privateResourceURI, SolidRDFSource.class));
                 assertEquals(Utils.UNAUTHORIZED, err.getStatusCode());
-                assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
                 Utils.checkProblemDetails(err);
 
                 //delete both resources with whichever client

--- a/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
+++ b/integration/base/src/main/java/com/inrupt/client/integration/base/DomainModulesResource.java
@@ -76,9 +76,6 @@ public class DomainModulesResource {
     private static final String CLIENT_SECRET = config.getValue("inrupt.test.client-secret", String.class);
     private static final String FOLDER_SEPARATOR = "/";
     private static URI publicContainerURI;
-    private static final Boolean INRUPT_TEST_ERROR_DESCRIPTION_FEATURE = config
-        .getOptionalValue("inrupt.test.error-description.feature", Boolean.class)
-        .orElse(true);
 
     private static SolidSyncClient localAuthClient;
 
@@ -278,7 +275,6 @@ public class DomainModulesResource {
         assertEquals(404, err.getStatusCode());
         assertEquals(missingWebId, err.getUri());
 
-        assertEquals(INRUPT_TEST_ERROR_DESCRIPTION_FEATURE, Utils.checkProblemDetails(err).isPresent());
         Utils.checkProblemDetails(err).ifPresent(problemDetails -> {
             assertEquals("Not Found", problemDetails.getTitle());
             assertNotNull(problemDetails.getInstance());


### PR DESCRIPTION
A configuration value was added to aid in feature detection for server-side `ProblemDetails` support in https://github.com/inrupt/solid-client-java/pull/1395/commits/103339f65ffd37774debdd9a08f22854baee2af3 (and subsequent commits in #1395) and then adjusted in https://github.com/inrupt/solid-client-java/pull/1396.

However, that has caused CD to fail ever since and prevents CI from succeeding.

This removes the configuration value entirely and relies solely on feature detection.