### PR TITLE
Configure dependabot for 1.2 maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,57 +45,6 @@ updates:
     schedule:
       interval: "weekly"
 
-# 1.0 Maintenance
-  - package-ecosystem: "maven"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "1.0"
-    ignore:
-      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
-    labels:
-      - "backport"
-      - "1.0"
-    groups:
-      plugins:
-        patterns:
-          - "org.apache.maven.plugins:*"
-          - "com.mycila:license-maven-plugin"
-          - "org.jacoco:jacoco-maven-plugin"
-          - "org.sonarsource.scanner.maven:sonar-maven-plugin"
-          - "org.sonatype.plugins:nexus-staging-maven-plugin"
-          - "org.owasp:dependency-check-maven"
-          - "com.puppycrawl.tools:checkstyle"
-
-  - package-ecosystem: "maven"
-    directory: "/rdf4j/"
-    schedule:
-      interval: "weekly"
-    target-branch: "1.0"
-    allow:
-      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
-    labels:
-      - "backport"
-      - "1.0"
-
-  - package-ecosystem: "gradle"
-    directory: "/gradle/"
-    schedule:
-      interval: "weekly"
-    target-branch: "1.0"
-    labels:
-      - "backport"
-      - "1.0"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "1.0"
-    labels:
-      - "backport"
-      - "1.0"
-
 # 1.1 Maintenance
   - package-ecosystem: "maven"
     directory: "/"
@@ -105,6 +54,9 @@ updates:
     ignore:
       - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
       - dependency-name: "org.springframework.security:spring-*"
+      - dependency-name: "com.google.protobuf:protobuf-java"
+        update-types:
+          - "version-update:semver-major"
     labels:
       - "backport"
       - "1.1"
@@ -158,4 +110,70 @@ updates:
     labels:
       - "backport"
       - "1.1"
+
+# 1.2 Maintenance
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.2"
+    ignore:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+      - dependency-name: "org.springframework.security:spring-*"
+      - dependency-name: "com.google.protobuf:protobuf-java"
+        update-types:
+          - "version-update:semver-major"
+    labels:
+      - "backport"
+      - "1.2"
+    groups:
+      plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "com.mycila:license-maven-plugin"
+          - "org.jacoco:jacoco-maven-plugin"
+          - "org.sonarsource.scanner.maven:sonar-maven-plugin"
+          - "org.sonatype.plugins:nexus-staging-maven-plugin"
+          - "org.owasp:dependency-check-maven"
+          - "com.puppycrawl.tools:checkstyle"
+
+  - package-ecosystem: "maven"
+    directory: "/rdf4j/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.2"
+    allow:
+      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
+    labels:
+      - "backport"
+      - "1.2"
+
+  - package-ecosystem: "maven"
+    directory: "/spring/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.2"
+    allow:
+      - dependency-name: "org.springframework.security:spring-*"
+    labels:
+      - "backport"
+      - "1.2"
+
+  - package-ecosystem: "gradle"
+    directory: "/gradle/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.2"
+    labels:
+      - "backport"
+      - "1.2"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "1.2"
+    labels:
+      - "backport"
+      - "1.2"
 


### PR DESCRIPTION
This also removes dependabot updates on the 1.0 branch, as there are currently no plans to release new versions on that series.