### PR TITLE
Consolidate dependabot management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,16 @@ updates:
     ignore:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
       - dependency-name: "org.springframework.security:spring-*"
+    groups:
+      plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "com.mycila:license-maven-plugin"
+          - "org.jacoco:jacoco-maven-plugin"
+          - "org.sonarsource.scanner.maven:sonar-maven-plugin"
+          - "org.sonatype.plugins:nexus-staging-maven-plugin"
+          - "org.owasp:dependency-check-maven"
+          - "com.puppycrawl.tools:checkstyle"
 
   - package-ecosystem: "maven"
     directory: "/rdf4j/"
@@ -43,6 +53,16 @@ updates:
     labels:
       - "backport"
       - "1.0"
+    groups:
+      plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "com.mycila:license-maven-plugin"
+          - "org.jacoco:jacoco-maven-plugin"
+          - "org.sonarsource.scanner.maven:sonar-maven-plugin"
+          - "org.sonatype.plugins:nexus-staging-maven-plugin"
+          - "org.owasp:dependency-check-maven"
+          - "com.puppycrawl.tools:checkstyle"
 
   - package-ecosystem: "maven"
     directory: "/rdf4j/"
@@ -85,6 +105,16 @@ updates:
     labels:
       - "backport"
       - "1.1"
+    groups:
+      plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "com.mycila:license-maven-plugin"
+          - "org.jacoco:jacoco-maven-plugin"
+          - "org.sonarsource.scanner.maven:sonar-maven-plugin"
+          - "org.sonatype.plugins:nexus-staging-maven-plugin"
+          - "org.owasp:dependency-check-maven"
+          - "com.puppycrawl.tools:checkstyle"
 
   - package-ecosystem: "maven"
     directory: "/rdf4j/"

--- a/pom.xml
+++ b/pom.xml
@@ -308,6 +308,7 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>${source.plugin.version}</version>
           <executions>
@@ -320,6 +321,7 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${compiler.plugin.version}</version>
           <configuration>
@@ -330,6 +332,7 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire.plugin.version}</version>
           <configuration>
@@ -340,6 +343,7 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <!-- keep the surefire and failsafe plugin versions aligned -->
           <version>${surefire.plugin.version}</version>


### PR DESCRIPTION
This adjusts the dependabot configuration to group all plugin updates. This should reduce the noise from dependabot updates across the various supported branches.