### PR TITLE
Align archetype plugin versions with project

### DIFF
--- a/archetypes/java/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/java/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -4,11 +4,14 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 https://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd">
     <requiredProperties>
-      <requiredProperty key="junit-version">
-        <defaultValue>${junit.version}</defaultValue>
+      <requiredProperty key="java-version">
+        <defaultValue>${maven.compiler.release}</defaultValue>
       </requiredProperty>
       <requiredProperty key="inrupt-client-version">
         <defaultValue>${project.version}</defaultValue>
+      </requiredProperty>
+      <requiredProperty key="junit-version">
+        <defaultValue>${junit.version}</defaultValue>
       </requiredProperty>
       <requiredProperty key="maven-clean-plugin">
         <defaultValue>${clean.plugin.version}</defaultValue>

--- a/archetypes/java/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/archetypes/java/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -10,6 +10,27 @@
       <requiredProperty key="inrupt-client-version">
         <defaultValue>${project.version}</defaultValue>
       </requiredProperty>
+      <requiredProperty key="maven-clean-plugin">
+        <defaultValue>${clean.plugin.version}</defaultValue>
+      </requiredProperty>
+      <requiredProperty key="maven-antrun-plugin">
+        <defaultValue>${antrun.plugin.version}</defaultValue>
+      </requiredProperty>
+      <requiredProperty key="maven-assembly-plugin">
+        <defaultValue>${assembly.plugin.version}</defaultValue>
+      </requiredProperty>
+      <requiredProperty key="maven-dependency-plugin">
+        <defaultValue>${dependency.plugin.version}</defaultValue>
+      </requiredProperty>
+      <requiredProperty key="maven-install-plugin">
+        <defaultValue>${install.plugin.version}</defaultValue>
+      </requiredProperty>
+      <requiredProperty key="maven-jar-plugin">
+        <defaultValue>${jar.plugin.version}</defaultValue>
+      </requiredProperty>
+      <requiredProperty key="maven-resources-plugin">
+        <defaultValue>${resources.plugin.version}</defaultValue>
+      </requiredProperty>
     </requiredProperties>
     <fileSets>
         <fileSet filtered="true" packaged="true">

--- a/archetypes/java/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/java/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Java version -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>${java-version}</maven.compiler.release>
   </properties>
 
   <dependencyManagement>

--- a/archetypes/java/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/java/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Java version -->
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencyManagement>

--- a/archetypes/java/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/java/src/main/resources/archetype-resources/pom.xml
@@ -13,9 +13,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Java version -->
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <java.version>11</java.version>
+    <maven.compiler.parameters>true</maven.compiler.parameters>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencyManagement>
@@ -102,41 +101,42 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>${maven-clean-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>${maven-antrun-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>${maven-assembly-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>${maven-dependency-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>${maven-install-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>${maven-jar-plugin}</version>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>${maven-compiler-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>${maven-resources-plugin}</version>
           <configuration>
             <propertiesEncoding>UTF-8</propertiesEncoding>
             <encoding>UTF-8</encoding>

--- a/archetypes/java/src/test/resources/projects/test/archetype.properties
+++ b/archetypes/java/src/test/resources/projects/test/archetype.properties
@@ -3,5 +3,14 @@ artifactId=inrupt-client-test
 version=1.0-SNAPSHOT
 package=com.inrupt.test
 
+java-version=${maven.compiler.release}
 inrupt-client-version=${project.version}
 junit-version=${junit.version}
+maven-antrun-plugin=${antrun.plugin.version}
+maven-assembly-plugin=${assembly.plugin.version}
+maven-clean-plugin=${clean.plugin.version}
+maven-compiler-plugin=${compiler.plugin.version}
+maven-dependency-plugin=${dependency.plugin.version}
+maven-install-plugin=${install.plugin.version}
+maven-jar-plugin=${jar.plugin.version}
+maven-resources-plugin=${resources.plugin.version}


### PR DESCRIPTION
The archetype plugin versions were getting out of sync with the rest of the project. Also, it was using Java 11, which is somewhat old and incompatible with most big frameworks.