### PR TITLE
Upgrade to Jena 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
           <artifactId>xmlunit-core</artifactId>
           <version>2.10.0</version>
         </dependency>
+        <!-- transitive dependency update for CVE-2024-7254 -->
+        <dependency>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+          <version>3.25.5</version>
+        </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <guava.version>33.3.0-jre</guava.version>
     <jackson.version>2.17.2</jackson.version>
     <jakarta.json.version>2.1.3</jakarta.json.version>
-    <jena.version>4.10.0</jena.version>
+    <jena.version>5.1.0</jena.version>
     <jose4j.version>0.9.6</jose4j.version>
     <json.bind.version>3.0.1</json.bind.version>
     <okhttp.version>4.12.0</okhttp.version>
@@ -159,12 +159,6 @@
           <groupId>org.xmlunit</groupId>
           <artifactId>xmlunit-core</artifactId>
           <version>2.10.0</version>
-        </dependency>
-        <!-- transitive dependency update for CVE-2024-7254 -->
-        <dependency>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-          <version>3.25.5</version>
         </dependency>
     </dependencies>
   </dependencyManagement>
@@ -776,6 +770,15 @@
   </reporting>
 
   <profiles>
+    <profile>
+      <id>java-11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <properties>
+        <jena.version>4.10.0</jena.version>
+      </properties>
+    </profile>
     <profile>
       <id>publish</id>
       <!-- skip tests for publish profile, since these tests have already run -->


### PR DESCRIPTION
This upgrades the default Jena version to 5.x.

For Java 11 runtimes, Jena 4.10.x will still be used.