### PR TITLE
Remove OWASP suppression configuration

### DIFF
--- a/build-tools/owasp/suppressions.xml
+++ b/build-tools/owasp/suppressions.xml
@@ -38,36 +38,4 @@
   </suppress>
 
   <!-- Suppressed vulnerabilities. These need monthly review. -->
-  <suppress until="2025-11-10Z">
-    <notes><![CDATA[
-        This vulnerability affects a transitive dependency of the test module but is not relevant
-        for how it is used in the context of the Java Client Libraries.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/net\.minidev/json-smart@.*$</packageUrl>
-    <vulnerabilityName>CVE-2024-57699</vulnerabilityName>
-  </suppress>
-  <suppress until="2025-11-10Z">
-    <notes><![CDATA[
-        This vulnerability affects a transitive dependency of the test module but is not relevant
-        for how it is used in the context of the Java Client Libraries.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2-common@.*$</packageUrl>
-    <cve>CVE-2024-6763</cve>
-  </suppress>
-  <suppress until="2025-11-10Z">
-    <notes><![CDATA[
-        This vulnerability affects a transitive dependency of the test module but is not relevant
-        for how it is used in the context of the Java Client Libraries.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2-common@.*$</packageUrl>
-    <cve>CVE-2025-1948</cve>
-  </suppress>
-    <suppress until="2025-11-10Z">
-    <notes><![CDATA[
-        This vulnerability affects a transitive dependency of the test module but is not relevant
-        for how it is used in the context of the Java Client Libraries.
-    ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty\.http2/http2-common@.*$</packageUrl>
-    <cve>CVE-2025-5115</cve>
-  </suppress>
 </suppressions>

--- a/integration/base/pom.xml
+++ b/integration/base/pom.xml
@@ -107,9 +107,14 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-standalone</artifactId>
             <version>${wiremock.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
         </dependency>
 
         <!-- test dependencies -->

--- a/performance/base/pom.xml
+++ b/performance/base/pom.xml
@@ -107,7 +107,7 @@
         </dependency>
         <dependency>
             <groupId>org.wiremock</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-standalone</artifactId>
             <version>${wiremock.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <smallrye.config.version>3.13.2</smallrye.config.version>
     <yasson.version>3.0.4</yasson.version>
     <wiremock.version>3.13.1</wiremock.version>
+    <hamcrest.version>3.0</hamcrest.version>
 
     <!-- disable by default (enabled by profile in CI) -->
     <dependency-check.skip>true</dependency-check.skip>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
The OWASP suppression list includes some entries that can be removed by using the stand-alone version of wiremock