### PR TITLE
Disable e2e tests on deprecated envs

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -45,21 +45,6 @@ jobs:
           INRUPT_TEST_REQUEST_METADATA_FEATURE: false
           INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_PROD_HEADERS_THAT_PROPAGATE }}
 
-      - name: Dev Integration tests
-        if: ${{ github.actor != 'dependabot[bot]' && matrix.java == 17 }}
-        continue-on-error: true
-        run: mvn -B -ntp verify -Pci -pl integration/uma,integration/openid
-        env:
-          INRUPT_TEST_WEBID: ${{ secrets.INRUPT_DEV_WEBID }}
-          INRUPT_TEST_ACCESS_GRANT_PROVIDER: ${{ secrets.INRUPT_DEV_ACCESS_GRANT_PROVIDER }}
-          INRUPT_TEST_CLIENT_ID: ${{ secrets.INRUPT_DEV_CLIENT_ID }}
-          INRUPT_TEST_CLIENT_SECRET: ${{ secrets.INRUPT_DEV_CLIENT_SECRET }}
-          INRUPT_TEST_REQUESTER_WEBID: ${{ secrets.INRUPT_DEV_REQUESTER_WEBID }}
-          INRUPT_TEST_REQUESTER_CLIENT_ID: ${{ secrets.INRUPT_DEV_REQUESTER_CLIENT_ID }}
-          INRUPT_TEST_REQUESTER_CLIENT_SECRET: ${{ secrets.INRUPT_DEV_REQUESTER_CLIENT_SECRET }}
-          INRUPT_TEST_REQUEST_METADATA_FEATURE: true
-          INRUPT_TEST_REQUEST_METADATA_HEADERS_THAT_PROPAGATE: ${{ secrets.INRUPT_DEV_HEADERS_THAT_PROPAGATE }}
-
   performance:
     name: Performance Tests
     permissions:


### PR DESCRIPTION
The current dev environment is being deprecated, so tests only run against prod for the time being.