### PR TITLE
Update java 11 configuration to include smallrye config

### DIFF
--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -121,18 +121,6 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-      <profile>
-        <id>java-11</id>
-        <activation>
-          <jdk>11</jdk>
-        </activation>
-        <properties>
-          <smallrye.config.version>3.10.2</smallrye.config.version>
-        </properties>
-      </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>

--- a/performance/base/pom.xml
+++ b/performance/base/pom.xml
@@ -121,18 +121,6 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-      <profile>
-        <id>java-11</id>
-        <activation>
-          <jdk>11</jdk>
-        </activation>
-        <properties>
-          <smallrye.config.version>3.10.2</smallrye.config.version>
-        </properties>
-      </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -781,6 +781,7 @@
       </activation>
       <properties>
         <jena.version>4.10.0</jena.version>
+        <smallrye.config.version>3.10.2</smallrye.config.version>
       </properties>
     </profile>
     <profile>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -110,15 +110,6 @@
         <spring.security.version>6.4.2</spring.security.version>
       </properties>
     </profile>
-    <profile>
-      <id>java-11</id>
-      <activation>
-        <jdk>11</jdk>
-      </activation>
-      <properties>
-        <smallrye.config.version>3.10.2</smallrye.config.version>
-      </properties>
-    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
This removes the special profiles from the various submodules and puts the smallrye-config version config in the parent pom profile so that dependabot updates are more manageable for Smallrye Config