### PR TITLE
Use shared java 11 profile for SR-config version mgmt

### DIFF
--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -121,18 +121,6 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-      <profile>
-        <id>java-11</id>
-        <activation>
-          <jdk>11</jdk>
-        </activation>
-        <properties>
-          <smallrye.config.version>3.10.2</smallrye.config.version>
-        </properties>
-      </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>

--- a/performance/base/pom.xml
+++ b/performance/base/pom.xml
@@ -121,18 +121,6 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-      <profile>
-        <id>java-11</id>
-        <activation>
-          <jdk>11</jdk>
-        </activation>
-        <properties>
-          <smallrye.config.version>3.10.2</smallrye.config.version>
-        </properties>
-      </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -785,6 +785,15 @@
       </modules>
     </profile>
     <profile>
+      <id>java-11</id>
+      <activation>
+        <jdk>11</jdk>
+      </activation>
+      <properties>
+        <smallrye.config.version>3.10.2</smallrye.config.version>
+      </properties>
+    </profile>
+    <profile>
       <id>publish</id>
       <!-- skip tests for publish profile, since these tests have already run -->
       <properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -110,15 +110,6 @@
         <spring.security.version>6.4.2</spring.security.version>
       </properties>
     </profile>
-    <profile>
-      <id>java-11</id>
-      <activation>
-        <jdk>11</jdk>
-      </activation>
-      <properties>
-        <smallrye.config.version>3.10.2</smallrye.config.version>
-      </properties>
-    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
This is a backport of #1890 

The parent pom does not currently have a Java 11 profile for the 1.2 maintenance branch, so one is added