### PR TITLE
Extend OWASP suppressions by three months

### DIFF
--- a/build-tools/owasp/suppressions.xml
+++ b/build-tools/owasp/suppressions.xml
@@ -38,7 +38,7 @@
   </suppress>
 
   <!-- Suppressed vulnerabilities. These need monthly review. -->
-  <suppress until="2025-08-10Z">
+  <suppress until="2025-11-10Z">
     <notes><![CDATA[
         This vulnerability affects a transitive dependency of the test module but is not relevant
         for how it is used in the context of the Java Client Libraries.
@@ -46,7 +46,7 @@
     <packageUrl regex="true">^pkg:maven/net\.minidev/json-smart@.*$</packageUrl>
     <vulnerabilityName>CVE-2024-57699</vulnerabilityName>
   </suppress>
-  <suppress until="2025-08-10Z">
+  <suppress until="2025-11-10Z">
     <notes><![CDATA[
         This vulnerability affects a transitive dependency of the test module but is not relevant
         for how it is used in the context of the Java Client Libraries.
@@ -54,7 +54,7 @@
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2-common@.*$</packageUrl>
     <cve>CVE-2024-6763</cve>
   </suppress>
-  <suppress until="2025-08-10Z">
+  <suppress until="2025-11-10Z">
     <notes><![CDATA[
         This vulnerability affects a transitive dependency of the test module but is not relevant
         for how it is used in the context of the Java Client Libraries.

--- a/build-tools/owasp/suppressions.xml
+++ b/build-tools/owasp/suppressions.xml
@@ -62,4 +62,12 @@
     <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2-common@.*$</packageUrl>
     <cve>CVE-2025-1948</cve>
   </suppress>
+    <suppress until="2025-11-10Z">
+    <notes><![CDATA[
+        This vulnerability affects a transitive dependency of the test module but is not relevant
+        for how it is used in the context of the Java Client Libraries.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2-common@.*$</packageUrl>
+    <cve>CVE-2025-5115</cve>
+  </suppress>
 </suppressions>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
-      <version>6.2.9</version>
+      <version>6.2.10</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -107,7 +107,7 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <spring.security.version>6.5.2</spring.security.version>
+        <spring.security.version>6.5.3</spring.security.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
This extends the OWASP suppressions that expired recently, to be checked against in three months.