### PR TITLE
Add check rollup job to CI workflow

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -113,3 +113,18 @@ jobs:
       - name: Sonar Analysis
         run: mvn sonar:sonar -Dsonar.token=${{ secrets.SONARQUBE_TOKEN }}
 
+
+  check:
+    if: always()
+    needs:
+      - build
+      - performance
+      - documentation
+      - sonar
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          allowed-skips: sonar, performance
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Adds a `check` rollup job that gates on all other CI jobs, enabling org-level required status checks.

`sonar` and `performance` are in `allowed-skips` because both are skipped for dependabot PRs.