### PR TITLE
Update spring security version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <quarkus.version>3.14.2</quarkus.version>
     <slf4j.version>2.0.16</slf4j.version>
     <!-- pinning to Spring 5.x for Java 11 support -->
-    <spring.security.version>5.8.13</spring.security.version>
+    <spring.security.version>5.8.14</spring.security.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
     <inrupt.rdf.wrapping.version>1.1.1</inrupt.rdf.wrapping.version>
 


### PR DESCRIPTION
For Java 11 support, we use Spring Security 5.x. This updates the version of spring-security for Java 11 runtimes.