### PR TITLE
JCL-476: Simplify build setup for Java 17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,6 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 4 1,15 * *"
-    ignore:
-      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
-      - dependency-name: "org.springframework.security:spring-*"
-      - dependency-name: "com.google.protobuf:protobuf-java"
-        update-types:
-          - "version-update:semver-major"
     groups:
       plugins:
         patterns:
@@ -21,22 +15,6 @@ updates:
           - "org.sonatype.plugins:nexus-staging-maven-plugin"
           - "org.owasp:dependency-check-maven"
           - "com.puppycrawl.tools:checkstyle"
-
-  - package-ecosystem: "maven"
-    directory: "/rdf4j/"
-    schedule:
-      interval: "cron"
-      cronjob: "15 4 1,15 * *"
-    allow:
-      - dependency-name: "org.eclipse.rdf4j:rdf4j-*"
-
-  - package-ecosystem: "maven"
-    directory: "/spring/"
-    schedule:
-      interval: "cron"
-      cronjob: "45 4 1,15 * *"
-    allow:
-      - dependency-name: "org.springframework.security:spring-*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -68,7 +46,6 @@ updates:
           - "org.sonarsource.scanner.maven:sonar-maven-plugin"
           - "org.sonatype.plugins:nexus-staging-maven-plugin"
           - "org.owasp:dependency-check-maven"
-          - "com.puppycrawl.tools:checkstyle"
 
   - package-ecosystem: "maven"
     directory: "/rdf4j/"
@@ -138,7 +115,6 @@ updates:
           - "org.sonarsource.scanner.maven:sonar-maven-plugin"
           - "org.sonatype.plugins:nexus-staging-maven-plugin"
           - "org.owasp:dependency-check-maven"
-          - "com.puppycrawl.tools:checkstyle"
 
   - package-ecosystem: "maven"
     directory: "/rdf4j/"

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <json.bind.version>3.0.1</json.bind.version>
     <okhttp.version>5.1.0</okhttp.version>
     <quarkus.version>3.24.3</quarkus.version>
+    <rdf4j.version>5.1.4</rdf4j.version>
     <slf4j.version>2.0.17</slf4j.version>
     <spring.security.version>6.5.3</spring.security.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
@@ -137,24 +138,6 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
           <version>${guava.version}</version>
-        </dependency>
-        <!-- transitive dependency update for CVE-2024-25710 -->
-        <dependency>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-          <version>1.28.0</version>
-        </dependency>
-        <!-- transitive dependency update for CVE-2024-31573 -->
-        <dependency>
-          <groupId>org.xmlunit</groupId>
-          <artifactId>xmlunit-core</artifactId>
-          <version>2.10.3</version>
-        </dependency>
-        <!-- transitive dependency update for CVE-2024-7254 -->
-        <dependency>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-          <version>3.25.8</version>
         </dependency>
     </dependencies>
   </dependencyManagement>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -13,10 +13,6 @@
       RDF4J integration for the Inrupt Java Client Libraries.
   </description>
 
-  <properties>
-    <rdf4j.version>5.1.4</rdf4j.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
This removes some work-arounds that were in place for Java 8/11. They can be removed now that Java 17 is the baseline supported version.