### PR TITLE
Update jackson dependencies in Jena module

### DIFF
--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -13,6 +13,18 @@
       Jena integration for the Inrupt Java Client Libraries.
   </description>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>com.inrupt.client</groupId>


### PR DESCRIPTION
The default jackson dependency brought in by Jena 4.x is somewhat old. This ensures that the jackson version aligns with the rest of the codebase