### PR TITLE
Upgrade Open Vulnerability Project version

### DIFF
--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         repository: jeremylong/Open-Vulnerability-Project
         path: ovp
-        ref: v6.1.2
+        ref: v7.0.0
 
     - name: Set up JDK 17
       uses: actions/setup-java@v4


### PR DESCRIPTION
This should fix the failing `maven-dependency-check` plugin updates.